### PR TITLE
Update the version label in the doxygen docs to Alpha

### DIFF
--- a/.github/workflows/publish-doxygen.yml
+++ b/.github/workflows/publish-doxygen.yml
@@ -6,7 +6,7 @@ on:
       - main
 
 env:
-  DOXYGEN_PROJECT_NUMBER: Pre-alpha version ${{ github.ref_name }}@${{ github.sha }}
+  DOXYGEN_PROJECT_NUMBER: Alpha version ${{ github.ref_name }}@${{ github.sha }}
 
 jobs:
   publish:


### PR DESCRIPTION
Change the version label at the top of the autogenerated Doxygen API docs from "Pre-alpha" to "Alpha"