### PR TITLE
Add prealpha version info to doxygen

### DIFF
--- a/.github/workflows/publish-doxygen.yml
+++ b/.github/workflows/publish-doxygen.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+env:
+  DOXYGEN_PROJECT_NUMBER: Pre-alpha version ${{ github.ref_name }}@${{ github.sha }}
+
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/Doxyfile
+++ b/Doxyfile
@@ -48,7 +48,7 @@ PROJECT_NAME           = "Realm C++ SDK"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         =
+PROJECT_NUMBER         = $(DOXYGEN_PROJECT_NUMBER)
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a


### PR DESCRIPTION
...so we know which commit built the docs

<img width="857" alt="image" src="https://user-images.githubusercontent.com/20050130/205330916-b6b87b80-48a2-442f-a8f7-c290bd523640.png">
