### PR TITLE
Address issue where libcpprealm was not being installed

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -40,3 +40,6 @@ foreach(FILE ${HEADERS})
             DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${DIR}
             COMPONENT devel)
 endforeach()
+
+install(TARGETS cpprealm
+        PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/cpprealm)


### PR DESCRIPTION
This line of code was accidentally removed in the last PR. It prevented the shared library from being installed on the users system.