### PR TITLE
Add rule of 5 to types using std::aligned_storage

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -126,8 +126,6 @@ jobs:
         configuration:
           - Debug
           - Release
-        exclude:
-          - configuration: ${{ (github.event_name == 'pull_request' && 'Release') || 'none' }}
     needs:
       - deploy-cluster
     env:
@@ -161,14 +159,6 @@ jobs:
           sudo apt-get install -y g++-${{ matrix.compiler.version }}
           sudo update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-${{ matrix.compiler.version }} 100
           sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-${{ matrix.compiler.version }} 100
-
-      - name: Setup Clang ${{ matrix.compiler.version }}
-        if: matrix.compiler.name == 'clang'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y clang-${{ matrix.compiler.version }}
-          sudo update-alternatives --install /usr/bin/cc cc /usr/bin/clang-${{ matrix.compiler.version }} 100
-          sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-${{ matrix.compiler.version }} 100
 
       - uses: ammaraskar/gcc-problem-matcher@master
 
@@ -207,13 +197,9 @@ jobs:
             version: 11
           - name: gcc
             version: 12
-#          - name: clang
-#            version: 14
         configuration:
           - Debug
           - Release
-        exclude:
-          - configuration: ${{ (github.event_name == 'pull_request' && 'Release') || 'none' }}
     needs:
       - deploy-cluster
     env:
@@ -248,14 +234,6 @@ jobs:
           sudo update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-${{ matrix.compiler.version }} 100
           sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-${{ matrix.compiler.version }} 100
 
-      - name: Setup Clang ${{ matrix.compiler.version }}
-        if: matrix.compiler.name == 'clang'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y clang-${{ matrix.compiler.version }}
-          sudo update-alternatives --install /usr/bin/cc cc /usr/bin/clang-${{ matrix.compiler.version }} 100
-          sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-${{ matrix.compiler.version }} 100
-
       - uses: ammaraskar/gcc-problem-matcher@master
 
       - name: Configure
@@ -267,92 +245,6 @@ jobs:
       - name: Test
         working-directory: .build/cmake-preset-linux
         run: ./${{ matrix.configuration }}/cpprealm_exe_tests
-
-      - name: Publish Test Report
-        uses: mikepenz/action-junit-report@v3
-        if: always()
-        with:
-          report_paths: '.build/**/TestResults.xml'
-          annotate_only: true
-          require_tests: true
-
-      - name: Open a tmate debug session
-        if: ${{ failure() && runner.debug }}
-        uses: mxschmitt/action-tmate@v3
-        with:
-          timeout-minutes: 15
-  build-linux-memcheck:
-    runs-on: ubuntu-22.04
-    name: Linux Memcheck ${{ matrix.configuration }} (${{ matrix.compiler.name }} ${{ matrix.compiler.version }})
-    strategy:
-      fail-fast: false
-      matrix:
-        compiler:
-          - name: gcc
-            version: 11
-          - name: gcc
-            version: 12
-#          - name: clang
-#            version: 14
-        configuration:
-          - Debug
-          - Release
-        exclude:
-          - configuration: ${{ (github.event_name == 'pull_request' && 'Release') || 'none' }}
-    needs:
-      - deploy-cluster
-    env:
-      REALM_ATLAS_CLUSTER_NAME: ${{ needs.deploy-cluster.outputs.clusterName }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          submodules: 'recursive'
-
-      - name: Setup Ccache
-        uses: hendrikmuhs/ccache-action@v1.1
-        with:
-          key: ccache-linux-${{ matrix.compiler.name }}-${{ matrix.compiler.version }}
-      
-      - name: Install Linux Dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            libcurl4-openssl-dev \
-            libssl-dev \
-            libuv1-dev \
-            ninja-build \
-            zlib1g-dev \
-            ${{ matrix.compiler.name }}-${{ matrix.compiler.version }} \
-            valgrind
-
-      - name: Setup GCC ${{ matrix.compiler.version }}
-        if: matrix.compiler.name == 'gcc'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y g++-${{ matrix.compiler.version }}
-          sudo update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-${{ matrix.compiler.version }} 100
-          sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-${{ matrix.compiler.version }} 100
-
-      - name: Setup Clang ${{ matrix.compiler.version }}
-        if: matrix.compiler.name == 'clang'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y clang-${{ matrix.compiler.version }}
-          sudo update-alternatives --install /usr/bin/cc cc /usr/bin/clang-${{ matrix.compiler.version }} 100
-          sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-${{ matrix.compiler.version }} 100
-
-      - uses: ammaraskar/gcc-problem-matcher@master
-
-      - name: Configure
-        run: cmake --preset linux -DCMAKE_VERBOSE_MAKEFILE=${RUNNER_DEBUG:-OFF}
-
-      - name: Compile
-        run: cmake --build --preset linux --config ${{ matrix.configuration }}
-
-      - name: Test
-        working-directory: .build/cmake-preset-linux/${{ matrix.configuration }}/
-        run: ctest --verbose -T memcheck
 
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v3

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -112,6 +112,90 @@ jobs:
         with:
           timeout-minutes: 15
 
+  build-linux-arm:
+    runs-on: ubuntu-latest
+    name: Linux ARM ${{ matrix.configuration }} (${{ matrix.compiler.name }} ${{ matrix.compiler.version }})
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler:
+          - name: gcc
+            version: 11
+          - name: gcc
+            version: 12
+        configuration:
+          - Debug
+          - Release
+        exclude:
+          - configuration: ${{ (github.event_name == 'pull_request' && 'Release') || 'none' }}
+    needs:
+      - deploy-cluster
+    env:
+      REALM_ATLAS_CLUSTER_NAME: ${{ needs.deploy-cluster.outputs.clusterName }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: 'recursive'
+
+      - name: Setup Ccache
+        uses: hendrikmuhs/ccache-action@v1.1
+        with:
+          key: ccache-linux-${{ matrix.compiler.name }}-${{ matrix.compiler.version }}
+      
+      - name: Install Linux Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libcurl4-openssl-dev \
+            libssl-dev \
+            libuv1-dev \
+            ninja-build \
+            zlib1g-dev \
+            ${{ matrix.compiler.name }}-${{ matrix.compiler.version }}
+
+      - name: Setup GCC ${{ matrix.compiler.version }}
+        if: matrix.compiler.name == 'gcc'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y g++-${{ matrix.compiler.version }}
+          sudo update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-${{ matrix.compiler.version }} 100
+          sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-${{ matrix.compiler.version }} 100
+
+      - name: Setup Clang ${{ matrix.compiler.version }}
+        if: matrix.compiler.name == 'clang'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang-${{ matrix.compiler.version }}
+          sudo update-alternatives --install /usr/bin/cc cc /usr/bin/clang-${{ matrix.compiler.version }} 100
+          sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-${{ matrix.compiler.version }} 100
+
+      - uses: ammaraskar/gcc-problem-matcher@master
+
+      - name: Configure
+        run: cmake --preset linux -DCMAKE_VERBOSE_MAKEFILE=${RUNNER_DEBUG:-OFF}
+
+      - name: Compile
+        run: cmake --build --preset linux --config ${{ matrix.configuration }}
+
+      - name: Test
+        working-directory: .build/cmake-preset-linux
+        run: ./${{ matrix.configuration }}/cpprealm_exe_tests
+
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@v3
+        if: always()
+        with:
+          report_paths: '.build/**/TestResults.xml'
+          annotate_only: true
+          require_tests: true
+
+      - name: Open a tmate debug session
+        if: ${{ failure() && runner.debug }}
+        uses: mxschmitt/action-tmate@v3
+        with:
+          timeout-minutes: 15
+
   build-linux:
     runs-on: ubuntu-22.04
     name: Linux ${{ matrix.configuration }} (${{ matrix.compiler.name }} ${{ matrix.compiler.version }})
@@ -197,3 +281,90 @@ jobs:
         uses: mxschmitt/action-tmate@v3
         with:
           timeout-minutes: 15
+  build-linux-memcheck:
+    runs-on: ubuntu-22.04
+    name: Linux Memcheck ${{ matrix.configuration }} (${{ matrix.compiler.name }} ${{ matrix.compiler.version }})
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler:
+          - name: gcc
+            version: 11
+          - name: gcc
+            version: 12
+#          - name: clang
+#            version: 14
+        configuration:
+          - Debug
+          - Release
+        exclude:
+          - configuration: ${{ (github.event_name == 'pull_request' && 'Release') || 'none' }}
+    needs:
+      - deploy-cluster
+    env:
+      REALM_ATLAS_CLUSTER_NAME: ${{ needs.deploy-cluster.outputs.clusterName }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: 'recursive'
+
+      - name: Setup Ccache
+        uses: hendrikmuhs/ccache-action@v1.1
+        with:
+          key: ccache-linux-${{ matrix.compiler.name }}-${{ matrix.compiler.version }}
+      
+      - name: Install Linux Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libcurl4-openssl-dev \
+            libssl-dev \
+            libuv1-dev \
+            ninja-build \
+            zlib1g-dev \
+            ${{ matrix.compiler.name }}-${{ matrix.compiler.version }} \
+            valgrind
+
+      - name: Setup GCC ${{ matrix.compiler.version }}
+        if: matrix.compiler.name == 'gcc'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y g++-${{ matrix.compiler.version }}
+          sudo update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-${{ matrix.compiler.version }} 100
+          sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-${{ matrix.compiler.version }} 100
+
+      - name: Setup Clang ${{ matrix.compiler.version }}
+        if: matrix.compiler.name == 'clang'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang-${{ matrix.compiler.version }}
+          sudo update-alternatives --install /usr/bin/cc cc /usr/bin/clang-${{ matrix.compiler.version }} 100
+          sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-${{ matrix.compiler.version }} 100
+
+      - uses: ammaraskar/gcc-problem-matcher@master
+
+      - name: Configure
+        run: cmake --preset linux -DCMAKE_VERBOSE_MAKEFILE=${RUNNER_DEBUG:-OFF}
+
+      - name: Compile
+        run: cmake --build --preset linux --config ${{ matrix.configuration }}
+
+      - name: Test
+        working-directory: .build/cmake-preset-linux/${{ matrix.configuration }}/
+        run: ctest --verbose -T memcheck
+
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@v3
+        if: always()
+        with:
+          report_paths: '.build/**/TestResults.xml'
+          annotate_only: true
+          require_tests: true
+
+      - name: Open a tmate debug session
+        if: ${{ failure() && runner.debug }}
+        uses: mxschmitt/action-tmate@v3
+        with:
+          timeout-minutes: 15
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,23 +1,20 @@
 # NEXT RELEASE
 
 ### Enhancements
-* Add support for Embedded Objects. Users can implement their own embedded objects by inheriting from `realm::embedded_object`. 
-* Add support for notifications on `results` collections by calling `results::observe`.
-* Add support for calling a Device Sync function by calling `user::call_function(realm::bson::Bson)`.
-* Add support for accessing custom user data via `user::custom_user_data()` and `user::refresh_custom_user_data()`.
 
 ### Fixed
-* None
+* Address memory leaks reported by instruments caused by some classes not implementing rule of 5 when using
+  `std::aligned_storage` ([#69](https://github.com/realm/realm-cpp/pull/69)), since v0.1.0).
 
 ### Breaking changes
-* None.
+* `scheduler::invoke(std::function<void()>)` has been change to `scheduler::invoke(realm::Function<void()>)`.
 
 ### Compatibility
-* Fileformat: Generates files with format v22. Reads and automatically upgrade from fileformat v5.
+* Fileformat: Generates files with format v22.
 
 -----------
 
 ### Internals
-* None
+* Upgraded to Core v13.9.2
 
 ----------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,6 +103,7 @@ endif()
 
 if (NOT REALM_CPP_NO_TESTS)
 Include(FetchContent)
+Include(CTest)
 FetchContent_Declare(
         Catch2
         GIT_REPOSITORY https://github.com/catchorg/Catch2.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,7 +103,6 @@ endif()
 
 if (NOT REALM_CPP_NO_TESTS)
 Include(FetchContent)
-Include(CTest)
 FetchContent_Declare(
         Catch2
         GIT_REPOSITORY https://github.com/catchorg/Catch2.git

--- a/src/cpprealm/analytics.cpp
+++ b/src/cpprealm/analytics.cpp
@@ -110,7 +110,7 @@ namespace realm {
             return "unknown";
         }
 
-        return std::string(static_cast<const char*>(buffer.release()), buffer_size - 1);
+        return std::string(static_cast<const char*>(buffer.get()), buffer_size - 1);
     }
 
     bool debugger_attached()

--- a/src/cpprealm/app.cpp
+++ b/src/cpprealm/app.cpp
@@ -44,29 +44,29 @@ namespace realm {
     static_assert((int)user::state::removed == (int)SyncUser::State::Removed);
 
     app_error::app_error(const app_error& other) {
-        new (&m_error) app::AppError(*reinterpret_cast<const app::AppError*>(other.m_error));
+        new (&m_error) app::AppError(*reinterpret_cast<const app::AppError*>(&other.m_error));
     }
 
     app_error& app_error::operator=(const app_error& other) {
         if (this != &other) {
-            *reinterpret_cast<app::AppError*>(m_error) = *reinterpret_cast<const app::AppError*>(other.m_error);
+            *reinterpret_cast<app::AppError*>(&m_error) = *reinterpret_cast<const app::AppError*>(&other.m_error);
         }
         return *this;
     }
 
     app_error::app_error(app_error&& other) {
-        new (&m_error) app::AppError(std::move(*reinterpret_cast<app::AppError*>(other.m_error)));
+        new (&m_error) app::AppError(std::move(*reinterpret_cast<app::AppError*>(&other.m_error)));
     }
 
     app_error& app_error::operator=(app_error&& other) {
         if (this != &other) {
-            *reinterpret_cast<app::AppError*>(m_error) = std::move(*reinterpret_cast<app::AppError*>(other.m_error));
+            *reinterpret_cast<app::AppError*>(&m_error) = std::move(*reinterpret_cast<app::AppError*>(&other.m_error));
         }
         return *this;
     }
 
     app_error::~app_error() {
-        reinterpret_cast<app::AppError*>(m_error)->~AppError();
+        reinterpret_cast<app::AppError*>(&m_error)->~AppError();
     }
 
     app_error::app_error(realm::app::AppError&& error) {
@@ -75,37 +75,37 @@ namespace realm {
 
     std::string_view app_error::mesage() const
     {
-        return reinterpret_cast<const app::AppError*>(m_error)->reason();
+        return reinterpret_cast<const app::AppError*>(&m_error)->reason();
     }
 
     std::string_view app_error::link_to_server_logs() const
     {
-        return reinterpret_cast<const app::AppError*>(m_error)->link_to_server_logs;
+        return reinterpret_cast<const app::AppError*>(&m_error)->link_to_server_logs;
     }
 
     bool app_error::is_json_error() const
     {
-        return reinterpret_cast<const app::AppError*>(m_error)->is_json_error();
+        return reinterpret_cast<const app::AppError*>(&m_error)->is_json_error();
     }
 
     bool app_error::is_service_error() const
     {
-        return reinterpret_cast<const app::AppError*>(m_error)->is_service_error();
+        return reinterpret_cast<const app::AppError*>(&m_error)->is_service_error();
     }
 
     bool app_error::is_http_error() const
     {
-        return reinterpret_cast<const app::AppError*>(m_error)->is_http_error();
+        return reinterpret_cast<const app::AppError*>(&m_error)->is_http_error();
     }
 
     bool app_error::is_custom_error() const
     {
-        return reinterpret_cast<const app::AppError*>(m_error)->is_custom_error();
+        return reinterpret_cast<const app::AppError*>(&m_error)->is_custom_error();
     }
 
     bool app_error::is_client_error() const
     {
-        return reinterpret_cast<const app::AppError*>(m_error)->is_client_error();
+        return reinterpret_cast<const app::AppError*>(&m_error)->is_client_error();
     }
 
     /**
@@ -242,36 +242,36 @@ namespace realm {
     }
 
     App::credentials::credentials(const credentials& other) {
-        new (&m_credentials) app::AppCredentials(*reinterpret_cast<const app::AppCredentials*>(other.m_credentials));
+        new (&m_credentials) app::AppCredentials(*reinterpret_cast<const app::AppCredentials*>(&other.m_credentials));
     }
 
     App::credentials& App::credentials::operator=(const credentials& other) {
         if (this != &other) {
-            *reinterpret_cast<app::AppCredentials*>(m_credentials) = *reinterpret_cast<const app::AppCredentials*>(other.m_credentials);
+            *reinterpret_cast<app::AppCredentials*>(&m_credentials) = *reinterpret_cast<const app::AppCredentials*>(&other.m_credentials);
         }
         return *this;
     }
 
     App::credentials::credentials(credentials&& other) {
-        new (&m_credentials) app::AppCredentials(std::move(*reinterpret_cast<app::AppCredentials*>(other.m_credentials)));
+        new (&m_credentials) app::AppCredentials(std::move(*reinterpret_cast<app::AppCredentials*>(&other.m_credentials)));
     }
 
     App::credentials& App::credentials::operator=(App::credentials&& other) {
         if (this != &other) {
-            *reinterpret_cast<app::AppCredentials*>(m_credentials) = std::move(*reinterpret_cast<app::AppCredentials*>(other.m_credentials));
+            *reinterpret_cast<app::AppCredentials*>(&m_credentials) = std::move(*reinterpret_cast<app::AppCredentials*>(&other.m_credentials));
         }
         return *this;
     }
 
     App::credentials::~credentials() {
-        reinterpret_cast<app::AppCredentials*>(m_credentials)->~AppCredentials();
+        reinterpret_cast<app::AppCredentials*>(&m_credentials)->~AppCredentials();
     }
 
     App::credentials::credentials(app::AppCredentials &&v) noexcept {
         new (&m_credentials) app::AppCredentials(std::move(v));
     }
     App::credentials::operator app::AppCredentials() const {
-        return *reinterpret_cast<const app::AppCredentials*>(m_credentials);
+        return *reinterpret_cast<const app::AppCredentials*>(&m_credentials);
     }
 
     App::credentials App::credentials::anonymous()

--- a/src/cpprealm/app.hpp
+++ b/src/cpprealm/app.hpp
@@ -45,6 +45,12 @@ namespace realm {
 
 // Represents an error state from the server.
 struct app_error {
+    app_error() = delete;
+    app_error(const app_error& other) ;
+    app_error& operator=(const app_error& other) ;
+    app_error(app_error&& other);
+    app_error& operator=(app_error&& other);
+    ~app_error();
     app_error(realm::app::AppError&& error); //NOLINT(google-explicit-constructor)
 
     [[nodiscard]] std::string_view mesage() const;
@@ -72,7 +78,11 @@ std::aligned_storage<56, 8>::type m_error[1];
 #elif __arm__
     std::aligned_storage<28, 4>::type m_error[1];
 #elif __aarch64__
+#if defined(__clang__)
     std::aligned_storage<48, 8>::type m_error[1];
+#elif defined(__GNUC__) || defined(__GNUG__)
+    std::aligned_storage<56, 8>::type m_error[1];
+#endif
 #endif
 };
 
@@ -136,7 +146,7 @@ struct user {
 
     [[nodiscard]] db_config flexible_sync_configuration() const
     {
-        db_config config;
+        db_config config = {std::nullopt, std::nullopt};
         config.set_sync_config(sync_config(m_user));
         config.sync_config().set_error_handler([](const sync_session& session, const sync_error& error) {
             std::cerr<<"sync error: "<<error.message()<<std::endl;
@@ -238,9 +248,12 @@ public:
         static credentials custom(const std::string& token);
         static credentials username_password(const std::string& username, const std::string& password);
         static credentials function(const bson::BsonDocument& payload);
-        credentials() = delete;
-        credentials(const credentials& credentials) = default;
-        credentials(credentials&&) = default;
+        credentials();
+        credentials(const credentials& other) ;
+        credentials& operator=(const credentials& other) ;
+        credentials(credentials&& other);
+        credentials& operator=(credentials&& other);
+        ~credentials();
     private:
         credentials(app::AppCredentials&& credentials) noexcept;
         operator app::AppCredentials() const;

--- a/src/cpprealm/db.hpp
+++ b/src/cpprealm/db.hpp
@@ -178,7 +178,7 @@ private:
 };
 
 template <typename ...Ts>
-static db<Ts...> open(db_config&& config = {})
+static db<Ts...> open(db_config&& config = {std::nullopt, std::nullopt})
 {
     return db<Ts...>(std::move(config));
 }

--- a/src/cpprealm/flex_sync.cpp
+++ b/src/cpprealm/flex_sync.cpp
@@ -24,9 +24,14 @@ namespace realm {
     static_assert(internal::bridge::SizeCheck<136, sizeof(sync::MutableSubscriptionSet)>{});
     static_assert(internal::bridge::SizeCheck<8, alignof(sync::MutableSubscriptionSet)>{});
 #elif __aarch64__
+#if defined(__clang__)
     static_assert(internal::bridge::SizeCheck<96, sizeof(sync::SubscriptionSet)>{});
-    static_assert(internal::bridge::SizeCheck<8, alignof(sync::SubscriptionSet)>{});
     static_assert(internal::bridge::SizeCheck<184, sizeof(sync::MutableSubscriptionSet)>{});
+#elif defined(__GNUC__) || defined(__GNUG__)
+    static_assert(internal::bridge::SizeCheck<104, sizeof(sync::SubscriptionSet)>{});
+    static_assert(internal::bridge::SizeCheck<192, sizeof(sync::MutableSubscriptionSet)>{});
+#endif
+    static_assert(internal::bridge::SizeCheck<8, alignof(sync::SubscriptionSet)>{});
     static_assert(internal::bridge::SizeCheck<8, alignof(sync::MutableSubscriptionSet)>{});
 #endif
     sync_subscription::sync_subscription(const sync::Subscription &v)
@@ -37,6 +42,23 @@ namespace realm {
         updated_at = v.updated_at.get_time_point();
         query_string = v.query_string;
         object_class_name = v.object_class_name;
+    }
+    mutable_sync_subscription_set& mutable_sync_subscription_set::operator=(const mutable_sync_subscription_set& other) {
+        if (this != &other) {
+            *reinterpret_cast<sync::MutableSubscriptionSet*>(m_subscription_set) = *reinterpret_cast<const sync::MutableSubscriptionSet*>(other.m_subscription_set);
+        }
+        return *this;
+    }
+
+    mutable_sync_subscription_set& mutable_sync_subscription_set::operator=(mutable_sync_subscription_set&& other) {
+        if (this != &other) {
+            *reinterpret_cast<sync::MutableSubscriptionSet*>(m_subscription_set) = std::move(*reinterpret_cast<sync::MutableSubscriptionSet*>(other.m_subscription_set));
+        }
+        return *this;
+    }
+
+    mutable_sync_subscription_set::~mutable_sync_subscription_set() {
+        reinterpret_cast<sync::MutableSubscriptionSet*>(m_subscription_set)->~MutableSubscriptionSet();
     }
     mutable_sync_subscription_set::mutable_sync_subscription_set(internal::bridge::realm& realm,
                                                                  const sync::MutableSubscriptionSet &subscription_set)
@@ -74,6 +96,24 @@ namespace realm {
             return sync_subscription(*it);
         }
         return std::nullopt;
+    }
+
+    sync_subscription_set& sync_subscription_set::operator=(const sync_subscription_set& other) {
+        if (this != &other) {
+            *reinterpret_cast<sync::SubscriptionSet*>(m_subscription_set) = *reinterpret_cast<const sync::SubscriptionSet*>(other.m_subscription_set);
+        }
+        return *this;
+    }
+
+    sync_subscription_set& sync_subscription_set::operator=(sync_subscription_set&& other) {
+        if (this != &other) {
+            *reinterpret_cast<sync::SubscriptionSet*>(m_subscription_set) = std::move(*reinterpret_cast<sync::SubscriptionSet*>(other.m_subscription_set));
+        }
+        return *this;
+    }
+
+    sync_subscription_set::~sync_subscription_set() {
+        reinterpret_cast<sync::SubscriptionSet*>(m_subscription_set)->~SubscriptionSet();
     }
 
     size_t sync_subscription_set::size() const {

--- a/src/cpprealm/flex_sync.hpp
+++ b/src/cpprealm/flex_sync.hpp
@@ -52,9 +52,9 @@ namespace realm {
         // Returns the timestamp of the last time this subscription was updated by calling update_query.
         std::chrono::time_point<std::chrono::system_clock> updated_at;
         // Returns a stringified version of the query associated with this subscription.
-        std::string_view query_string;
+        std::string query_string;
         // Returns the name of the object class of the query for this subscription.
-        std::string_view object_class_name;
+        std::string object_class_name;
     private:
         sync_subscription(const sync::Subscription&);
 

--- a/src/cpprealm/flex_sync.hpp
+++ b/src/cpprealm/flex_sync.hpp
@@ -68,6 +68,12 @@ namespace realm {
     private:
         void insert_or_assign(const std::string& name, const internal::bridge::query&);
     public:
+        mutable_sync_subscription_set() = delete;
+        mutable_sync_subscription_set(const mutable_sync_subscription_set& other) = delete;
+        mutable_sync_subscription_set& operator=(const mutable_sync_subscription_set& other) ;
+        mutable_sync_subscription_set(mutable_sync_subscription_set&& other) = delete;
+        mutable_sync_subscription_set& operator=(mutable_sync_subscription_set&& other);
+        ~mutable_sync_subscription_set();
         // Inserts a new subscription into the set if one does not exist already.
         // If the `query_fn` parameter is left empty, the subscription will sync *all* objects
         // for the templated class type.
@@ -111,7 +117,6 @@ namespace realm {
         // Removes all subscriptions.
         void clear();
 
-
     private:
         mutable_sync_subscription_set(internal::bridge::realm&, const sync::MutableSubscriptionSet& subscription_set);
 #ifdef __i386__
@@ -125,7 +130,11 @@ namespace realm {
 #elif __arm__
         std::aligned_storage<136, 8>::type m_subscription_set[1];
 #elif __aarch64__
+#if defined(__clang__)
         std::aligned_storage<184, 8>::type m_subscription_set[1];
+#elif defined(__GNUC__) || defined(__GNUG__)
+        std::aligned_storage<192, 8>::type m_subscription_set[1];
+#endif
 #endif
         std::reference_wrapper<internal::bridge::realm> m_realm;
         friend struct sync_subscription_set;
@@ -134,6 +143,13 @@ namespace realm {
 
     struct sync_subscription_set {
     public:
+        sync_subscription_set() = delete;
+        sync_subscription_set(const sync_subscription_set& other) = delete;
+        sync_subscription_set& operator=(const sync_subscription_set& other) ;
+        sync_subscription_set(sync_subscription_set&& other) = delete;
+        sync_subscription_set& operator=(sync_subscription_set&& other);
+        ~sync_subscription_set();
+
         /// The total number of subscriptions in the set.
         [[nodiscard]] size_t size() const;
 
@@ -158,7 +174,11 @@ namespace realm {
 #elif __arm__
         std::aligned_storage<64, 8>::type m_subscription_set[1];
 #elif __aarch64__
+#if defined(__clang__)
         std::aligned_storage<96, 8>::type m_subscription_set[1];
+#elif defined(__GNUC__) || defined(__GNUG__)
+        std::aligned_storage<104, 8>::type m_subscription_set[1];
+#endif
 #endif
         std::reference_wrapper<internal::bridge::realm> m_realm;
     };

--- a/src/cpprealm/internal/bridge/binary.cpp
+++ b/src/cpprealm/internal/bridge/binary.cpp
@@ -5,46 +5,46 @@
 
 namespace realm::internal::bridge {
 #ifdef __i386__
-        static_assert(SizeCheck<8, sizeof(OwnedBinaryData)>{});
-        static_assert(SizeCheck<4, alignof(OwnedBinaryData)>{});
+        static_assert(SizeCheck<8, sizeof(BinaryData)>{});
+        static_assert(SizeCheck<4, alignof(BinaryData)>{});
 #elif __x86_64__
-        static_assert(SizeCheck<16, sizeof(OwnedBinaryData)>{});
-        static_assert(SizeCheck<8, alignof(OwnedBinaryData)>{});
+        static_assert(SizeCheck<16, sizeof(BinaryData)>{});
+        static_assert(SizeCheck<8, alignof(BinaryData)>{});
 #elif __arm__
-        static_assert(SizeCheck<8, sizeof(OwnedBinaryData)>{});
-        static_assert(SizeCheck<4, alignof(OwnedBinaryData)>{});
+        static_assert(SizeCheck<8, sizeof(BinaryData)>{});
+        static_assert(SizeCheck<4, alignof(BinaryData)>{});
 #elif __aarch64__
-        static_assert(SizeCheck<16, sizeof(OwnedBinaryData)>{});
-        static_assert(SizeCheck<8, alignof(OwnedBinaryData)>{});
+        static_assert(SizeCheck<16, sizeof(BinaryData)>{});
+        static_assert(SizeCheck<8, alignof(BinaryData)>{});
 #endif
 
     char binary::operator[](size_t i) const noexcept {
         return reinterpret_cast<const BinaryData*>(m_data)->operator[](i);
     }
-    binary::binary() {
-        new (&m_data) OwnedBinaryData();
-    }
-    binary::binary(const binary& other) {
-        new (&m_data) OwnedBinaryData(*reinterpret_cast<const OwnedBinaryData*>(&other.m_data));
-    }
-    binary& binary::operator=(const binary& other) {
-        if (this != &other) {
-            *reinterpret_cast<OwnedBinaryData*>(&m_data) = *reinterpret_cast<const OwnedBinaryData*>(&other.m_data);
-        }
-        return *this;
-    }
-    binary::binary(binary&& other) {
-        new (&m_data) OwnedBinaryData(std::move(*reinterpret_cast<OwnedBinaryData*>(&other.m_data)));
-    }
-    binary& binary::operator=(binary&& other) {
-        if (this != &other) {
-            *reinterpret_cast<OwnedBinaryData*>(&m_data) = std::move(*reinterpret_cast<OwnedBinaryData*>(&other.m_data));
-        }
-        return *this;
-    }
-    binary::~binary() {
-        reinterpret_cast<OwnedBinaryData*>(&m_data)->~OwnedBinaryData();
-    }
+//    binary::binary() {
+//        new (&m_data) OwnedBinaryData();
+//    }
+//    binary::binary(const binary& other) {
+//        new (&m_data) OwnedBinaryData(*reinterpret_cast<const OwnedBinaryData*>(other.m_data));
+//    }
+//    binary& binary::operator=(const binary& other) {
+//        if (this != &other) {
+//            *reinterpret_cast<OwnedBinaryData*>(m_data) = *reinterpret_cast<const OwnedBinaryData*>(other.m_data);
+//        }
+//        return *this;
+//    }
+//    binary::binary(binary&& other) {
+//        new (&m_data) OwnedBinaryData(std::move(*reinterpret_cast<OwnedBinaryData*>(other.m_data)));
+//    }
+//    binary& binary::operator=(binary&& other) {
+//        if (this != &other) {
+//            *reinterpret_cast<OwnedBinaryData*>(m_data) = std::move(*reinterpret_cast<OwnedBinaryData*>(other.m_data));
+//        }
+//        return *this;
+//    }
+//    binary::~binary() {
+//        reinterpret_cast<OwnedBinaryData*>(m_data)->~OwnedBinaryData();
+//    }
     binary::binary(const realm::BinaryData &v) {
         new (&m_data) OwnedBinaryData(v);
     }

--- a/src/cpprealm/internal/bridge/binary.cpp
+++ b/src/cpprealm/internal/bridge/binary.cpp
@@ -24,6 +24,27 @@ namespace realm::internal::bridge {
     binary::binary() {
         new (&m_data) OwnedBinaryData();
     }
+    binary::binary(const binary& other) {
+        new (&m_data) OwnedBinaryData(*reinterpret_cast<const OwnedBinaryData*>(&other.m_data));
+    }
+    binary& binary::operator=(const binary& other) {
+        if (this != &other) {
+            *reinterpret_cast<OwnedBinaryData*>(&m_data) = *reinterpret_cast<const OwnedBinaryData*>(&other.m_data);
+        }
+        return *this;
+    }
+    binary::binary(binary&& other) {
+        new (&m_data) OwnedBinaryData(std::move(*reinterpret_cast<OwnedBinaryData*>(&other.m_data)));
+    }
+    binary& binary::operator=(binary&& other) {
+        if (this != &other) {
+            *reinterpret_cast<OwnedBinaryData*>(&m_data) = std::move(*reinterpret_cast<OwnedBinaryData*>(&other.m_data));
+        }
+        return *this;
+    }
+    binary::~binary() {
+        reinterpret_cast<OwnedBinaryData*>(&m_data)->~OwnedBinaryData();
+    }
     binary::binary(const realm::BinaryData &v) {
         new (&m_data) OwnedBinaryData(v);
     }

--- a/src/cpprealm/internal/bridge/binary.cpp
+++ b/src/cpprealm/internal/bridge/binary.cpp
@@ -19,35 +19,32 @@ namespace realm::internal::bridge {
 #endif
 
     char binary::operator[](size_t i) const noexcept {
-        return reinterpret_cast<const BinaryData*>(m_data)->operator[](i);
+        return reinterpret_cast<const BinaryData*>(&m_data)->operator[](i);
     }
-//    binary::binary() {
-//        new (&m_data) OwnedBinaryData();
-//    }
-//    binary::binary(const binary& other) {
-//        new (&m_data) OwnedBinaryData(*reinterpret_cast<const OwnedBinaryData*>(other.m_data));
-//    }
-//    binary& binary::operator=(const binary& other) {
-//        if (this != &other) {
-//            *reinterpret_cast<OwnedBinaryData*>(m_data) = *reinterpret_cast<const OwnedBinaryData*>(other.m_data);
-//        }
-//        return *this;
-//    }
-//    binary::binary(binary&& other) {
-//        new (&m_data) OwnedBinaryData(std::move(*reinterpret_cast<OwnedBinaryData*>(other.m_data)));
-//    }
-//    binary& binary::operator=(binary&& other) {
-//        if (this != &other) {
-//            *reinterpret_cast<OwnedBinaryData*>(m_data) = std::move(*reinterpret_cast<OwnedBinaryData*>(other.m_data));
-//        }
-//        return *this;
-//    }
-//    binary::~binary() {
-//        reinterpret_cast<OwnedBinaryData*>(m_data)->~OwnedBinaryData();
-//    }
+    binary::binary() {
+        new (&m_data) BinaryData();
+    }
+    binary::binary(const binary& other) {
+        new (&m_data) BinaryData(*reinterpret_cast<const BinaryData*>(&other.m_data));
+    }
+    binary& binary::operator=(const binary& other) {
+        *reinterpret_cast<BinaryData*>(&m_data) = *reinterpret_cast<const BinaryData*>(&other.m_data);
+        return *this;
+    }
+    binary::binary(binary&& other) {
+        new (&m_data) BinaryData(std::move(*reinterpret_cast<BinaryData*>(&other.m_data)));
+    }
+    binary& binary::operator=(binary&& other) {
+        *reinterpret_cast<BinaryData*>(&m_data) = std::move(*reinterpret_cast<BinaryData*>(&other.m_data));
+        return *this;
+    }
+    binary::~binary() {
+        reinterpret_cast<BinaryData*>(&m_data)->~BinaryData();
+    }
     binary::binary(const realm::BinaryData &v) {
         new (&m_data) OwnedBinaryData(v);
     }
+
     binary::binary(const std::vector<uint8_t> &v) {
         if (v.empty()) {
             new (&m_data) OwnedBinaryData("", 0);
@@ -57,13 +54,13 @@ namespace realm::internal::bridge {
     }
 
     binary::operator BinaryData() const {
-        return *reinterpret_cast<const BinaryData*>(m_data);
+        return *reinterpret_cast<const BinaryData*>(&m_data);
     }
     size_t binary::size() const {
-        return reinterpret_cast<const BinaryData*>(m_data)->size();
+        return reinterpret_cast<const BinaryData*>(&m_data)->size();
     }
     const char *binary::data() const {
-        return reinterpret_cast<const BinaryData*>(m_data)->data();
+        return reinterpret_cast<const BinaryData*>(&m_data)->data();
     }
     bool operator ==(binary const& lhs, binary const& rhs) {
         return static_cast<BinaryData>(lhs) == static_cast<BinaryData>(rhs);

--- a/src/cpprealm/internal/bridge/binary.hpp
+++ b/src/cpprealm/internal/bridge/binary.hpp
@@ -9,12 +9,12 @@ namespace realm {
 }
 namespace realm::internal::bridge {
     struct binary {
-        binary();
-        binary(const binary& other) ;
-        binary& operator=(const binary& other) ;
-        binary(binary&& other);
-        binary& operator=(binary&& other);
-        ~binary();
+//        binary();
+//        binary(const binary& other) ;
+//        binary& operator=(const binary& other) ;
+//        binary(binary&& other);
+//        binary& operator=(binary&& other);
+//        ~binary();
         binary(const BinaryData&); //NOLINT(google-explicit-constructor)
         binary(const std::vector<uint8_t>&); //NOLINT(google-explicit-constructor)
         [[nodiscard]] const char* data() const;

--- a/src/cpprealm/internal/bridge/binary.hpp
+++ b/src/cpprealm/internal/bridge/binary.hpp
@@ -10,6 +10,11 @@ namespace realm {
 namespace realm::internal::bridge {
     struct binary {
         binary();
+        binary(const binary& other) ;
+        binary& operator=(const binary& other) ;
+        binary(binary&& other);
+        binary& operator=(binary&& other);
+        ~binary();
         binary(const BinaryData&); //NOLINT(google-explicit-constructor)
         binary(const std::vector<uint8_t>&); //NOLINT(google-explicit-constructor)
         [[nodiscard]] const char* data() const;

--- a/src/cpprealm/internal/bridge/binary.hpp
+++ b/src/cpprealm/internal/bridge/binary.hpp
@@ -6,15 +6,16 @@
 
 namespace realm {
     class BinaryData;
+    class OwnedBinaryData;
 }
 namespace realm::internal::bridge {
     struct binary {
-//        binary();
-//        binary(const binary& other) ;
-//        binary& operator=(const binary& other) ;
-//        binary(binary&& other);
-//        binary& operator=(binary&& other);
-//        ~binary();
+        binary();
+        binary(const binary& other) ;
+        binary& operator=(const binary& other) ;
+        binary(binary&& other);
+        binary& operator=(binary&& other);
+        ~binary();
         binary(const BinaryData&); //NOLINT(google-explicit-constructor)
         binary(const std::vector<uint8_t>&); //NOLINT(google-explicit-constructor)
         [[nodiscard]] const char* data() const;

--- a/src/cpprealm/internal/bridge/col_key.cpp
+++ b/src/cpprealm/internal/bridge/col_key.cpp
@@ -25,21 +25,21 @@ namespace realm::internal::bridge {
     }
     col_key& col_key::operator=(const col_key& other) {
         if (this != &other) {
-            *reinterpret_cast<ColKey*>(&m_col_key) = *reinterpret_cast<const ColKey*>(&other.m_col_key);
+            *reinterpret_cast<ColKey*>(m_col_key) = *reinterpret_cast<const ColKey*>(other.m_col_key);
         }
         return *this;
     }
     col_key::col_key(col_key&& other) {
-        new (&m_col_key) ColKey(std::move(*reinterpret_cast<ColKey*>(&other.m_col_key)));
+        new (m_col_key) ColKey(std::move(*reinterpret_cast<ColKey*>(other.m_col_key)));
     }
     col_key& col_key::operator=(col_key&& other) {
         if (this != &other) {
-            *reinterpret_cast<ColKey*>(&m_col_key) = std::move(*reinterpret_cast<ColKey*>(&other.m_col_key));
+            *reinterpret_cast<ColKey*>(m_col_key) = std::move(*reinterpret_cast<ColKey*>(other.m_col_key));
         }
         return *this;
     }
     col_key::~col_key() {
-        reinterpret_cast<ColKey*>(&m_col_key)->~ColKey();
+        reinterpret_cast<ColKey*>(m_col_key)->~ColKey();
     }
     col_key::col_key(int64_t v) {
         new (&m_col_key) ColKey(v);

--- a/src/cpprealm/internal/bridge/col_key.cpp
+++ b/src/cpprealm/internal/bridge/col_key.cpp
@@ -25,21 +25,21 @@ namespace realm::internal::bridge {
     }
     col_key& col_key::operator=(const col_key& other) {
         if (this != &other) {
-            *reinterpret_cast<ColKey*>(m_col_key) = *reinterpret_cast<const ColKey*>(other.m_col_key);
+            *reinterpret_cast<ColKey*>(&m_col_key) = *reinterpret_cast<const ColKey*>(&other.m_col_key);
         }
         return *this;
     }
     col_key::col_key(col_key&& other) {
-        new (m_col_key) ColKey(std::move(*reinterpret_cast<ColKey*>(other.m_col_key)));
+        new (&m_col_key) ColKey(std::move(*reinterpret_cast<ColKey*>(&other.m_col_key)));
     }
     col_key& col_key::operator=(col_key&& other) {
         if (this != &other) {
-            *reinterpret_cast<ColKey*>(m_col_key) = std::move(*reinterpret_cast<ColKey*>(other.m_col_key));
+            *reinterpret_cast<ColKey*>(&m_col_key) = std::move(*reinterpret_cast<ColKey*>(&other.m_col_key));
         }
         return *this;
     }
     col_key::~col_key() {
-        reinterpret_cast<ColKey*>(m_col_key)->~ColKey();
+        reinterpret_cast<ColKey*>(&m_col_key)->~ColKey();
     }
     col_key::col_key(int64_t v) {
         new (&m_col_key) ColKey(v);
@@ -49,10 +49,10 @@ namespace realm::internal::bridge {
     }
 
     int64_t col_key::value() const {
-        return reinterpret_cast<const ColKey*>(m_col_key)->value;
+        return reinterpret_cast<const ColKey*>(&m_col_key)->value;
     }
 
     col_key::operator ColKey() const {
-        return *reinterpret_cast<const ColKey*>(m_col_key);
+        return *reinterpret_cast<const ColKey*>(&m_col_key);
     }
 }

--- a/src/cpprealm/internal/bridge/col_key.cpp
+++ b/src/cpprealm/internal/bridge/col_key.cpp
@@ -20,6 +20,27 @@ namespace realm::internal::bridge {
     col_key::col_key() noexcept {
         new (&m_col_key) ColKey();
     }
+    col_key::col_key(const col_key& other) {
+        new (&m_col_key) ColKey(*reinterpret_cast<const ColKey*>(&other.m_col_key));
+    }
+    col_key& col_key::operator=(const col_key& other) {
+        if (this != &other) {
+            *reinterpret_cast<ColKey*>(&m_col_key) = *reinterpret_cast<const ColKey*>(&other.m_col_key);
+        }
+        return *this;
+    }
+    col_key::col_key(col_key&& other) {
+        new (&m_col_key) ColKey(std::move(*reinterpret_cast<ColKey*>(&other.m_col_key)));
+    }
+    col_key& col_key::operator=(col_key&& other) {
+        if (this != &other) {
+            *reinterpret_cast<ColKey*>(&m_col_key) = std::move(*reinterpret_cast<ColKey*>(&other.m_col_key));
+        }
+        return *this;
+    }
+    col_key::~col_key() {
+        reinterpret_cast<ColKey*>(&m_col_key)->~ColKey();
+    }
     col_key::col_key(int64_t v) {
         new (&m_col_key) ColKey(v);
     }

--- a/src/cpprealm/internal/bridge/col_key.hpp
+++ b/src/cpprealm/internal/bridge/col_key.hpp
@@ -10,6 +10,11 @@ namespace realm {
 namespace realm::internal::bridge {
     struct col_key {
         col_key() noexcept;
+        col_key(const col_key& other) ;
+        col_key& operator=(const col_key& other) ;
+        col_key(col_key&& other);
+        col_key& operator=(col_key&& other);
+        ~col_key();
         col_key(int64_t); //NOLINT(google-explicit-constructor)
         col_key(const ColKey&); //NOLINT(google-explicit-constructor)
         operator ColKey() const; //NOLINT(google-explicit-constructor)

--- a/src/cpprealm/internal/bridge/dictionary.cpp
+++ b/src/cpprealm/internal/bridge/dictionary.cpp
@@ -23,36 +23,36 @@ namespace realm::internal::bridge {
 #endif
 
     dictionary::dictionary() {
-        new (m_dictionary) Dictionary();
+        new (&m_dictionary) Dictionary();
     }
     dictionary::dictionary(const dictionary& other) {
-        new (&m_dictionary) Dictionary(*reinterpret_cast<const Dictionary*>(&other.m_dictionary));
+        new (&m_dictionary) Dictionary(*reinterpret_cast<const Dictionary*>(other.m_dictionary));
     }
-    
+
     dictionary& dictionary::operator=(const dictionary& other) {
         if (this != &other) {
-            *reinterpret_cast<Dictionary*>(&m_dictionary) = *reinterpret_cast<const Dictionary*>(&other.m_dictionary);
+            *reinterpret_cast<Dictionary*>(&m_dictionary) = *reinterpret_cast<const Dictionary*>(other.m_dictionary);
         }
         return *this;
     }
 
     dictionary::dictionary(dictionary&& other) {
-        new (&m_dictionary) Dictionary(std::move(*reinterpret_cast<Dictionary*>(&other.m_dictionary)));
+        new (&m_dictionary) Dictionary(std::move(*reinterpret_cast<Dictionary*>(other.m_dictionary)));
     }
 
     dictionary& dictionary::operator=(dictionary&& other) {
         if (this != &other) {
-            *reinterpret_cast<Dictionary*>(&m_dictionary) = std::move(*reinterpret_cast<Dictionary*>(&other.m_dictionary));
+            *reinterpret_cast<Dictionary*>(m_dictionary) = std::move(*reinterpret_cast<Dictionary*>(other.m_dictionary));
         }
         return *this;
     }
 
     dictionary::~dictionary() {
-        reinterpret_cast<Dictionary*>(&m_dictionary)->~Dictionary();
+        reinterpret_cast<Dictionary*>(m_dictionary)->~Dictionary();
     }
     
     dictionary::dictionary(const Dictionary &v) {
-        new (m_dictionary) Dictionary(v);
+        new (&m_dictionary) Dictionary(v);
     }
 
     dictionary::operator Dictionary() const {

--- a/src/cpprealm/internal/bridge/dictionary.cpp
+++ b/src/cpprealm/internal/bridge/dictionary.cpp
@@ -25,7 +25,32 @@ namespace realm::internal::bridge {
     dictionary::dictionary() {
         new (m_dictionary) Dictionary();
     }
+    dictionary::dictionary(const dictionary& other) {
+        new (&m_dictionary) Dictionary(*reinterpret_cast<const Dictionary*>(&other.m_dictionary));
+    }
+    
+    dictionary& dictionary::operator=(const dictionary& other) {
+        if (this != &other) {
+            *reinterpret_cast<Dictionary*>(&m_dictionary) = *reinterpret_cast<const Dictionary*>(&other.m_dictionary);
+        }
+        return *this;
+    }
 
+    dictionary::dictionary(dictionary&& other) {
+        new (&m_dictionary) Dictionary(std::move(*reinterpret_cast<Dictionary*>(&other.m_dictionary)));
+    }
+
+    dictionary& dictionary::operator=(dictionary&& other) {
+        if (this != &other) {
+            *reinterpret_cast<Dictionary*>(&m_dictionary) = std::move(*reinterpret_cast<Dictionary*>(&other.m_dictionary));
+        }
+        return *this;
+    }
+
+    dictionary::~dictionary() {
+        reinterpret_cast<Dictionary*>(&m_dictionary)->~Dictionary();
+    }
+    
     dictionary::dictionary(const Dictionary &v) {
         new (m_dictionary) Dictionary(v);
     }

--- a/src/cpprealm/internal/bridge/dictionary.cpp
+++ b/src/cpprealm/internal/bridge/dictionary.cpp
@@ -26,29 +26,29 @@ namespace realm::internal::bridge {
         new (&m_dictionary) Dictionary();
     }
     dictionary::dictionary(const dictionary& other) {
-        new (&m_dictionary) Dictionary(*reinterpret_cast<const Dictionary*>(other.m_dictionary));
+        new (&m_dictionary) Dictionary(*reinterpret_cast<const Dictionary*>(&other.m_dictionary));
     }
 
     dictionary& dictionary::operator=(const dictionary& other) {
         if (this != &other) {
-            *reinterpret_cast<Dictionary*>(&m_dictionary) = *reinterpret_cast<const Dictionary*>(other.m_dictionary);
+            *reinterpret_cast<Dictionary*>(&m_dictionary) = *reinterpret_cast<const Dictionary*>(&other.m_dictionary);
         }
         return *this;
     }
 
     dictionary::dictionary(dictionary&& other) {
-        new (&m_dictionary) Dictionary(std::move(*reinterpret_cast<Dictionary*>(other.m_dictionary)));
+        new (&m_dictionary) Dictionary(std::move(*reinterpret_cast<Dictionary*>(&other.m_dictionary)));
     }
 
     dictionary& dictionary::operator=(dictionary&& other) {
         if (this != &other) {
-            *reinterpret_cast<Dictionary*>(m_dictionary) = std::move(*reinterpret_cast<Dictionary*>(other.m_dictionary));
+            *reinterpret_cast<Dictionary*>(&m_dictionary) = std::move(*reinterpret_cast<Dictionary*>(&other.m_dictionary));
         }
         return *this;
     }
 
     dictionary::~dictionary() {
-        reinterpret_cast<Dictionary*>(m_dictionary)->~Dictionary();
+        reinterpret_cast<Dictionary*>(&m_dictionary)->~Dictionary();
     }
     
     dictionary::dictionary(const Dictionary &v) {
@@ -56,25 +56,25 @@ namespace realm::internal::bridge {
     }
 
     dictionary::operator Dictionary() const {
-        return *reinterpret_cast<const Dictionary*>(m_dictionary);
+        return *reinterpret_cast<const Dictionary*>(&m_dictionary);
     }
     size_t dictionary::size() const {
-        return reinterpret_cast<const Dictionary*>(m_dictionary)->size();
+        return reinterpret_cast<const Dictionary*>(&m_dictionary)->size();
     }
 
     void dictionary::insert(const std::string &key, const mixed &value) {
-        reinterpret_cast<Dictionary*>(m_dictionary)->insert_any(key, static_cast<Mixed>(value));
+        reinterpret_cast<Dictionary*>(&m_dictionary)->insert_any(key, static_cast<Mixed>(value));
     }
 
     void dictionary::insert(const std::string &key, const std::string &value) {
-        reinterpret_cast<Dictionary*>(m_dictionary)->insert(key, StringData(value));
+        reinterpret_cast<Dictionary*>(&m_dictionary)->insert(key, StringData(value));
     }
     void dictionary::clear() {
-        reinterpret_cast<Dictionary*>(m_dictionary)->remove_all();
+        reinterpret_cast<Dictionary*>(&m_dictionary)->remove_all();
     }
 
     size_t dictionary::find(const std::string& key) {
-        return reinterpret_cast<Dictionary*>(m_dictionary)->find_any(key);
+        return reinterpret_cast<Dictionary*>(&m_dictionary)->find_any(key);
     }
 
     void dictionary::remove_all() {
@@ -82,62 +82,62 @@ namespace realm::internal::bridge {
     }
 
     void dictionary::remove(const std::string& key) {
-        reinterpret_cast<Dictionary*>(m_dictionary)->try_erase(key);
+        reinterpret_cast<Dictionary*>(&m_dictionary)->try_erase(key);
     }
 
     std::pair<std::string, mixed> dictionary::get_pair(size_t idx) {
-        auto pair = reinterpret_cast<Dictionary*>(m_dictionary)->get_pair(idx);
+        auto pair = reinterpret_cast<Dictionary*>(&m_dictionary)->get_pair(idx);
         return { pair.first, static_cast<mixed>(pair.second) };
     }
 
     size_t dictionary::get_key_index(const std::string& key) {
-        Results keys = reinterpret_cast<Dictionary*>(m_dictionary)->get_keys();
+        Results keys = reinterpret_cast<Dictionary*>(&m_dictionary)->get_keys();
         return keys.index_of(StringData(key));
     }
 
     template <>
     std::string get(dictionary& dict, const std::string &key) {
-        return reinterpret_cast<Dictionary*>(dict.m_dictionary)->get<StringData>(key);
+        return reinterpret_cast<Dictionary*>(&dict.m_dictionary)->get<StringData>(key);
     }
     template <>
     uuid get(dictionary& dict, const std::string &key) {
-        return reinterpret_cast<Dictionary*>(dict.m_dictionary)->get<UUID>(key);
+        return reinterpret_cast<Dictionary*>(&dict.m_dictionary)->get<UUID>(key);
     }
     template <>
     object_id get(dictionary& dict, const std::string &key) {
-        return reinterpret_cast<Dictionary*>(dict.m_dictionary)->get<ObjectId>(key);
+        return reinterpret_cast<Dictionary*>(&dict.m_dictionary)->get<ObjectId>(key);
     }
     template <>
     timestamp get(dictionary& dict, const std::string &key) {
-        return reinterpret_cast<Dictionary*>(dict.m_dictionary)->get<Timestamp>(key);
+        return reinterpret_cast<Dictionary*>(&dict.m_dictionary)->get<Timestamp>(key);
     }
     template <>
     binary get(dictionary& dict, const std::string &key) {
-        return reinterpret_cast<Dictionary*>(dict.m_dictionary)->get<BinaryData>(key);
+        return reinterpret_cast<Dictionary*>(&dict.m_dictionary)->get<BinaryData>(key);
     }
     template <>
     int64_t get(dictionary& dict, const std::string &key) {
-        return reinterpret_cast<Dictionary*>(dict.m_dictionary)->get<Int>(key);
+        return reinterpret_cast<Dictionary*>(&dict.m_dictionary)->get<Int>(key);
     }
     template <>
     double get(dictionary& dict, const std::string &key) {
-        return reinterpret_cast<Dictionary*>(dict.m_dictionary)->get<Double>(key);
+        return reinterpret_cast<Dictionary*>(&dict.m_dictionary)->get<Double>(key);
     }
     template <>
     obj_key get(dictionary& dict, const std::string &key) {
-        return reinterpret_cast<Dictionary*>(dict.m_dictionary)->get<ObjKey>(key);
+        return reinterpret_cast<Dictionary*>(&dict.m_dictionary)->get<ObjKey>(key);
     }
     template <>
     obj get(dictionary& dict, const std::string &key) {
-        return reinterpret_cast<Dictionary*>(dict.m_dictionary)->get_object(key);
+        return reinterpret_cast<Dictionary*>(&dict.m_dictionary)->get_object(key);
     }
     template <>
     mixed get(dictionary& dict, const std::string &key) {
-        return reinterpret_cast<Dictionary*>(dict.m_dictionary)->get_any(key);
+        return reinterpret_cast<Dictionary*>(&dict.m_dictionary)->get_any(key);
     }
     template <>
     bool get(dictionary& dict, const std::string &key) {
-        return reinterpret_cast<Dictionary*>(dict.m_dictionary)->get<Bool>(key);
+        return reinterpret_cast<Dictionary*>(&dict.m_dictionary)->get<Bool>(key);
     }
 
     notification_token dictionary::add_notification_callback(std::shared_ptr<collection_change_callback>&& cb) {
@@ -152,10 +152,10 @@ namespace realm::internal::bridge {
                 m_cb->after(v);
             }
         } ccb(std::move(cb));
-        return reinterpret_cast<Dictionary*>(m_dictionary)->add_notification_callback(ccb);
+        return reinterpret_cast<Dictionary*>(&m_dictionary)->add_notification_callback(ccb);
     }
 
     obj dictionary::insert_embedded(const std::string &v) {
-        return reinterpret_cast<Dictionary*>(m_dictionary)->insert_embedded(v);
+        return reinterpret_cast<Dictionary*>(&m_dictionary)->insert_embedded(v);
     }
 }

--- a/src/cpprealm/internal/bridge/dictionary.hpp
+++ b/src/cpprealm/internal/bridge/dictionary.hpp
@@ -23,6 +23,11 @@ namespace realm::internal::bridge {
 
     struct dictionary {
         dictionary();
+        dictionary(const dictionary& other) ;
+        dictionary& operator=(const dictionary& other) ;
+        dictionary(dictionary&& other);
+        dictionary& operator=(dictionary&& other);
+        ~dictionary();
         dictionary(const Dictionary& v); //NOLINT(google-explicit-constructor)
         operator Dictionary() const; //NOLINT(google-explicit-constructor)
         void insert(const std::string& key, const mixed& value);

--- a/src/cpprealm/internal/bridge/list.cpp
+++ b/src/cpprealm/internal/bridge/list.cpp
@@ -30,6 +30,32 @@ namespace realm::internal::bridge {
     list::list() {
         new (&m_list) List();
     }
+    
+    list::list(const list& other) {
+        new (&m_list) List(*reinterpret_cast<const List*>(&other.m_list));
+    }
+    
+    list& list::operator=(const list& other) {
+        if (this != &other) {
+            *reinterpret_cast<List*>(&m_list) = *reinterpret_cast<const List*>(&other.m_list);
+        }
+        return *this;
+    }
+
+    list::list(list&& other) {
+        new (&m_list) List(std::move(*reinterpret_cast<List*>(&other.m_list)));
+    }
+
+    list& list::operator=(list&& other) {
+        if (this != &other) {
+            *reinterpret_cast<List*>(&m_list) = std::move(*reinterpret_cast<List*>(&other.m_list));
+        }
+        return *this;
+    }
+
+    list::~list() {
+        reinterpret_cast<List*>(&m_list)->~List();
+    }
 
     list::list(const List &v) {
         new (&m_list) List(v);

--- a/src/cpprealm/internal/bridge/list.cpp
+++ b/src/cpprealm/internal/bridge/list.cpp
@@ -32,23 +32,23 @@ namespace realm::internal::bridge {
     }
     
     list::list(const list& other) {
-        new (&m_list) List(*reinterpret_cast<const List*>(&other.m_list));
+        new (&m_list) List(*reinterpret_cast<const List*>(other.m_list));
     }
     
     list& list::operator=(const list& other) {
         if (this != &other) {
-            *reinterpret_cast<List*>(&m_list) = *reinterpret_cast<const List*>(&other.m_list);
+            *reinterpret_cast<List*>(&m_list) = *reinterpret_cast<const List*>(other.m_list);
         }
         return *this;
     }
 
     list::list(list&& other) {
-        new (&m_list) List(std::move(*reinterpret_cast<List*>(&other.m_list)));
+        new (&m_list) List(std::move(*reinterpret_cast<List*>(other.m_list)));
     }
 
     list& list::operator=(list&& other) {
         if (this != &other) {
-            *reinterpret_cast<List*>(&m_list) = std::move(*reinterpret_cast<List*>(&other.m_list));
+            *reinterpret_cast<List*>(&m_list) = std::move(*reinterpret_cast<List*>(other.m_list));
         }
         return *this;
     }

--- a/src/cpprealm/internal/bridge/list.cpp
+++ b/src/cpprealm/internal/bridge/list.cpp
@@ -32,23 +32,23 @@ namespace realm::internal::bridge {
     }
     
     list::list(const list& other) {
-        new (&m_list) List(*reinterpret_cast<const List*>(other.m_list));
+        new (&m_list) List(*reinterpret_cast<const List*>(&other.m_list));
     }
     
     list& list::operator=(const list& other) {
         if (this != &other) {
-            *reinterpret_cast<List*>(&m_list) = *reinterpret_cast<const List*>(other.m_list);
+            *reinterpret_cast<List*>(&m_list) = *reinterpret_cast<const List*>(&other.m_list);
         }
         return *this;
     }
 
     list::list(list&& other) {
-        new (&m_list) List(std::move(*reinterpret_cast<List*>(other.m_list)));
+        new (&m_list) List(std::move(*reinterpret_cast<List*>(&other.m_list)));
     }
 
     list& list::operator=(list&& other) {
         if (this != &other) {
-            *reinterpret_cast<List*>(&m_list) = std::move(*reinterpret_cast<List*>(other.m_list));
+            *reinterpret_cast<List*>(&m_list) = std::move(*reinterpret_cast<List*>(&other.m_list));
         }
         return *this;
     }
@@ -68,126 +68,126 @@ namespace realm::internal::bridge {
     }
 
     list::operator List() const {
-        return *reinterpret_cast<const List*>(m_list);
+        return *reinterpret_cast<const List*>(&m_list);
     }
 
     table list::get_table() const {
-        return reinterpret_cast<const List *>(m_list)->get_table();
+        return reinterpret_cast<const List *>(&m_list)->get_table();
     }
     size_t list::size() const {
-        return reinterpret_cast<const List *>(m_list)->size();
+        return reinterpret_cast<const List *>(&m_list)->size();
     }
     void list::remove(size_t idx) {
-        reinterpret_cast<List *>(m_list)->remove(idx);
+        reinterpret_cast<List *>(&m_list)->remove(idx);
     }
     void list::remove_all() {
-        reinterpret_cast<List *>(m_list)->remove_all();
+        reinterpret_cast<List *>(&m_list)->remove_all();
     }
 
     realm list::get_realm() const {
-        return reinterpret_cast<const List *>(m_list)->get_realm();
+        return reinterpret_cast<const List *>(&m_list)->get_realm();
     }
 
     void list::add(const std::string &v) {
-        reinterpret_cast<List *>(m_list)->add(StringData(v));
+        reinterpret_cast<List *>(&m_list)->add(StringData(v));
     }
     void list::add(const int64_t &v) {
-        reinterpret_cast<List *>(m_list)->add(v);
+        reinterpret_cast<List *>(&m_list)->add(v);
     }
     void list::add(const double &v) {
-        reinterpret_cast<List *>(m_list)->add(v);
+        reinterpret_cast<List *>(&m_list)->add(v);
     }
     void list::add(const binary &v) {
-        reinterpret_cast<List *>(m_list)->add(static_cast<BinaryData>(v));
+        reinterpret_cast<List *>(&m_list)->add(static_cast<BinaryData>(v));
     }
     void list::add(const uuid &v) {
-        reinterpret_cast<List *>(m_list)->add(static_cast<UUID>(v));
+        reinterpret_cast<List *>(&m_list)->add(static_cast<UUID>(v));
     }
     void list::add(const object_id &v) {
-        reinterpret_cast<List *>(m_list)->add(static_cast<ObjectId>(v));
+        reinterpret_cast<List *>(&m_list)->add(static_cast<ObjectId>(v));
     }
     void list::add(const mixed &v) {
-        reinterpret_cast<List *>(m_list)->add(static_cast<Mixed>(v));
+        reinterpret_cast<List *>(&m_list)->add(static_cast<Mixed>(v));
     }
     void list::add(const obj_key &v) {
-        reinterpret_cast<List *>(m_list)->add(static_cast<ObjKey>(v));
+        reinterpret_cast<List *>(&m_list)->add(static_cast<ObjKey>(v));
     }
     void list::add(const timestamp &v) {
-        reinterpret_cast<List *>(m_list)->add(static_cast<Timestamp>(v));
+        reinterpret_cast<List *>(&m_list)->add(static_cast<Timestamp>(v));
     }
     void list::add(const bool &v) {
-        reinterpret_cast<List *>(m_list)->add(v);
+        reinterpret_cast<List *>(&m_list)->add(v);
     }
     obj list::add_embedded() {
-        return reinterpret_cast<List *>(m_list)->add_embedded();
+        return reinterpret_cast<List *>(&m_list)->add_embedded();
     }
 
     template <>
     std::string get(const list& lst, size_t idx) {
-        return reinterpret_cast<const List *>(lst.m_list)->get<StringData>(idx);
+        return reinterpret_cast<const List *>(&lst.m_list)->get<StringData>(idx);
     }
     template <>
     int64_t get(const list& lst, size_t idx) {
-        return reinterpret_cast<const List *>(lst.m_list)->get<Int>(idx);
+        return reinterpret_cast<const List *>(&lst.m_list)->get<Int>(idx);
     }
     template <>
     double get(const list& lst, size_t idx) {
-        return reinterpret_cast<const List *>(lst.m_list)->get<Double>(idx);
+        return reinterpret_cast<const List *>(&lst.m_list)->get<Double>(idx);
     }
     template <>
     binary get(const list& lst, size_t idx) {
-        return reinterpret_cast<const List *>(lst.m_list)->get<BinaryData>(idx);
+        return reinterpret_cast<const List *>(&lst.m_list)->get<BinaryData>(idx);
     }
     template <>
     uuid get(const list& lst, size_t idx) {
-        return reinterpret_cast<const List *>(lst.m_list)->get<UUID>(idx);
+        return reinterpret_cast<const List *>(&lst.m_list)->get<UUID>(idx);
     }
     template <>
     object_id get(const list& lst, size_t idx) {
-        return reinterpret_cast<const List *>(lst.m_list)->get<ObjectId>(idx);
+        return reinterpret_cast<const List *>(&lst.m_list)->get<ObjectId>(idx);
     }
     template <>
     mixed get(const list& lst, size_t idx) {
-        return reinterpret_cast<const List *>(lst.m_list)->get<Mixed>(idx);
+        return reinterpret_cast<const List *>(&lst.m_list)->get<Mixed>(idx);
     }
     template <>
     obj get(const list& lst, size_t idx) {
-        return reinterpret_cast<const List *>(lst.m_list)->get<Obj>(idx);
+        return reinterpret_cast<const List *>(&lst.m_list)->get<Obj>(idx);
     }
     template <>
     bool get(const list& lst, size_t idx) {
-        return reinterpret_cast<const List *>(lst.m_list)->get<Bool>(idx);
+        return reinterpret_cast<const List *>(&lst.m_list)->get<Bool>(idx);
     }
     template <>
     timestamp get(const list& lst, size_t idx) {
-        return reinterpret_cast<const List *>(lst.m_list)->get<Timestamp>(idx);
+        return reinterpret_cast<const List *>(&lst.m_list)->get<Timestamp>(idx);
     }
 
-    void list::set(size_t pos, const int64_t &v) { reinterpret_cast<List *>(m_list)->set(pos, v); }
-    void list::set(size_t pos, const bool &v) { reinterpret_cast<List *>(m_list)->set(pos, v); }
-    void list::set(size_t pos, const std::string &v) { reinterpret_cast<List *>(m_list)->set(pos, StringData(v)); }
-    void list::set(size_t pos, const double &v) { reinterpret_cast<List *>(m_list)->set(pos, v); }
-    void list::set(size_t pos, const uuid &v) { reinterpret_cast<List *>(m_list)->set(pos, static_cast<UUID>(v)); }
-    void list::set(size_t pos, const object_id &v) { reinterpret_cast<List *>(m_list)->set(pos, static_cast<ObjectId>(v)); }
-    void list::set(size_t pos, const mixed &v) { reinterpret_cast<List *>(m_list)->set(pos, static_cast<Mixed>(v)); }
-    void list::set(size_t pos, const binary &v) { reinterpret_cast<List *>(m_list)->set(pos, static_cast<BinaryData>(v)); }
-    void list::set(size_t pos, const timestamp &v) { reinterpret_cast<List *>(m_list)->set(pos, static_cast<Timestamp>(v)); }
+    void list::set(size_t pos, const int64_t &v) { reinterpret_cast<List *>(&m_list)->set(pos, v); }
+    void list::set(size_t pos, const bool &v) { reinterpret_cast<List *>(&m_list)->set(pos, v); }
+    void list::set(size_t pos, const std::string &v) { reinterpret_cast<List *>(&m_list)->set(pos, StringData(v)); }
+    void list::set(size_t pos, const double &v) { reinterpret_cast<List *>(&m_list)->set(pos, v); }
+    void list::set(size_t pos, const uuid &v) { reinterpret_cast<List *>(&m_list)->set(pos, static_cast<UUID>(v)); }
+    void list::set(size_t pos, const object_id &v) { reinterpret_cast<List *>(&m_list)->set(pos, static_cast<ObjectId>(v)); }
+    void list::set(size_t pos, const mixed &v) { reinterpret_cast<List *>(&m_list)->set(pos, static_cast<Mixed>(v)); }
+    void list::set(size_t pos, const binary &v) { reinterpret_cast<List *>(&m_list)->set(pos, static_cast<BinaryData>(v)); }
+    void list::set(size_t pos, const timestamp &v) { reinterpret_cast<List *>(&m_list)->set(pos, static_cast<Timestamp>(v)); }
 
-    size_t list::find(const int64_t &v) { return reinterpret_cast<List *>(m_list)->find(v); }
-    size_t list::find(const bool &v) { return reinterpret_cast<List *>(m_list)->find(v); }
-    size_t list::find(const double &v) { return reinterpret_cast<List *>(m_list)->find(v); }
-    size_t list::find(const std::string &v) { return reinterpret_cast<List *>(m_list)->find(StringData(v)); }
-    size_t list::find(const uuid &v) { return reinterpret_cast<List *>(m_list)->find(static_cast<UUID>(v)); }
-    size_t list::find(const object_id &v) { return reinterpret_cast<List *>(m_list)->find(static_cast<ObjectId>(v)); }
-    size_t list::find(const mixed &v) { return reinterpret_cast<List *>(m_list)->find(static_cast<Mixed>(v)); }
-    size_t list::find(const timestamp &v) { return reinterpret_cast<List *>(m_list)->find(static_cast<Timestamp>(v)); }
+    size_t list::find(const int64_t &v) { return reinterpret_cast<List *>(&m_list)->find(v); }
+    size_t list::find(const bool &v) { return reinterpret_cast<List *>(&m_list)->find(v); }
+    size_t list::find(const double &v) { return reinterpret_cast<List *>(&m_list)->find(v); }
+    size_t list::find(const std::string &v) { return reinterpret_cast<List *>(&m_list)->find(StringData(v)); }
+    size_t list::find(const uuid &v) { return reinterpret_cast<List *>(&m_list)->find(static_cast<UUID>(v)); }
+    size_t list::find(const object_id &v) { return reinterpret_cast<List *>(&m_list)->find(static_cast<ObjectId>(v)); }
+    size_t list::find(const mixed &v) { return reinterpret_cast<List *>(&m_list)->find(static_cast<Mixed>(v)); }
+    size_t list::find(const timestamp &v) { return reinterpret_cast<List *>(&m_list)->find(static_cast<Timestamp>(v)); }
     size_t list::find(const binary& v) {
         auto v_actual = v.operator BinaryData();
-        auto val_actual = reinterpret_cast<List *>(m_list)->get<BinaryData>(1);
-        auto val = reinterpret_cast<List *>(m_list)->find(static_cast<BinaryData>(v));
+        auto val_actual = reinterpret_cast<List *>(&m_list)->get<BinaryData>(1);
+        auto val = reinterpret_cast<List *>(&m_list)->find(static_cast<BinaryData>(v));
         return val;
     }
-    size_t list::find(const obj_key& v) { return reinterpret_cast<List *>(m_list)->find(static_cast<ObjKey>(v)); }
+    size_t list::find(const obj_key& v) { return reinterpret_cast<List *>(&m_list)->find(static_cast<ObjKey>(v)); }
 
     notification_token list::add_notification_callback(std::shared_ptr<collection_change_callback> cb) {
         struct wrapper : CollectionChangeCallback {
@@ -201,6 +201,6 @@ namespace realm::internal::bridge {
                 m_cb->after(v);
             }
         } ccb(std::move(cb));
-        return reinterpret_cast<List*>(m_list)->add_notification_callback(ccb);
+        return reinterpret_cast<List*>(&m_list)->add_notification_callback(ccb);
     }
 }

--- a/src/cpprealm/internal/bridge/list.hpp
+++ b/src/cpprealm/internal/bridge/list.hpp
@@ -31,6 +31,11 @@ namespace realm::internal::bridge {
 
     struct list {
         list();
+        list(const list& other) ;
+        list& operator=(const list& other) ;
+        list(list&& other);
+        list& operator=(list&& other);
+        ~list();
         list(const List&); //NOLINT(google-explicit-constructor)
         operator List() const; //NOLINT(google-explicit-constructor)
         list(const realm& realm, const obj& obj, const col_key&);

--- a/src/cpprealm/internal/bridge/lnklst.cpp
+++ b/src/cpprealm/internal/bridge/lnklst.cpp
@@ -19,6 +19,36 @@ namespace realm::internal::bridge {
     static_assert(SizeCheck<160, sizeof(LnkLst)>{});
     static_assert(SizeCheck<8, alignof(LnkLst)>{});
 #endif
+    
+    lnklst::lnklst() {
+        new (&m_lnk_lst) LnkLst();
+    }
+    
+    lnklst::lnklst(const lnklst& other) {
+        new (&m_lnk_lst) LnkLst(*reinterpret_cast<const LnkLst*>(&other.m_lnk_lst));
+    }
+
+    lnklst& lnklst::operator=(const lnklst& other) {
+        if (this != &other) {
+            *reinterpret_cast<LnkLst*>(&m_lnk_lst) = *reinterpret_cast<const LnkLst*>(&other.m_lnk_lst);
+        }
+        return *this;
+    }
+
+    lnklst::lnklst(lnklst&& other) {
+        new (&m_lnk_lst) LnkLst(std::move(*reinterpret_cast<LnkLst*>(&other.m_lnk_lst)));
+    }
+
+    lnklst& lnklst::operator=(lnklst&& other) {
+        if (this != &other) {
+            *reinterpret_cast<LnkLst*>(&m_lnk_lst) = std::move(*reinterpret_cast<LnkLst*>(&other.m_lnk_lst));
+        }
+        return *this;
+    }
+
+    lnklst::~lnklst() {
+        reinterpret_cast<LnkLst*>(&m_lnk_lst)->~LnkLst();
+    }
 
     lnklst::lnklst(const LnkLst &v) {
         new (&m_lnk_lst) LnkLst(v);

--- a/src/cpprealm/internal/bridge/lnklst.cpp
+++ b/src/cpprealm/internal/bridge/lnklst.cpp
@@ -25,29 +25,29 @@ namespace realm::internal::bridge {
     }
     
     lnklst::lnklst(const lnklst& other) {
-        new (&m_lnk_lst) LnkLst(*reinterpret_cast<const LnkLst*>(other.m_lnk_lst));
+        new (&m_lnk_lst) LnkLst(*reinterpret_cast<const LnkLst*>(&other.m_lnk_lst));
     }
 
     lnklst& lnklst::operator=(const lnklst& other) {
         if (this != &other) {
-            *reinterpret_cast<LnkLst*>(&m_lnk_lst) = *reinterpret_cast<const LnkLst*>(other.m_lnk_lst);
+            *reinterpret_cast<LnkLst*>(&m_lnk_lst) = *reinterpret_cast<const LnkLst*>(&other.m_lnk_lst);
         }
         return *this;
     }
 
     lnklst::lnklst(lnklst&& other) {
-        new (&m_lnk_lst) LnkLst(std::move(*reinterpret_cast<LnkLst*>(other.m_lnk_lst)));
+        new (&m_lnk_lst) LnkLst(std::move(*reinterpret_cast<LnkLst*>(&other.m_lnk_lst)));
     }
 
     lnklst& lnklst::operator=(lnklst&& other) {
         if (this != &other) {
-            *reinterpret_cast<LnkLst*>(m_lnk_lst) = std::move(*reinterpret_cast<LnkLst*>(other.m_lnk_lst));
+            *reinterpret_cast<LnkLst*>(&m_lnk_lst) = std::move(*reinterpret_cast<LnkLst*>(&other.m_lnk_lst));
         }
         return *this;
     }
 
     lnklst::~lnklst() {
-        reinterpret_cast<LnkLst*>(m_lnk_lst)->~LnkLst();
+        reinterpret_cast<LnkLst*>(&m_lnk_lst)->~LnkLst();
     }
 
     lnklst::lnklst(const LnkLst &v) {
@@ -55,14 +55,14 @@ namespace realm::internal::bridge {
     }
 
     obj lnklst::create_and_insert_linked_object(size_t idx) {
-        return reinterpret_cast<LnkLst*>(m_lnk_lst)->create_and_insert_linked_object(idx);
+        return reinterpret_cast<LnkLst*>(&m_lnk_lst)->create_and_insert_linked_object(idx);
     }
 
     void lnklst::add(const obj_key &v) {
-        return reinterpret_cast<LnkLst*>(m_lnk_lst)->add(v);
+        return reinterpret_cast<LnkLst*>(&m_lnk_lst)->add(v);
     }
 
     lnklst::operator LnkLst() const {
-        return *reinterpret_cast<const LnkLst*>(m_lnk_lst);
+        return *reinterpret_cast<const LnkLst*>(&m_lnk_lst);
     }
 }

--- a/src/cpprealm/internal/bridge/lnklst.cpp
+++ b/src/cpprealm/internal/bridge/lnklst.cpp
@@ -25,29 +25,29 @@ namespace realm::internal::bridge {
     }
     
     lnklst::lnklst(const lnklst& other) {
-        new (&m_lnk_lst) LnkLst(*reinterpret_cast<const LnkLst*>(&other.m_lnk_lst));
+        new (&m_lnk_lst) LnkLst(*reinterpret_cast<const LnkLst*>(other.m_lnk_lst));
     }
 
     lnklst& lnklst::operator=(const lnklst& other) {
         if (this != &other) {
-            *reinterpret_cast<LnkLst*>(&m_lnk_lst) = *reinterpret_cast<const LnkLst*>(&other.m_lnk_lst);
+            *reinterpret_cast<LnkLst*>(&m_lnk_lst) = *reinterpret_cast<const LnkLst*>(other.m_lnk_lst);
         }
         return *this;
     }
 
     lnklst::lnklst(lnklst&& other) {
-        new (&m_lnk_lst) LnkLst(std::move(*reinterpret_cast<LnkLst*>(&other.m_lnk_lst)));
+        new (&m_lnk_lst) LnkLst(std::move(*reinterpret_cast<LnkLst*>(other.m_lnk_lst)));
     }
 
     lnklst& lnklst::operator=(lnklst&& other) {
         if (this != &other) {
-            *reinterpret_cast<LnkLst*>(&m_lnk_lst) = std::move(*reinterpret_cast<LnkLst*>(&other.m_lnk_lst));
+            *reinterpret_cast<LnkLst*>(m_lnk_lst) = std::move(*reinterpret_cast<LnkLst*>(other.m_lnk_lst));
         }
         return *this;
     }
 
     lnklst::~lnklst() {
-        reinterpret_cast<LnkLst*>(&m_lnk_lst)->~LnkLst();
+        reinterpret_cast<LnkLst*>(m_lnk_lst)->~LnkLst();
     }
 
     lnklst::lnklst(const LnkLst &v) {

--- a/src/cpprealm/internal/bridge/lnklst.hpp
+++ b/src/cpprealm/internal/bridge/lnklst.hpp
@@ -12,6 +12,12 @@ namespace realm::internal::bridge {
     struct obj_key;
 
     struct lnklst {
+        lnklst() ;
+        lnklst(const lnklst& other) ;
+        lnklst& operator=(const lnklst& other) ;
+        lnklst(lnklst&& other);
+        lnklst& operator=(lnklst&& other);
+        ~lnklst();
         lnklst(const LnkLst&); // NOLINT
         operator LnkLst() const; //NOLINT
         obj create_and_insert_linked_object(size_t idx);

--- a/src/cpprealm/internal/bridge/mixed.cpp
+++ b/src/cpprealm/internal/bridge/mixed.cpp
@@ -33,29 +33,41 @@ namespace realm::internal::bridge {
     }
 
     mixed::mixed(const mixed& other) {
-        new (&m_mixed) Mixed(*reinterpret_cast<const Mixed*>(other.m_mixed));
+        if (other.type() == data_type::String) {
+            m_owned_string = other.m_owned_string;
+        }
+        new (&m_mixed) Mixed(*reinterpret_cast<const Mixed*>(&other.m_mixed));
     }
 
     mixed& mixed::operator=(const mixed& other) {
         if (this != &other) {
-            *reinterpret_cast<Mixed*>(m_mixed) = *reinterpret_cast<const Mixed*>(other.m_mixed);
+            if (other.type() == data_type::String) {
+                m_owned_string = other.m_owned_string;
+            }
+            *reinterpret_cast<Mixed*>(&m_mixed) = *reinterpret_cast<const Mixed*>(&other.m_mixed);
         }
         return *this;
     }
 
     mixed::mixed(mixed&& other) {
-        new (&m_mixed) Mixed(std::move(*reinterpret_cast<Mixed*>(other.m_mixed)));
+        if (other.type() == data_type::String) {
+            m_owned_string = std::move(other.m_owned_string);
+        }
+        new (&m_mixed) Mixed(std::move(*reinterpret_cast<Mixed*>(&other.m_mixed)));
     }
 
     mixed& mixed::operator=(mixed&& other) {
         if (this != &other) {
-            *reinterpret_cast<Mixed*>(m_mixed) = std::move(*reinterpret_cast<Mixed*>(&other.m_mixed));
+            if (other.type() == data_type::String) {
+                m_owned_string = std::move(other.m_owned_string);
+            }
+            *reinterpret_cast<Mixed*>(&m_mixed) = std::move(*reinterpret_cast<Mixed*>(&other.m_mixed));
         }
         return *this;
     }
 
     mixed::~mixed() {
-        reinterpret_cast<Mixed*>(m_mixed)->~Mixed();
+        reinterpret_cast<Mixed*>(&m_mixed)->~Mixed();
     }
 
     mixed::mixed(const std::monostate&) {
@@ -130,37 +142,37 @@ namespace realm::internal::bridge {
         return m_owned_string;
     }
     mixed::operator bridge::binary() const {
-        return reinterpret_cast<const Mixed*>(m_mixed)->get_binary();
+        return reinterpret_cast<const Mixed*>(&m_mixed)->get_binary();
     }
     mixed::operator bridge::timestamp() const {
-        return reinterpret_cast<const Mixed*>(m_mixed)->get_timestamp();
+        return reinterpret_cast<const Mixed*>(&m_mixed)->get_timestamp();
     }
     mixed::operator bridge::obj_link() const {
-        return reinterpret_cast<const Mixed*>(m_mixed)->get<ObjLink>();
+        return reinterpret_cast<const Mixed*>(&m_mixed)->get<ObjLink>();
     }
     mixed::operator bridge::obj_key() const {
-        return reinterpret_cast<const Mixed*>(m_mixed)->get<ObjKey>();
+        return reinterpret_cast<const Mixed*>(&m_mixed)->get<ObjKey>();
     }
     mixed::operator bridge::uuid() const {
-        return static_cast<const uuid &>(reinterpret_cast<const Mixed *>(m_mixed)->get_uuid());
+        return static_cast<const uuid &>(reinterpret_cast<const Mixed *>(&m_mixed)->get_uuid());
     }
     mixed::operator bridge::object_id() const {
-        return static_cast<const object_id &>(reinterpret_cast<const Mixed *>(m_mixed)->get_object_id());
+        return static_cast<const object_id &>(reinterpret_cast<const Mixed *>(&m_mixed)->get_object_id());
     }
     mixed::operator int64_t() const {
-        return static_cast<const int64_t &>(reinterpret_cast<const Mixed *>(m_mixed)->get_int());
+        return static_cast<const int64_t &>(reinterpret_cast<const Mixed *>(&m_mixed)->get_int());
     }
     mixed::operator double() const {
-        return static_cast<const double &>(reinterpret_cast<const Mixed *>(m_mixed)->get_double());
+        return static_cast<const double &>(reinterpret_cast<const Mixed *>(&m_mixed)->get_double());
     }
     mixed::operator bool() const {
-        return static_cast<const bool &>(reinterpret_cast<const Mixed *>(m_mixed)->get_bool());
+        return static_cast<const bool &>(reinterpret_cast<const Mixed *>(&m_mixed)->get_bool());
     }
     data_type mixed::type() const noexcept {
-        return data_type(static_cast<int>(reinterpret_cast<const Mixed *>(m_mixed)->get_type()));
+        return data_type(static_cast<int>(reinterpret_cast<const Mixed *>(&m_mixed)->get_type()));
     }
     bool mixed::is_null() const noexcept {
-        return reinterpret_cast<const Mixed *>(m_mixed)->is_null();
+        return reinterpret_cast<const Mixed *>(&m_mixed)->is_null();
     }
 #define __cpp_realm_gen_mixed_op(op) \
     bool operator op(const mixed& a, const mixed& b) { \

--- a/src/cpprealm/internal/bridge/mixed.cpp
+++ b/src/cpprealm/internal/bridge/mixed.cpp
@@ -26,36 +26,36 @@ namespace realm::internal::bridge {
         } else { \
             new (&m_mixed) Mixed(realm::none); \
         } \
-    } \
-    
+    }                                 \
+
     mixed::mixed() {
         new (&m_mixed) Mixed();
     }
-    
+
     mixed::mixed(const mixed& other) {
-        new (&m_mixed) Mixed(*reinterpret_cast<const Mixed*>(&other.m_mixed));
+        new (&m_mixed) Mixed(*reinterpret_cast<const Mixed*>(other.m_mixed));
     }
 
     mixed& mixed::operator=(const mixed& other) {
         if (this != &other) {
-            *reinterpret_cast<Mixed*>(&m_mixed) = *reinterpret_cast<const Mixed*>(&other.m_mixed);
+            *reinterpret_cast<Mixed*>(m_mixed) = *reinterpret_cast<const Mixed*>(other.m_mixed);
         }
         return *this;
     }
 
     mixed::mixed(mixed&& other) {
-        new (&m_mixed) Mixed(std::move(*reinterpret_cast<Mixed*>(&other.m_mixed)));
+        new (&m_mixed) Mixed(std::move(*reinterpret_cast<Mixed*>(other.m_mixed)));
     }
 
     mixed& mixed::operator=(mixed&& other) {
         if (this != &other) {
-            *reinterpret_cast<Mixed*>(&m_mixed) = std::move(*reinterpret_cast<Mixed*>(&other.m_mixed));
+            *reinterpret_cast<Mixed*>(m_mixed) = std::move(*reinterpret_cast<Mixed*>(&other.m_mixed));
         }
         return *this;
     }
 
     mixed::~mixed() {
-        reinterpret_cast<Mixed*>(&m_mixed)->~Mixed();
+        reinterpret_cast<Mixed*>(m_mixed)->~Mixed();
     }
 
     mixed::mixed(const std::monostate&) {

--- a/src/cpprealm/internal/bridge/mixed.cpp
+++ b/src/cpprealm/internal/bridge/mixed.cpp
@@ -27,6 +27,36 @@ namespace realm::internal::bridge {
             new (&m_mixed) Mixed(realm::none); \
         } \
     } \
+    
+    mixed::mixed() {
+        new (&m_mixed) Mixed();
+    }
+    
+    mixed::mixed(const mixed& other) {
+        new (&m_mixed) Mixed(*reinterpret_cast<const Mixed*>(&other.m_mixed));
+    }
+
+    mixed& mixed::operator=(const mixed& other) {
+        if (this != &other) {
+            *reinterpret_cast<Mixed*>(&m_mixed) = *reinterpret_cast<const Mixed*>(&other.m_mixed);
+        }
+        return *this;
+    }
+
+    mixed::mixed(mixed&& other) {
+        new (&m_mixed) Mixed(std::move(*reinterpret_cast<Mixed*>(&other.m_mixed)));
+    }
+
+    mixed& mixed::operator=(mixed&& other) {
+        if (this != &other) {
+            *reinterpret_cast<Mixed*>(&m_mixed) = std::move(*reinterpret_cast<Mixed*>(&other.m_mixed));
+        }
+        return *this;
+    }
+
+    mixed::~mixed() {
+        reinterpret_cast<Mixed*>(&m_mixed)->~Mixed();
+    }
 
     mixed::mixed(const std::monostate&) {
         new (&m_mixed) Mixed(std::nullopt);

--- a/src/cpprealm/internal/bridge/mixed.hpp
+++ b/src/cpprealm/internal/bridge/mixed.hpp
@@ -51,6 +51,13 @@ namespace realm::internal::bridge {
     };
 
     struct mixed {
+        mixed();
+        mixed(const mixed& other) ;
+        mixed& operator=(const mixed& other) ;
+        mixed(mixed&& other);
+        mixed& operator=(mixed&& other);
+        ~mixed();
+
         explicit mixed(const std::string&);
         mixed(const std::monostate&); //NOLINT(google-explicit-constructor)
         mixed(const int&); //NOLINT(google-explicit-constructor)
@@ -63,7 +70,6 @@ namespace realm::internal::bridge {
         mixed(const struct obj_link&); //NOLINT(google-explicit-constructor)
         mixed(const struct obj_key&); //NOLINT(google-explicit-constructor)
         mixed(const struct binary&); //NOLINT(google-explicit-constructor)
-        mixed(const mixed&) = default;
         mixed(const Mixed&); //NOLINT(google-explicit-constructor)
         template<typename T>
         mixed(const std::optional<T>& o);  //NOLINT(google-explicit-constructor)

--- a/src/cpprealm/internal/bridge/obj.cpp
+++ b/src/cpprealm/internal/bridge/obj.cpp
@@ -25,6 +25,36 @@ namespace realm::internal::bridge {
     static_assert(SizeCheck<64, sizeof(Obj)>{});
     static_assert(SizeCheck<8, alignof(Obj)>{});
 #endif
+    
+    obj::obj() {
+        new (&m_obj) Obj();
+    }
+    
+    obj::obj(const obj& other) {
+        new (&m_obj) Obj(*reinterpret_cast<const Obj*>(&other.m_obj));
+    }
+
+    obj& obj::operator=(const obj& other) {
+        if (this != &other) {
+            *reinterpret_cast<Obj*>(&m_obj) = *reinterpret_cast<const Obj*>(&other.m_obj);
+        }
+        return *this;
+    }
+
+    obj::obj(obj&& other) {
+        new (&m_obj) Obj(std::move(*reinterpret_cast<Obj*>(&other.m_obj)));
+    }
+
+    obj& obj::operator=(obj&& other) {
+        if (this != &other) {
+            *reinterpret_cast<Obj*>(&m_obj) = std::move(*reinterpret_cast<Obj*>(&other.m_obj));
+        }
+        return *this;
+    }
+
+    obj::~obj() {
+        reinterpret_cast<Obj*>(&m_obj)->~Obj();
+    }
 
     group::group(realm& val)
     : m_realm(val)

--- a/src/cpprealm/internal/bridge/obj.cpp
+++ b/src/cpprealm/internal/bridge/obj.cpp
@@ -31,29 +31,29 @@ namespace realm::internal::bridge {
     }
     
     obj::obj(const obj& other) {
-        new (&m_obj) Obj(*reinterpret_cast<const Obj*>(other.m_obj));
+        new (&m_obj) Obj(*reinterpret_cast<const Obj*>(&other.m_obj));
     }
 
     obj& obj::operator=(const obj& other) {
         if (this != &other) {
-            *reinterpret_cast<Obj*>(m_obj) = *reinterpret_cast<const Obj*>(other.m_obj);
+            *reinterpret_cast<Obj*>(&m_obj) = *reinterpret_cast<const Obj*>(&other.m_obj);
         }
         return *this;
     }
 
     obj::obj(obj&& other) {
-        new (&m_obj) Obj(std::move(*reinterpret_cast<Obj*>(other.m_obj)));
+        new (&m_obj) Obj(std::move(*reinterpret_cast<Obj*>(&other.m_obj)));
     }
 
     obj& obj::operator=(obj&& other) {
         if (this != &other) {
-            *reinterpret_cast<Obj*>(m_obj) = std::move(*reinterpret_cast<Obj*>(other.m_obj));
+            *reinterpret_cast<Obj*>(&m_obj) = std::move(*reinterpret_cast<Obj*>(&other.m_obj));
         }
         return *this;
     }
 
     obj::~obj() {
-        reinterpret_cast<Obj*>(m_obj)->~Obj();
+        reinterpret_cast<Obj*>(&m_obj)->~Obj();
     }
 
     group::group(realm& val)
@@ -70,106 +70,106 @@ namespace realm::internal::bridge {
     }
 
     obj::operator Obj() const {
-        return *reinterpret_cast<const Obj*>(m_obj);
+        return *reinterpret_cast<const Obj*>(&m_obj);
     }
 
     obj_key obj::get_key() const {
-        return reinterpret_cast<const Obj*>(m_obj)->get_key();
+        return reinterpret_cast<const Obj*>(&m_obj)->get_key();
     }
     obj_link obj::get_link() const {
-        return reinterpret_cast<const Obj*>(m_obj)->get_link();
+        return reinterpret_cast<const Obj*>(&m_obj)->get_link();
     }
     table obj::get_table() const noexcept {
-        return reinterpret_cast<const Obj*>(m_obj)->get_table();
+        return reinterpret_cast<const Obj*>(&m_obj)->get_table();
     }
     table obj::get_target_table(col_key key) const noexcept {
-        return reinterpret_cast<const Obj*>(m_obj)->get_target_table(key);
+        return reinterpret_cast<const Obj*>(&m_obj)->get_target_table(key);
     }
     obj obj::get_linked_object(const col_key &col_key) {
-        return reinterpret_cast<Obj*>(m_obj)->get_linked_object(col_key);
+        return reinterpret_cast<Obj*>(&m_obj)->get_linked_object(col_key);
     }
     bool obj::is_null(const col_key &col_key) const {
-        return reinterpret_cast<const Obj*>(m_obj)->is_null(col_key);
+        return reinterpret_cast<const Obj*>(&m_obj)->is_null(col_key);
     }
     bool obj::is_valid() const {
-        return reinterpret_cast<const Obj*>(m_obj)->is_valid();
+        return reinterpret_cast<const Obj*>(&m_obj)->is_valid();
     }
     template <>
     std::string get(const obj& o, const col_key& col_key) {
-        return reinterpret_cast<const Obj*>(o.m_obj)->get<StringData>(col_key);
+        return reinterpret_cast<const Obj*>(&o.m_obj)->get<StringData>(col_key);
     }
     template <>
     int64_t get(const obj& o, const col_key& col_key) {
-        return reinterpret_cast<const Obj*>(o.m_obj)->get<Int>(col_key);
+        return reinterpret_cast<const Obj*>(&o.m_obj)->get<Int>(col_key);
     }
     template <>
     double get(const obj& o, const col_key& col_key) {
-        return reinterpret_cast<const Obj*>(o.m_obj)->get<Double>(col_key);
+        return reinterpret_cast<const Obj*>(&o.m_obj)->get<Double>(col_key);
     }
     template <>
     bool get(const obj& o, const col_key& col_key) {
-        return reinterpret_cast<const Obj*>(o.m_obj)->get<bool>(col_key);
+        return reinterpret_cast<const Obj*>(&o.m_obj)->get<bool>(col_key);
     }
     template <>
     binary get(const obj& o, const col_key& col_key) {
-        return reinterpret_cast<const Obj*>(o.m_obj)->get<BinaryData>(col_key);
+        return reinterpret_cast<const Obj*>(&o.m_obj)->get<BinaryData>(col_key);
     }
     template <>
     uuid get(const obj& o, const col_key& col_key) {
-        return reinterpret_cast<const Obj*>(o.m_obj)->get<UUID>(col_key);
+        return reinterpret_cast<const Obj*>(&o.m_obj)->get<UUID>(col_key);
     }
     template <>
     object_id get(const obj& o, const col_key& col_key) {
-        return reinterpret_cast<const Obj*>(o.m_obj)->get<ObjectId>(col_key);
+        return reinterpret_cast<const Obj*>(&o.m_obj)->get<ObjectId>(col_key);
     }
     template <>
     mixed get(const obj& o, const col_key& col_key) {
-        return reinterpret_cast<const Obj*>(o.m_obj)->get_any(col_key);
+        return reinterpret_cast<const Obj*>(&o.m_obj)->get_any(col_key);
     }
     template <>
     timestamp get(const obj& o, const col_key& col_key) {
-        return reinterpret_cast<const Obj*>(o.m_obj)->get<Timestamp>(col_key);
+        return reinterpret_cast<const Obj*>(&o.m_obj)->get<Timestamp>(col_key);
     }
     void obj::set(const col_key &col_key, const std::string &value) {
-        reinterpret_cast<Obj*>(m_obj)->set<StringData>(col_key, value);
+        reinterpret_cast<Obj*>(&m_obj)->set<StringData>(col_key, value);
     }
     void obj::set(const col_key &col_key, const binary &value) {
-        reinterpret_cast<Obj*>(m_obj)->set<BinaryData>(col_key, value);
+        reinterpret_cast<Obj*>(&m_obj)->set<BinaryData>(col_key, value);
     }
     void obj::set(const col_key &col_key, const int64_t &value) {
-        reinterpret_cast<Obj*>(m_obj)->set<Int>(col_key, value);
+        reinterpret_cast<Obj*>(&m_obj)->set<Int>(col_key, value);
     }
     void obj::set(const col_key &col_key, const bool &value) {
-        reinterpret_cast<Obj*>(m_obj)->set<Bool>(col_key, value);
+        reinterpret_cast<Obj*>(&m_obj)->set<Bool>(col_key, value);
     }
     void obj::set(const col_key &col_key, const double &value) {
-        reinterpret_cast<Obj*>(m_obj)->set<Double>(col_key, value);
+        reinterpret_cast<Obj*>(&m_obj)->set<Double>(col_key, value);
     }
     void obj::set(const col_key &col_key, const internal::bridge::uuid &value) {
-        reinterpret_cast<Obj*>(m_obj)->set<UUID>(col_key, value);
+        reinterpret_cast<Obj*>(&m_obj)->set<UUID>(col_key, value);
     }
     void obj::set(const col_key &col_key, const internal::bridge::object_id &value) {
-        reinterpret_cast<Obj*>(m_obj)->set<ObjectId>(col_key, value);
+        reinterpret_cast<Obj*>(&m_obj)->set<ObjectId>(col_key, value);
     }
     void obj::set(const col_key &col_key, const obj_key &value) {
-        reinterpret_cast<Obj*>(m_obj)->set<ObjKey>(col_key, value);
+        reinterpret_cast<Obj*>(&m_obj)->set<ObjKey>(col_key, value);
     }
     void obj::set(const col_key &col_key, const mixed &value) {
         if (value.is_null()) {
-            reinterpret_cast<Obj*>(m_obj)->set(col_key, Mixed());
+            reinterpret_cast<Obj*>(&m_obj)->set(col_key, Mixed());
         } else if (value.type() == data_type::Link) {
-            reinterpret_cast<Obj *>(m_obj)->set(col_key,
-                                                Mixed(ObjLink(reinterpret_cast<Obj *>(m_obj)->get_table()->get_key(),
+            reinterpret_cast<Obj *>(&m_obj)->set(col_key,
+                                                Mixed(ObjLink(reinterpret_cast<Obj *>(&m_obj)->get_table()->get_key(),
                                                               value.operator bridge::obj_key())));
         } else {
-            reinterpret_cast<Obj*>(m_obj)->set(col_key, static_cast<Mixed>(value));
+            reinterpret_cast<Obj*>(&m_obj)->set(col_key, static_cast<Mixed>(value));
         }
     }
     void obj::set(const col_key &col_key, const timestamp &value) {
-        reinterpret_cast<Obj*>(m_obj)->set<Timestamp>(col_key, value);
+        reinterpret_cast<Obj*>(&m_obj)->set<Timestamp>(col_key, value);
     }
     lnklst obj::get_linklist(const col_key &col_key) {
-        return reinterpret_cast<Obj*>(m_obj)->get_linklist(col_key);
+        return reinterpret_cast<Obj*>(&m_obj)->get_linklist(col_key);
     }
 
     void obj::set_list_values(const col_key &col_key, const std::vector<obj_key> &values) {
@@ -177,62 +177,62 @@ namespace realm::internal::bridge {
         for (auto& v2 : values) {
             v.push_back(v2);
         }
-        reinterpret_cast<Obj*>(m_obj)->set_list_values(col_key, v);
+        reinterpret_cast<Obj*>(&m_obj)->set_list_values(col_key, v);
     }
     void obj::set_list_values(const col_key &col_key, const std::vector<bool> &values) {
-        reinterpret_cast<Obj*>(m_obj)->set_list_values(col_key, values);
+        reinterpret_cast<Obj*>(&m_obj)->set_list_values(col_key, values);
     }
     void obj::set_list_values(const col_key &col_key, const std::vector<int64_t> &values) {
-        reinterpret_cast<Obj*>(m_obj)->set_list_values(col_key, values);
+        reinterpret_cast<Obj*>(&m_obj)->set_list_values(col_key, values);
     }
     void obj::set_list_values(const col_key &col_key, const std::vector<double> &values) {
-        reinterpret_cast<Obj*>(m_obj)->set_list_values(col_key, values);
+        reinterpret_cast<Obj*>(&m_obj)->set_list_values(col_key, values);
     }
     void obj::set_list_values(const col_key &col_key, const std::vector<internal::bridge::uuid> &values) {
         std::vector<UUID> v;
         for (auto& v2 : values) {
             v.push_back(v2);
         }
-        reinterpret_cast<Obj*>(m_obj)->set_list_values(col_key, v);
+        reinterpret_cast<Obj*>(&m_obj)->set_list_values(col_key, v);
     }
     void obj::set_list_values(const col_key &col_key, const std::vector<internal::bridge::object_id> &values) {
         std::vector<ObjectId> v;
         for (auto& v2 : values) {
             v.push_back(v2);
         }
-        reinterpret_cast<Obj*>(m_obj)->set_list_values(col_key, v);
+        reinterpret_cast<Obj*>(&m_obj)->set_list_values(col_key, v);
     }
     void obj::set_list_values(const col_key &col_key, const std::vector<binary> &values) {
         std::vector<BinaryData> v;
         for (auto& v2 : values) {
             v.push_back(v2);
         }
-        reinterpret_cast<Obj*>(m_obj)->set_list_values(col_key, v);
+        reinterpret_cast<Obj*>(&m_obj)->set_list_values(col_key, v);
     }
     void obj::set_list_values(const col_key &col_key, const std::vector<std::string> &values) {
         std::vector<StringData> v;
         for (auto& v2 : values) {
             v.emplace_back(v2);
         }
-        reinterpret_cast<Obj*>(m_obj)->set_list_values(col_key, v);
+        reinterpret_cast<Obj*>(&m_obj)->set_list_values(col_key, v);
     }
     void obj::set_list_values(const col_key &col_key, const std::vector<timestamp> &values) {
         std::vector<Timestamp> v;
         for (auto& v2 : values) {
             v.emplace_back(v2);
         }
-        reinterpret_cast<Obj*>(m_obj)->set_list_values(col_key, v);
+        reinterpret_cast<Obj*>(&m_obj)->set_list_values(col_key, v);
     }
     void obj::set_list_values(const col_key &col_key, const std::vector<mixed> &values) {
         std::vector<Mixed> v;
         for (auto& v2 : values) {
             v.emplace_back(v2);
         }
-        reinterpret_cast<Obj*>(m_obj)->set_list_values(col_key, v);
+        reinterpret_cast<Obj*>(&m_obj)->set_list_values(col_key, v);
     }
 
     void obj::set_null(const col_key &v) {
-        reinterpret_cast<Obj*>(m_obj)->set_null(v);
+        reinterpret_cast<Obj*>(&m_obj)->set_null(v);
     }
 
     table group::get_table(const std::string &table_key) {
@@ -243,7 +243,7 @@ namespace realm::internal::bridge {
     }
 
     obj obj::create_and_set_linked_object(const col_key &v) {
-        return reinterpret_cast<Obj*>(m_obj)->create_and_set_linked_object(v);
+        return reinterpret_cast<Obj*>(&m_obj)->create_and_set_linked_object(v);
     }
 }
 

--- a/src/cpprealm/internal/bridge/obj.cpp
+++ b/src/cpprealm/internal/bridge/obj.cpp
@@ -31,29 +31,29 @@ namespace realm::internal::bridge {
     }
     
     obj::obj(const obj& other) {
-        new (&m_obj) Obj(*reinterpret_cast<const Obj*>(&other.m_obj));
+        new (&m_obj) Obj(*reinterpret_cast<const Obj*>(other.m_obj));
     }
 
     obj& obj::operator=(const obj& other) {
         if (this != &other) {
-            *reinterpret_cast<Obj*>(&m_obj) = *reinterpret_cast<const Obj*>(&other.m_obj);
+            *reinterpret_cast<Obj*>(m_obj) = *reinterpret_cast<const Obj*>(other.m_obj);
         }
         return *this;
     }
 
     obj::obj(obj&& other) {
-        new (&m_obj) Obj(std::move(*reinterpret_cast<Obj*>(&other.m_obj)));
+        new (&m_obj) Obj(std::move(*reinterpret_cast<Obj*>(other.m_obj)));
     }
 
     obj& obj::operator=(obj&& other) {
         if (this != &other) {
-            *reinterpret_cast<Obj*>(&m_obj) = std::move(*reinterpret_cast<Obj*>(&other.m_obj));
+            *reinterpret_cast<Obj*>(m_obj) = std::move(*reinterpret_cast<Obj*>(other.m_obj));
         }
         return *this;
     }
 
     obj::~obj() {
-        reinterpret_cast<Obj*>(&m_obj)->~Obj();
+        reinterpret_cast<Obj*>(m_obj)->~Obj();
     }
 
     group::group(realm& val)

--- a/src/cpprealm/internal/bridge/obj.hpp
+++ b/src/cpprealm/internal/bridge/obj.hpp
@@ -93,6 +93,12 @@ namespace realm::internal::bridge {
     [[nodiscard]] mixed get(const obj&, const col_key& col_key);
 
     struct obj {
+        obj();
+        obj(const obj& other) ;
+        obj& operator=(const obj& other) ;
+        obj(obj&& other);
+        obj& operator=(obj&& other);
+        ~obj();
         obj(const Obj&); //NOLINT google-explicit-constructor
         operator Obj() const; //NOLINT google-explicit-constructor
         [[nodiscard]] table get_table() const noexcept;

--- a/src/cpprealm/internal/bridge/obj_key.cpp
+++ b/src/cpprealm/internal/bridge/obj_key.cpp
@@ -47,9 +47,6 @@ namespace realm::internal::bridge {
     obj_key::~obj_key() {
         reinterpret_cast<ObjKey*>(&m_obj_key)->~ObjKey();
     }
-    obj_key::obj_key() {
-        new (&m_obj_key) ObjKey();
-    }
 
     obj_key::obj_key(int64_t v) {
         new (&m_obj_key) ObjKey(v);
@@ -84,7 +81,33 @@ namespace realm::internal::bridge {
     obj_link::obj_link() {
         new (&m_obj_link) ObjLink();
     }
+    
+    obj_link::obj_link(const obj_link& other) {
+        new (&m_obj_link) ObjLink(*reinterpret_cast<const ObjLink*>(other.m_obj_link));
+    }
 
+    obj_link& obj_link::operator=(const obj_link& other) {
+        if (this != &other) {
+            *reinterpret_cast<ObjLink*>(m_obj_link) = *reinterpret_cast<const ObjLink*>(other.m_obj_link);
+        }
+        return *this;
+    }
+
+    obj_link::obj_link(obj_link&& other) {
+        new (&m_obj_link) ObjLink(std::move(*reinterpret_cast<ObjLink*>(other.m_obj_link)));
+    }
+
+    obj_link& obj_link::operator=(obj_link&& other) {
+        if (this != &other) {
+            *reinterpret_cast<ObjLink*>(m_obj_link) = std::move(*reinterpret_cast<ObjLink*>(other.m_obj_link));
+        }
+        return *this;
+    }
+
+    obj_link::~obj_link() {
+        reinterpret_cast<ObjLink*>(m_obj_link)->~ObjLink();
+    }
+    
     obj_link::obj_link(const ObjLink& v) {
         new (&m_obj_link) ObjLink(v);
     }

--- a/src/cpprealm/internal/bridge/obj_key.cpp
+++ b/src/cpprealm/internal/bridge/obj_key.cpp
@@ -22,6 +22,35 @@ namespace realm::internal::bridge {
         new (&m_obj_key) ObjKey();
     }
 
+    obj_key::obj_key(const obj_key& other) {
+        new (&m_obj_key) ObjKey(*reinterpret_cast<const ObjKey*>(&other.m_obj_key));
+    }
+
+    obj_key& obj_key::operator=(const obj_key& other) {
+        if (this != &other) {
+            *reinterpret_cast<ObjKey*>(&m_obj_key) = *reinterpret_cast<const ObjKey*>(&other.m_obj_key);
+        }
+        return *this;
+    }
+
+    obj_key::obj_key(obj_key&& other) {
+        new (&m_obj_key) ObjKey(std::move(*reinterpret_cast<ObjKey*>(&other.m_obj_key)));
+    }
+
+    obj_key& obj_key::operator=(obj_key&& other) {
+        if (this != &other) {
+            *reinterpret_cast<ObjKey*>(&m_obj_key) = std::move(*reinterpret_cast<ObjKey*>(&other.m_obj_key));
+        }
+        return *this;
+    }
+
+    obj_key::~obj_key() {
+        reinterpret_cast<ObjKey*>(&m_obj_key)->~ObjKey();
+    }
+    obj_key::obj_key() {
+        new (&m_obj_key) ObjKey();
+    }
+
     obj_key::obj_key(int64_t v) {
         new (&m_obj_key) ObjKey(v);
     }

--- a/src/cpprealm/internal/bridge/obj_key.cpp
+++ b/src/cpprealm/internal/bridge/obj_key.cpp
@@ -57,7 +57,7 @@ namespace realm::internal::bridge {
     }
 
     obj_key::operator ObjKey() const {
-        return *reinterpret_cast<const ObjKey*>(m_obj_key);
+        return *reinterpret_cast<const ObjKey*>(&m_obj_key);
     }
 
     bool operator==(obj_key const& lhs, obj_key const& rhs) {
@@ -83,29 +83,29 @@ namespace realm::internal::bridge {
     }
     
     obj_link::obj_link(const obj_link& other) {
-        new (&m_obj_link) ObjLink(*reinterpret_cast<const ObjLink*>(other.m_obj_link));
+        new (&m_obj_link) ObjLink(*reinterpret_cast<const ObjLink*>(&other.m_obj_link));
     }
 
     obj_link& obj_link::operator=(const obj_link& other) {
         if (this != &other) {
-            *reinterpret_cast<ObjLink*>(m_obj_link) = *reinterpret_cast<const ObjLink*>(other.m_obj_link);
+            *reinterpret_cast<ObjLink*>(&m_obj_link) = *reinterpret_cast<const ObjLink*>(&other.m_obj_link);
         }
         return *this;
     }
 
     obj_link::obj_link(obj_link&& other) {
-        new (&m_obj_link) ObjLink(std::move(*reinterpret_cast<ObjLink*>(other.m_obj_link)));
+        new (&m_obj_link) ObjLink(std::move(*reinterpret_cast<ObjLink*>(&other.m_obj_link)));
     }
 
     obj_link& obj_link::operator=(obj_link&& other) {
         if (this != &other) {
-            *reinterpret_cast<ObjLink*>(m_obj_link) = std::move(*reinterpret_cast<ObjLink*>(other.m_obj_link));
+            *reinterpret_cast<ObjLink*>(&m_obj_link) = std::move(*reinterpret_cast<ObjLink*>(&other.m_obj_link));
         }
         return *this;
     }
 
     obj_link::~obj_link() {
-        reinterpret_cast<ObjLink*>(m_obj_link)->~ObjLink();
+        reinterpret_cast<ObjLink*>(&m_obj_link)->~ObjLink();
     }
     
     obj_link::obj_link(const ObjLink& v) {
@@ -113,11 +113,11 @@ namespace realm::internal::bridge {
     }
 
     obj_link::operator ObjLink() const {
-        return *reinterpret_cast<const ObjLink*>(m_obj_link);
+        return *reinterpret_cast<const ObjLink*>(&m_obj_link);
     }
 
     obj_key obj_link::get_obj_key() {
-        return reinterpret_cast<const ObjLink*>(m_obj_link)->get_obj_key();
+        return reinterpret_cast<const ObjLink*>(&m_obj_link)->get_obj_key();
     }
 
     bool operator==(obj_link const& lhs, obj_link const& rhs) {

--- a/src/cpprealm/internal/bridge/obj_key.hpp
+++ b/src/cpprealm/internal/bridge/obj_key.hpp
@@ -13,6 +13,11 @@ namespace realm::internal::bridge {
         obj_key(const ObjKey&);
         obj_key(int64_t);
         obj_key();
+        obj_key(const obj_key& other) ;
+        obj_key& operator=(const obj_key& other) ;
+        obj_key(obj_key&& other);
+        obj_key& operator=(obj_key&& other);
+        ~obj_key();
         operator ObjKey() const;
     private:
 #ifdef __i386__
@@ -35,6 +40,11 @@ namespace realm::internal::bridge {
     struct obj_link {
         obj_link(const ObjLink&);
         obj_link();
+        obj_link(const obj_link& other) ;
+        obj_link& operator=(const obj_link& other) ;
+        obj_link(obj_link&& other);
+        obj_link& operator=(obj_link&& other);
+        ~obj_link();
         operator ObjLink() const;
         obj_key get_obj_key();
     private:

--- a/src/cpprealm/internal/bridge/object.cpp
+++ b/src/cpprealm/internal/bridge/object.cpp
@@ -81,29 +81,29 @@ namespace realm::internal::bridge {
     }
 
     object::object(const object& other) {
-        new (&m_object) Object(* reinterpret_cast<const Object*>(other.m_object));
+        new (&m_object) Object(* reinterpret_cast<const Object*>(&other.m_object));
     }
 
     object& object::operator=(const object& other) {
         if (this != &other) {
-            *reinterpret_cast<Object*>(m_object) = *reinterpret_cast<const Object*>(other.m_object);
+            *reinterpret_cast<Object*>(&m_object) = *reinterpret_cast<const Object*>(&other.m_object);
         }
         return *this;
     }
 
     object::object(object&& other) {
-        new (&m_object) Object(std::move(*reinterpret_cast<Object*>(other.m_object)));
+        new (&m_object) Object(std::move(*reinterpret_cast<Object*>(&other.m_object)));
     }
 
     object& object::operator=(object&& other) {
         if (this != &other) {
-            *reinterpret_cast<Object*>(m_object) = std::move(*reinterpret_cast<Object*>(other.m_object));
+            *reinterpret_cast<Object*>(&m_object) = std::move(*reinterpret_cast<Object*>(&other.m_object));
         }
         return *this;
     }
 
     object::~object() {
-        reinterpret_cast<Object*>(m_object)->~Object();
+        reinterpret_cast<Object*>(&m_object)->~Object();
     }
 
     object::object(const Object &v) {
@@ -116,7 +116,7 @@ namespace realm::internal::bridge {
         new (&m_object) Object(realm, link);
     }
     obj object::get_obj() const {
-        return reinterpret_cast<const Object*>(m_object)->obj();
+        return reinterpret_cast<const Object*>(&m_object)->obj();
     }
     list object::get_list(const col_key& col_key) const {
         return List(get_realm(), get_obj(), col_key);
@@ -125,16 +125,16 @@ namespace realm::internal::bridge {
         return Dictionary(get_realm(), get_obj(), v);
     }
     bool object::is_valid() const {
-        return reinterpret_cast<const Object*>(m_object)->is_valid();
+        return reinterpret_cast<const Object*>(&m_object)->is_valid();
     }
     realm object::get_realm() const {
-        return reinterpret_cast<const Object*>(m_object)->get_realm();
+        return reinterpret_cast<const Object*>(&m_object)->get_realm();
     }
     object_schema object::get_object_schema() const {
-        return reinterpret_cast<const Object*>(m_object)->get_object_schema();
+        return reinterpret_cast<const Object*>(&m_object)->get_object_schema();
     }
     object::operator Object() const {
-        return *reinterpret_cast<const Object*>(m_object);
+        return *reinterpret_cast<const Object*>(&m_object);
     }
     notification_token object::add_notification_callback(std::shared_ptr<collection_change_callback>&& cb) {
         struct wrapper : CollectionChangeCallback {
@@ -148,32 +148,57 @@ namespace realm::internal::bridge {
                 m_cb->after(v);
             }
         } ccb(std::move(cb));
-        return reinterpret_cast<Object*>(m_object)->add_notification_callback(ccb);
+        return reinterpret_cast<Object*>(&m_object)->add_notification_callback(ccb);
     }
 
     bool index_set::empty() const {
-        return reinterpret_cast<const IndexSet*>(m_idx_set)->empty();
+        return reinterpret_cast<const IndexSet*>(&m_idx_set)->empty();
     }
     index_set::index_set() {
         new (&m_idx_set) IndexSet();
+    }
+    index_set::index_set(const index_set& other) {
+        new (&m_idx_set) IndexSet(*reinterpret_cast<const IndexSet*>(&other.m_idx_set));
+    }
+
+    index_set& index_set::operator=(const index_set& other) {
+        if (this != &other) {
+            *reinterpret_cast<IndexSet*>(&m_idx_set) = *reinterpret_cast<const IndexSet*>(&other.m_idx_set);
+        }
+        return *this;
+    }
+
+    index_set::index_set(index_set&& other) {
+        new (&m_idx_set) IndexSet(std::move(*reinterpret_cast<IndexSet*>(&other.m_idx_set)));
+    }
+
+    index_set& index_set::operator=(index_set&& other) {
+        if (this != &other) {
+            *reinterpret_cast<IndexSet*>(&m_idx_set) = std::move(*reinterpret_cast<IndexSet*>(&other.m_idx_set));
+        }
+        return *this;
+    }
+
+    index_set::~index_set() {
+        reinterpret_cast<IndexSet*>(&m_idx_set)->~IndexSet();
     }
     index_set::index_set(const IndexSet& v) {
         new (&m_idx_set) IndexSet(v);
     }
     bool collection_change_set::empty() const {
-        return reinterpret_cast<const CollectionChangeSet *>(m_change_set)->empty();
+        return reinterpret_cast<const CollectionChangeSet *>(&m_change_set)->empty();
     }
 
     collection_change_set::operator CollectionChangeSet() const {
-        return *reinterpret_cast<const CollectionChangeSet *>(m_change_set);
+        return *reinterpret_cast<const CollectionChangeSet *>(&m_change_set);
     }
 
     index_set collection_change_set::modifications() const {
-        return reinterpret_cast<const CollectionChangeSet *>(m_change_set)->modifications;
+        return reinterpret_cast<const CollectionChangeSet *>(&m_change_set)->modifications;
     }
 
     std::unordered_map<int64_t, index_set> collection_change_set::columns() const {
-        auto& columns = reinterpret_cast<const CollectionChangeSet *>(m_change_set)->columns;
+        auto& columns = reinterpret_cast<const CollectionChangeSet *>(&m_change_set)->columns;
         std::unordered_map<int64_t, index_set> map;
         for (const auto &[k, v]: columns) {
             map[k] = v;
@@ -182,7 +207,7 @@ namespace realm::internal::bridge {
     }
 
     index_set collection_change_set::deletions() const {
-        return reinterpret_cast<const CollectionChangeSet *>(m_change_set)->deletions;
+        return reinterpret_cast<const CollectionChangeSet *>(&m_change_set)->deletions;
     }
 
     notification_token::notification_token() {
@@ -193,57 +218,139 @@ namespace realm::internal::bridge {
         new (&m_token) NotificationToken(std::move(v));
     }
     void notification_token::unregister() {
-        reinterpret_cast<NotificationToken *>(m_token)->unregister();
+        reinterpret_cast<NotificationToken *>(&m_token)->unregister();
+    }
+
+    collection_change_set::collection_change_set() {
+        new (&m_change_set) CollectionChangeSet();
+    }
+
+    collection_change_set::collection_change_set(const collection_change_set& other) {
+        new (&m_change_set) CollectionChangeSet(* reinterpret_cast<const CollectionChangeSet*>(&other.m_change_set));
+    }
+
+    collection_change_set& collection_change_set::operator=(const collection_change_set& other) {
+        if (this != &other) {
+            *reinterpret_cast<CollectionChangeSet*>(&m_change_set) = *reinterpret_cast<const CollectionChangeSet*>(&other.m_change_set);
+        }
+        return *this;
+    }
+
+    collection_change_set::collection_change_set(collection_change_set&& other) {
+        new (&m_change_set) CollectionChangeSet(std::move(*reinterpret_cast<CollectionChangeSet*>(&other.m_change_set)));
+    }
+
+    collection_change_set& collection_change_set::operator=(collection_change_set&& other) {
+        if (this != &other) {
+            *reinterpret_cast<CollectionChangeSet*>(&m_change_set) = std::move(*reinterpret_cast<CollectionChangeSet*>(&other.m_change_set));
+        }
+        return *this;
+    }
+
+    collection_change_set::~collection_change_set() {
+        reinterpret_cast<CollectionChangeSet*>(&m_change_set)->~CollectionChangeSet();
     }
 
     collection_change_set::collection_change_set(const CollectionChangeSet &v) {
         new (&m_change_set) CollectionChangeSet(v);
     }
 
+    index_set::index_iterator::index_iterator(const index_set::index_iterator& other) {
+        new (&m_iterator) IndexSet::IndexIterator(*reinterpret_cast<const IndexSet::IndexIterator*>(&other.m_iterator));
+    }
+
+    index_set::index_iterator& index_set::index_iterator::operator=(const index_set::index_iterator& other) {
+        if (this != &other) {
+            *reinterpret_cast<IndexSet::IndexIterator*>(&m_iterator) = *reinterpret_cast<const IndexSet::IndexIterator*>(&other.m_iterator);
+        }
+        return *this;
+    }
+
+    index_set::index_iterator::index_iterator(index_set::index_iterator&& other) {
+        new (&m_iterator) IndexSet::IndexIterator(std::move(*reinterpret_cast<IndexSet::IndexIterator*>(&other.m_iterator)));
+    }
+
+    index_set::index_iterator& index_set::index_iterator::operator=(index_set::index_iterator&& other) {
+        if (this != &other) {
+            *reinterpret_cast<IndexSet::IndexIterator*>(&m_iterator) = std::move(*reinterpret_cast<IndexSet::IndexIterator*>(&other.m_iterator));
+        }
+        return *this;
+    }
+
+    index_set::index_iterator::~index_iterator() {
+        reinterpret_cast<IndexSet::IndexIterator*>(&m_iterator)->~IndexIterator();
+    }
+
     size_t index_set::index_iterator::operator*() const noexcept {
-        return reinterpret_cast<const IndexSet::IndexIterator*>(m_iterator)->operator*();
+        return reinterpret_cast<const IndexSet::IndexIterator*>(&m_iterator)->operator*();
     }
 
     bool index_set::index_iterator::operator==(const index_set::index_iterator &it) const noexcept {
-        return reinterpret_cast<const IndexSet::IndexIterator*>(m_iterator)->operator==(
+        return reinterpret_cast<const IndexSet::IndexIterator*>(&m_iterator)->operator==(
                 *reinterpret_cast<const IndexSet::IndexIterator*>(it.m_iterator));
     }
 
     index_set::index_iterator &index_set::index_iterator::operator++() noexcept {
-        new (&m_iterator) IndexSet::IndexIterator(reinterpret_cast<IndexSet::IndexIterator*>(m_iterator)->operator++());
+        new (&m_iterator) IndexSet::IndexIterator(reinterpret_cast<IndexSet::IndexIterator*>(&m_iterator)->operator++());
         return *this;
     }
 
     index_set collection_change_set::insertions() const {
-        return reinterpret_cast<const CollectionChangeSet*>(m_change_set)->insertions;
+        return reinterpret_cast<const CollectionChangeSet*>(&m_change_set)->insertions;
     }
 
     bool collection_change_set::collection_root_was_deleted() const {
-        return reinterpret_cast<const CollectionChangeSet*>(m_change_set)->collection_root_was_deleted;
+        return reinterpret_cast<const CollectionChangeSet*>(&m_change_set)->collection_root_was_deleted;
     }
 
     bool index_set::index_iterator::operator!=(const index_set::index_iterator &it) const noexcept {
-        return reinterpret_cast<const IndexSet::IndexIterator*>(m_iterator)->operator!=(
+        return reinterpret_cast<const IndexSet::IndexIterator*>(&m_iterator)->operator!=(
                 *reinterpret_cast<const IndexSet::IndexIterator*>(it.m_iterator));
+    }
+
+    index_set::index_iterable_adaptor::index_iterable_adaptor(const index_set::index_iterable_adaptor& other) {
+        new (&m_index_iterable_adaptor) IndexSet::IndexIterator(*reinterpret_cast<const IndexSet::IndexIterator*>(&other.m_index_iterable_adaptor));
+    }
+
+    index_set::index_iterable_adaptor& index_set::index_iterable_adaptor::operator=(const index_set::index_iterable_adaptor& other) {
+        if (this != &other) {
+            *reinterpret_cast<IndexSet::IndexIterator*>(&m_index_iterable_adaptor) = *reinterpret_cast<const IndexSet::IndexIterator*>(&other.m_index_iterable_adaptor);
+        }
+        return *this;
+    }
+
+    index_set::index_iterable_adaptor::index_iterable_adaptor(index_set::index_iterable_adaptor&& other) {
+        new (&m_index_iterable_adaptor) IndexSet::IndexIterator(std::move(*reinterpret_cast<IndexSet::IndexIterator*>(&other.m_index_iterable_adaptor)));
+    }
+
+    index_set::index_iterable_adaptor& index_set::index_iterable_adaptor::operator=(index_set::index_iterable_adaptor&& other) {
+        if (this != &other) {
+            *reinterpret_cast<IndexSet::IndexIterator*>(&m_index_iterable_adaptor) = std::move(*reinterpret_cast<IndexSet::IndexIterator*>(&other.m_index_iterable_adaptor));
+        }
+        return *this;
+    }
+
+    index_set::index_iterable_adaptor::~index_iterable_adaptor() {
+        reinterpret_cast<IndexSet::IndexIterator*>(&m_index_iterable_adaptor)->~IndexIterator();
     }
 
     index_set::index_iterator index_set::index_iterable_adaptor::begin() const noexcept {
         index_iterator iter;
         new (&iter.m_iterator) IndexSet::IndexIterator(
-                reinterpret_cast<const IndexSet::IndexIteratableAdaptor*>(index_iterable_adaptor)->begin());
+                reinterpret_cast<const IndexSet::IndexIteratableAdaptor*>(&m_index_iterable_adaptor)->begin());
         return iter;
     }
     index_set::index_iterator index_set::index_iterable_adaptor::end() const noexcept {
         index_iterator iter;
         new (&iter.m_iterator) IndexSet::IndexIterator(
-                reinterpret_cast<const IndexSet::IndexIteratableAdaptor*>(index_iterable_adaptor)->end());
+                reinterpret_cast<const IndexSet::IndexIteratableAdaptor*>(&m_index_iterable_adaptor)->end());
         return iter;
     }
 
     index_set::index_iterable_adaptor index_set::as_indexes() const {
         index_iterable_adaptor iter;
-        new (&iter.index_iterable_adaptor) IndexSet::IndexIteratableAdaptor(
-                reinterpret_cast<const IndexSet*>(m_idx_set)->as_indexes());
+        new (&iter.m_index_iterable_adaptor) IndexSet::IndexIteratableAdaptor(
+                reinterpret_cast<const IndexSet*>(&m_idx_set)->as_indexes());
         return iter;
     }
 }

--- a/src/cpprealm/internal/bridge/object.hpp
+++ b/src/cpprealm/internal/bridge/object.hpp
@@ -118,19 +118,27 @@ namespace realm::internal::bridge {
 #elif __arm__
         std::aligned_storage<84, 4>::type m_change_set[1];
 #elif __aarch64__
+#if defined(__clang__)
         std::aligned_storage<168, 8>::type m_change_set[1];
+#elif defined(__GNUC__) || defined(__GNUG__)
+        std::aligned_storage<184, 8>::type m_change_set[1];
+#endif
 #else
         std::aligned_storage<84, 4>::type m_change_set[1];
 #endif
     };
     struct collection_change_callback {
-//        operator CollectionChangeCallback() const;
         virtual void before(collection_change_set const& c) = 0;
         virtual void after(collection_change_set const& c) = 0;
     };
 
     struct object {
         object(); //NOLINT(google-explicit-constructor)
+        object(const object& other) ;
+        object& operator=(const object& other);
+        object(object&& other);
+        object& operator=(object&& other);
+        ~object();
         object(const Object&); //NOLINT(google-explicit-constructor)
         object(const realm &realm, const obj &obj); //NOLINT(google-explicit-constructor)
         object(const realm &realm, const obj_link& link);

--- a/src/cpprealm/internal/bridge/object.hpp
+++ b/src/cpprealm/internal/bridge/object.hpp
@@ -40,13 +40,24 @@ namespace realm::internal::bridge {
     };
 
     struct index_set {
-        index_set();
+        index_set(); //NOLINT(google-explicit-constructor)
+        index_set(const index_set& other) ;
+        index_set& operator=(const index_set& other);
+        index_set(index_set&& other);
+        index_set& operator=(index_set&& other);
+        ~index_set();
         index_set(const IndexSet&); //NOLINT(google-explicit-constructor)
         [[nodiscard]] bool empty() const;
         struct index_iterable_adaptor;
         // An iterator over the individual indices in the set rather than the ranges
         class index_iterator {
         public:
+            index_iterator() = default;
+            index_iterator(const index_iterator& other) ;
+            index_iterator& operator=(const index_iterator& other);
+            index_iterator(index_iterator&& other);
+            index_iterator& operator=(index_iterator&& other);
+            ~index_iterator();
             size_t operator*() const noexcept;
             bool operator==(index_iterator const& it) const noexcept;
             bool operator!=(index_iterator const& it) const noexcept;
@@ -69,6 +80,12 @@ namespace realm::internal::bridge {
         };
 
         struct index_iterable_adaptor {
+            index_iterable_adaptor() = default;
+            index_iterable_adaptor(const index_iterable_adaptor& other) ;
+            index_iterable_adaptor& operator=(const index_iterable_adaptor& other);
+            index_iterable_adaptor(index_iterable_adaptor&& other);
+            index_iterable_adaptor& operator=(index_iterable_adaptor&& other);
+            ~index_iterable_adaptor();
             using const_iterator = index_iterator;
 
             const_iterator begin() const noexcept;
@@ -76,13 +93,13 @@ namespace realm::internal::bridge {
         private:
             friend struct index_set;
 #ifdef __i386__
-            std::aligned_storage<4, 4>::type index_iterable_adaptor[1];
+            std::aligned_storage<4, 4>::type m_index_iterable_adaptor[1];
 #elif __x86_64__
-            std::aligned_storage<8, 8>::type index_iterable_adaptor[1];
+            std::aligned_storage<8, 8>::type m_index_iterable_adaptor[1];
 #elif __arm__
-            std::aligned_storage<4, 4>::type index_iterable_adaptor[1];
+            std::aligned_storage<4, 4>::type m_index_iterable_adaptor[1];
 #elif __aarch64__
-            std::aligned_storage<8, 8>::type index_iterable_adaptor[1];
+            std::aligned_storage<8, 8>::type m_index_iterable_adaptor[1];
 #endif
         };
         index_iterable_adaptor as_indexes() const;
@@ -98,6 +115,12 @@ namespace realm::internal::bridge {
 #endif
     };
     struct collection_change_set {
+        collection_change_set(); //NOLINT(google-explicit-constructor)
+        collection_change_set(const collection_change_set& other) ;
+        collection_change_set& operator=(const collection_change_set& other);
+        collection_change_set(collection_change_set&& other);
+        collection_change_set& operator=(collection_change_set&& other);
+        ~collection_change_set();
         collection_change_set(const CollectionChangeSet&);
         operator CollectionChangeSet() const;
         [[nodiscard]] index_set deletions() const;

--- a/src/cpprealm/internal/bridge/object_id.cpp
+++ b/src/cpprealm/internal/bridge/object_id.cpp
@@ -20,6 +20,31 @@ namespace realm::internal::bridge {
     object_id::object_id() {
         new(&m_object_id) ObjectId();
     }
+    object_id::object_id(const object_id& other) {
+        new (&m_object_id) ObjectId(*reinterpret_cast<const ObjectId*>(other.m_object_id));
+    }
+
+    object_id& object_id::operator=(const object_id& other) {
+        if (this != &other) {
+            *reinterpret_cast<ObjectId*>(m_object_id) = *reinterpret_cast<const ObjectId*>(other.m_object_id);
+        }
+        return *this;
+    }
+
+    object_id::object_id(object_id&& other) {
+        new (&m_object_id) ObjectId(std::move(*reinterpret_cast<ObjectId*>(other.m_object_id)));
+    }
+
+    object_id& object_id::operator=(object_id&& other) {
+        if (this != &other) {
+            *reinterpret_cast<ObjectId*>(m_object_id) = std::move(*reinterpret_cast<ObjectId*>(other.m_object_id));
+        }
+        return *this;
+    }
+
+    object_id::~object_id() {
+        reinterpret_cast<ObjectId*>(m_object_id)->~ObjectId();
+    }
 
     object_id::object_id(const std::string &v) {
         new(&m_object_id) ObjectId(v);

--- a/src/cpprealm/internal/bridge/object_id.cpp
+++ b/src/cpprealm/internal/bridge/object_id.cpp
@@ -21,29 +21,29 @@ namespace realm::internal::bridge {
         new(&m_object_id) ObjectId();
     }
     object_id::object_id(const object_id& other) {
-        new (&m_object_id) ObjectId(*reinterpret_cast<const ObjectId*>(other.m_object_id));
+        new (&m_object_id) ObjectId(*reinterpret_cast<const ObjectId*>(&other.m_object_id));
     }
 
     object_id& object_id::operator=(const object_id& other) {
         if (this != &other) {
-            *reinterpret_cast<ObjectId*>(m_object_id) = *reinterpret_cast<const ObjectId*>(other.m_object_id);
+            *reinterpret_cast<ObjectId*>(&m_object_id) = *reinterpret_cast<const ObjectId*>(&other.m_object_id);
         }
         return *this;
     }
 
     object_id::object_id(object_id&& other) {
-        new (&m_object_id) ObjectId(std::move(*reinterpret_cast<ObjectId*>(other.m_object_id)));
+        new (&m_object_id) ObjectId(std::move(*reinterpret_cast<ObjectId*>(&other.m_object_id)));
     }
 
     object_id& object_id::operator=(object_id&& other) {
         if (this != &other) {
-            *reinterpret_cast<ObjectId*>(m_object_id) = std::move(*reinterpret_cast<ObjectId*>(other.m_object_id));
+            *reinterpret_cast<ObjectId*>(&m_object_id) = std::move(*reinterpret_cast<ObjectId*>(&other.m_object_id));
         }
         return *this;
     }
 
     object_id::~object_id() {
-        reinterpret_cast<ObjectId*>(m_object_id)->~ObjectId();
+        reinterpret_cast<ObjectId*>(&m_object_id)->~ObjectId();
     }
 
     object_id::object_id(const std::string &v) {
@@ -59,7 +59,7 @@ namespace realm::internal::bridge {
     }
 
     std::string object_id::to_string() const {
-        return reinterpret_cast<const ObjectId *>(m_object_id)->to_string();
+        return reinterpret_cast<const ObjectId *>(&m_object_id)->to_string();
     }
 
     object_id object_id::generate() {
@@ -71,12 +71,12 @@ namespace realm::internal::bridge {
     }
 
     object_id::operator ObjectId() const {
-        return *reinterpret_cast<const ObjectId *>(m_object_id);
+        return *reinterpret_cast<const ObjectId *>(&m_object_id);
     }
 
 #define __cpp_realm_gen_object_id_op(op) \
     bool operator op(const object_id& a, const object_id& b) { \
-        return *reinterpret_cast<const ObjectId*>(a.m_object_id) op *reinterpret_cast<const ObjectId*>(b.m_object_id);                                        \
+        return *reinterpret_cast<const ObjectId*>(&a.m_object_id) op *reinterpret_cast<const ObjectId*>(&b.m_object_id);                                        \
     }
 
     __cpp_realm_gen_object_id_op(==)

--- a/src/cpprealm/internal/bridge/object_id.hpp
+++ b/src/cpprealm/internal/bridge/object_id.hpp
@@ -11,6 +11,11 @@ namespace realm {
 namespace realm::internal::bridge {
     struct object_id : core_binding<ObjectId> {
         object_id();
+        object_id(const object_id& other) ;
+        object_id& operator=(const object_id& other) ;
+        object_id(object_id&& other);
+        object_id& operator=(object_id&& other);
+        ~object_id();
         object_id(const ObjectId&); //NOLINT(google-explicit-constructor);
         explicit object_id(const std::string&);
         object_id(const struct ::realm::object_id&); //NOLINT(google-explicit-constructor);

--- a/src/cpprealm/internal/bridge/object_schema.cpp
+++ b/src/cpprealm/internal/bridge/object_schema.cpp
@@ -20,7 +20,11 @@ namespace realm::internal::bridge {
     static_assert(SizeCheck<68, sizeof(ObjectSchema)>{});
     static_assert(SizeCheck<4, alignof(ObjectSchema)>{});
 #elif __aarch64__
+#if defined(__clang__)
     static_assert(SizeCheck<128, sizeof(ObjectSchema)>{});
+#elif defined(__GNUC__) || defined(__GNUG__)
+    static_assert(SizeCheck<152, sizeof(ObjectSchema)>{});
+#endif
     static_assert(SizeCheck<8, alignof(ObjectSchema)>{});
 #endif
 

--- a/src/cpprealm/internal/bridge/object_schema.cpp
+++ b/src/cpprealm/internal/bridge/object_schema.cpp
@@ -69,38 +69,38 @@ namespace realm::internal::bridge {
                                  const std::string &primary_key,
                                  realm::internal::bridge::object_schema::object_type type) {
         new (&m_schema) ObjectSchema();
-        reinterpret_cast<ObjectSchema*>(m_schema)->name = name;
+        reinterpret_cast<ObjectSchema*>(&m_schema)->name = name;
         std::transform(properties.begin(),
                        properties.end(),
-                       reinterpret_cast<ObjectSchema*>(m_schema)->persisted_properties.begin(),
+                       reinterpret_cast<ObjectSchema*>(&m_schema)->persisted_properties.begin(),
                        [](const property& p) {
             return static_cast<Property>(p);
         });
-        reinterpret_cast<ObjectSchema*>(m_schema)->primary_key = primary_key;
-        reinterpret_cast<ObjectSchema*>(m_schema)->table_type = static_cast<ObjectSchema::ObjectType>(type);
+        reinterpret_cast<ObjectSchema*>(&m_schema)->primary_key = primary_key;
+        reinterpret_cast<ObjectSchema*>(&m_schema)->table_type = static_cast<ObjectSchema::ObjectType>(type);
     }
     uint32_t object_schema::table_key() {
-        return reinterpret_cast<ObjectSchema*>(m_schema)->table_key.value;
+        return reinterpret_cast<ObjectSchema*>(&m_schema)->table_key.value;
     }
 
     void object_schema::set_object_type(realm::internal::bridge::object_schema::object_type o) {
-        reinterpret_cast<ObjectSchema*>(m_schema)->table_type = static_cast<ObjectSchema::ObjectType>(o);
+        reinterpret_cast<ObjectSchema*>(&m_schema)->table_type = static_cast<ObjectSchema::ObjectType>(o);
     }
 
     void object_schema::add_property(const realm::internal::bridge::property &v) {
-        reinterpret_cast<ObjectSchema*>(m_schema)->persisted_properties.push_back(v);
+        reinterpret_cast<ObjectSchema*>(&m_schema)->persisted_properties.push_back(v);
     }
 
     void object_schema::set_name(const std::string &name) {
-        reinterpret_cast<ObjectSchema*>(m_schema)->name = name;
+        reinterpret_cast<ObjectSchema*>(&m_schema)->name = name;
     }
     property object_schema::property_for_name(const std::string &v) {
-        return *reinterpret_cast<ObjectSchema*>(m_schema)->property_for_name(v);
+        return *reinterpret_cast<ObjectSchema*>(&m_schema)->property_for_name(v);
     }
     void object_schema::set_primary_key(const std::string &primary_key) {
-        reinterpret_cast<ObjectSchema*>(m_schema)->primary_key = primary_key;
+        reinterpret_cast<ObjectSchema*>(&m_schema)->primary_key = primary_key;
     }
     object_schema::operator ObjectSchema() const {
-        return *reinterpret_cast<const ObjectSchema*>(m_schema);
+        return *reinterpret_cast<const ObjectSchema*>(&m_schema);
     }
 }

--- a/src/cpprealm/internal/bridge/object_schema.cpp
+++ b/src/cpprealm/internal/bridge/object_schema.cpp
@@ -27,6 +27,37 @@ namespace realm::internal::bridge {
     object_schema::object_schema() {
         new (&m_schema) ObjectSchema();
     }
+
+    object_schema::object_schema(const object_schema& other) {
+        new (&m_schema) ObjectSchema(*reinterpret_cast<const ObjectSchema*>(&other.m_schema));
+    }
+
+    object_schema& object_schema::operator=(const object_schema& other) {
+        if (this != &other) {
+            *reinterpret_cast<ObjectSchema*>(&m_schema) = *reinterpret_cast<const ObjectSchema*>(&other.m_schema);
+        }
+        return *this;
+    }
+
+    object_schema::object_schema(object_schema&& other) {
+        new (&m_schema) ObjectSchema(std::move(*reinterpret_cast<ObjectSchema*>(&other.m_schema)));
+    }
+
+    object_schema& object_schema::operator=(object_schema&& other) {
+        if (this != &other) {
+            *reinterpret_cast<ObjectSchema*>(&m_schema) = std::move(*reinterpret_cast<ObjectSchema*>(&other.m_schema));
+        }
+        return *this;
+    }
+
+    object_schema::~object_schema() {
+        reinterpret_cast<ObjectSchema*>(&m_schema)->~ObjectSchema();
+    }
+
+
+
+
+
     object_schema::object_schema(const realm::ObjectSchema &v) {
         new (&m_schema) ObjectSchema(v);
     }

--- a/src/cpprealm/internal/bridge/object_schema.hpp
+++ b/src/cpprealm/internal/bridge/object_schema.hpp
@@ -15,6 +15,14 @@ namespace realm::internal::bridge {
         enum class object_type : uint8_t { TopLevel = 0, Embedded = 0x1, TopLevelAsymmetric = 0x2 };
 
         object_schema();
+
+        object_schema(const object_schema& other) ;
+        object_schema& operator=(const object_schema& other) ;
+        object_schema(object_schema&& other);
+        object_schema& operator=(object_schema&& other);
+        ~object_schema();
+
+
         object_schema(const std::string& name,
                       const std::vector<property>& properties,
                       const std::string& primary_key,

--- a/src/cpprealm/internal/bridge/object_schema.hpp
+++ b/src/cpprealm/internal/bridge/object_schema.hpp
@@ -48,7 +48,11 @@ namespace realm::internal::bridge {
 #elif __arm__
         std::aligned_storage<68, 4>::type m_schema[1];
 #elif __aarch64__
+#if defined(__clang__)
         std::aligned_storage<128, 8>::type m_schema[1];
+#elif defined(__GNUC__) || defined(__GNUG__)
+        std::aligned_storage<152, 8>::type m_schema[1];
+#endif
 #endif
     };
 }

--- a/src/cpprealm/internal/bridge/property.cpp
+++ b/src/cpprealm/internal/bridge/property.cpp
@@ -23,6 +23,37 @@ namespace realm::internal::bridge {
     static_assert(SizeCheck<8, alignof(Property)>{});
 #endif
 
+
+    property::property() {
+        new (&m_property) Property();
+    }
+
+    property::property(const property& other) {
+        new (&m_property) Property(*reinterpret_cast<const Property*>(&other.m_property));
+    }
+
+    property& property::operator=(const property& other) {
+        if (this != &other) {
+            *reinterpret_cast<Property*>(&m_property) = *reinterpret_cast<const Property*>(&other.m_property);
+        }
+        return *this;
+    }
+
+    property::property(property&& other) {
+        new (&m_property) Property(std::move(*reinterpret_cast<Property*>(&other.m_property)));
+    }
+
+    property& property::operator=(property&& other) {
+        if (this != &other) {
+            *reinterpret_cast<Property*>(&m_property) = std::move(*reinterpret_cast<Property*>(&other.m_property));
+        }
+        return *this;
+    }
+
+    property::~property() {
+        reinterpret_cast<Property*>(&m_property)->~Property();
+    }
+
     property::property(const realm::Property &v) {
         new (m_property) Property(v);
     }

--- a/src/cpprealm/internal/bridge/property.cpp
+++ b/src/cpprealm/internal/bridge/property.cpp
@@ -70,17 +70,17 @@ namespace realm::internal::bridge {
         new (&m_property) Property(name, static_cast<PropertyType>(type), is_primary_key);
     }
     void property::set_object_link(const std::string & v) {
-        reinterpret_cast<Property*>(m_property)->object_type = v;
+        reinterpret_cast<Property*>(&m_property)->object_type = v;
     }
     col_key property::column_key() const {
-        return reinterpret_cast<const Property*>(m_property)->column_key;
+        return reinterpret_cast<const Property*>(&m_property)->column_key;
     }
 
     property::operator Property() const {
-        return *reinterpret_cast<const Property*>(m_property);
+        return *reinterpret_cast<const Property*>(&m_property);
     }
 
     void property::set_type(realm::internal::bridge::property::type t) {
-        reinterpret_cast<Property*>(m_property)->type = static_cast<PropertyType>(t);
+        reinterpret_cast<Property*>(&m_property)->type = static_cast<PropertyType>(t);
     }
 }

--- a/src/cpprealm/internal/bridge/property.cpp
+++ b/src/cpprealm/internal/bridge/property.cpp
@@ -19,7 +19,11 @@ namespace realm::internal::bridge {
     static_assert(SizeCheck<64, sizeof(Property)>{});
     static_assert(SizeCheck<8, alignof(Property)>{});
 #elif __aarch64__
+#if defined(__clang__)
     static_assert(SizeCheck<120, sizeof(Property)>{});
+#elif defined(__GNUC__) || defined(__GNUG__)
+    static_assert(SizeCheck<152, sizeof(Property)>{});
+#endif
     static_assert(SizeCheck<8, alignof(Property)>{});
 #endif
 

--- a/src/cpprealm/internal/bridge/property.hpp
+++ b/src/cpprealm/internal/bridge/property.hpp
@@ -38,6 +38,13 @@ namespace realm::internal::bridge {
             Collection = Array | Set | Dictionary,
             Flags = Nullable | Collection
         };
+
+        property();
+        property(const property& other) ;
+        property& operator=(const property& other) ;
+        property(property&& other);
+        property& operator=(property&& other);
+        ~property();
         property(const Property&); //NOLINT(google-explicit-constructor)
         property(const std::string& name,
                  type type,

--- a/src/cpprealm/internal/bridge/property.hpp
+++ b/src/cpprealm/internal/bridge/property.hpp
@@ -68,7 +68,11 @@ namespace realm::internal::bridge {
 #elif __arm__
         std::aligned_storage<64, 8>::type m_property[1];
 #elif __aarch64__
+#if defined(__clang__)
         std::aligned_storage<120, 8>::type m_property[1];
+#elif defined(__GNUC__) || defined(__GNUG__)
+        std::aligned_storage<152, 8>::type m_property[1];
+#endif
 #endif
     };
 

--- a/src/cpprealm/internal/bridge/query.cpp
+++ b/src/cpprealm/internal/bridge/query.cpp
@@ -41,9 +41,43 @@ namespace realm::internal::bridge {
     static_assert(SizeCheck<80, sizeof(Query)>{});
     static_assert(SizeCheck<8, alignof(Query)>{});
 #elif __aarch64__
+#if defined(__clang__)
     static_assert(SizeCheck<128, sizeof(Query)>{});
+#elif defined(__GNUC__) || defined(__GNUG__)
+    static_assert(SizeCheck<136, sizeof(Query)>{});
+#endif
     static_assert(SizeCheck<8, alignof(Query)>{});
 #endif
+
+    query::query() {
+        new (&m_query) Query();
+    }
+
+    query::query(const query& other) {
+        new (&m_query) Query(*reinterpret_cast<const Query*>(other.m_query));
+    }
+
+    query& query::operator=(const query& other) {
+        if (this != &other) {
+            *reinterpret_cast<Query*>(m_query) = *reinterpret_cast<const Query*>(other.m_query);
+        }
+        return *this;
+    }
+
+    query::query(query&& other) {
+        new (&m_query) Query(std::move(*reinterpret_cast<Query*>(other.m_query)));
+    }
+
+    query& query::operator=(query&& other) {
+        if (this != &other) {
+            *reinterpret_cast<Query*>(m_query) = std::move(*reinterpret_cast<Query*>(other.m_query));
+        }
+        return *this;
+    }
+
+    query::~query() {
+        reinterpret_cast<Query*>(m_query)->~Query();
+    }
 
     query::query(const table &table) {
         new (&m_query) Query(static_cast<ConstTableRef>(table));

--- a/src/cpprealm/internal/bridge/query.cpp
+++ b/src/cpprealm/internal/bridge/query.cpp
@@ -11,19 +11,19 @@
 
 #define __generate_query_operator(op, type) \
     query &query::op(col_key column_key, type value) { \
-        *reinterpret_cast<Query *>(m_query) = reinterpret_cast<Query *>(m_query)->op(column_key, value); \
+        *reinterpret_cast<Query *>(&m_query) = reinterpret_cast<Query *>(&m_query)->op(column_key, value); \
         return *this; \
     }
 
 #define __generate_query_operator_case_sensitive(op, type) \
     query &query::op(col_key column_key, type value, bool) { \
-        *reinterpret_cast<Query *>(m_query) = reinterpret_cast<Query *>(m_query)->op(column_key, value); \
+        *reinterpret_cast<Query *>(&m_query) = reinterpret_cast<Query *>(&m_query)->op(column_key, value); \
         return *this; \
     }
 
 #define __generate_query_operator_mixed(op) \
     query &query::op(col_key column_key, mixed value, bool) { \
-        *reinterpret_cast<Query *>(m_query) = reinterpret_cast<Query *>(m_query)->op(column_key, static_cast<Mixed>(value)); \
+        *reinterpret_cast<Query *>(&m_query) = reinterpret_cast<Query *>(&m_query)->op(column_key, static_cast<Mixed>(value)); \
         return *this; \
     }
 namespace realm::internal::bridge {
@@ -54,29 +54,29 @@ namespace realm::internal::bridge {
     }
 
     query::query(const query& other) {
-        new (&m_query) Query(*reinterpret_cast<const Query*>(other.m_query));
+        new (&m_query) Query(*reinterpret_cast<const Query*>(&other.m_query));
     }
 
     query& query::operator=(const query& other) {
         if (this != &other) {
-            *reinterpret_cast<Query*>(m_query) = *reinterpret_cast<const Query*>(other.m_query);
+            *reinterpret_cast<Query*>(&m_query) = *reinterpret_cast<const Query*>(&other.m_query);
         }
         return *this;
     }
 
     query::query(query&& other) {
-        new (&m_query) Query(std::move(*reinterpret_cast<Query*>(other.m_query)));
+        new (&m_query) Query(std::move(*reinterpret_cast<Query*>(&other.m_query)));
     }
 
     query& query::operator=(query&& other) {
         if (this != &other) {
-            *reinterpret_cast<Query*>(m_query) = std::move(*reinterpret_cast<Query*>(other.m_query));
+            *reinterpret_cast<Query*>(&m_query) = std::move(*reinterpret_cast<Query*>(&other.m_query));
         }
         return *this;
     }
 
     query::~query() {
-        reinterpret_cast<Query*>(m_query)->~Query();
+        reinterpret_cast<Query*>(&m_query)->~Query();
     }
 
     query::query(const table &table) {
@@ -88,13 +88,13 @@ namespace realm::internal::bridge {
     }
 
     query::operator Query() const {
-        return *reinterpret_cast<const Query*>(m_query);
+        return *reinterpret_cast<const Query*>(&m_query);
     }
     table query::get_table() {
-        return reinterpret_cast<Query*>(m_query)->get_table();
+        return reinterpret_cast<Query*>(&m_query)->get_table();
     }
     query query::and_query(const query &v) {
-        return reinterpret_cast<Query*>(m_query)->and_query(v);
+        return reinterpret_cast<Query*>(&m_query)->and_query(v);
     }
 
     __generate_query_operator(greater, int64_t)
@@ -136,11 +136,11 @@ namespace realm::internal::bridge {
     __generate_query_operator(not_equal, bool)
 
     query& query::equal(col_key column_key, std::nullopt_t) {
-        *reinterpret_cast<Query *>(m_query) = reinterpret_cast<Query *>(m_query)->equal(column_key, realm::null{});
+        *reinterpret_cast<Query *>(&m_query) = reinterpret_cast<Query *>(&m_query)->equal(column_key, realm::null{});
         return *this;
     }
     query& query::not_equal(col_key column_key, std::nullopt_t) {
-        *reinterpret_cast<Query *>(m_query) = reinterpret_cast<Query *>(m_query)->not_equal(column_key, realm::null{});
+        *reinterpret_cast<Query *>(&m_query) = reinterpret_cast<Query *>(&m_query)->not_equal(column_key, realm::null{});
         return *this;
     }
 

--- a/src/cpprealm/internal/bridge/query.hpp
+++ b/src/cpprealm/internal/bridge/query.hpp
@@ -22,6 +22,12 @@ namespace realm::internal::bridge {
 
 
     struct query {
+        query();
+        query(const query& other) ;
+        query& operator=(const query& other) ;
+        query(query&& other);
+        query& operator=(query&& other);
+        ~query();
         query(const table& table); //NOLINT(google-explicit-constructor)
         table get_table();
         query and_query(const query&);
@@ -118,7 +124,11 @@ namespace realm::internal::bridge {
 #elif __arm__
         std::aligned_storage<80, 8>::type m_query[1];
 #elif __aarch64__
+#if defined(__clang__)
         std::aligned_storage<128, 8>::type m_query[1];
+#elif defined(__GNUC__) || defined(__GNUG__)
+        std::aligned_storage<136, 8>::type m_query[1];
+#endif
 #endif
 
     };

--- a/src/cpprealm/internal/bridge/realm.cpp
+++ b/src/cpprealm/internal/bridge/realm.cpp
@@ -68,15 +68,13 @@ namespace realm::internal::bridge {
 
     struct internal_scheduler : util::Scheduler {
         internal_scheduler(const std::shared_ptr<scheduler>& s)
-        : m_scheduler(s), m_thread_id(std::this_thread::get_id())
+        : m_scheduler(s)
         {
         }
 
         ~internal_scheduler() override = default;
         void invoke(util::UniqueFunction<void ()> &&fn) override {
-            m_scheduler->invoke([fn = fn.release()]() {
-                fn->call();
-            });
+            m_scheduler->invoke(std::move(fn));
         }
 
         bool is_on_thread() const noexcept override {
@@ -84,7 +82,7 @@ namespace realm::internal::bridge {
         }
         bool is_same_as(const util::Scheduler *other) const noexcept override {
             if (auto o = dynamic_cast<const internal_scheduler *>(other)) {
-                return m_thread_id == o->m_thread_id;
+                return m_scheduler->is_same_as(o->m_scheduler.get());
             }
             return false;
         }
@@ -94,7 +92,6 @@ namespace realm::internal::bridge {
         }
     private:
         std::shared_ptr<scheduler> m_scheduler;
-        std::thread::id m_thread_id;
     };
 
     realm::realm(thread_safe_reference&& tsr, const std::optional<std::shared_ptr<struct scheduler>>& s) {
@@ -110,23 +107,23 @@ namespace realm::internal::bridge {
     }
 
     realm::config::config(const config& other) {
-        new (&m_config) RealmConfig(*reinterpret_cast<const RealmConfig*>(other.m_config));
+        new (&m_config) RealmConfig(*reinterpret_cast<const RealmConfig*>(&other.m_config));
     }
 
     realm::config& realm::config::operator=(const config& other) {
         if (this != &other) {
-            *reinterpret_cast<RealmConfig*>(m_config) = *reinterpret_cast<const RealmConfig*>(other.m_config);
+            *reinterpret_cast<RealmConfig*>(&m_config) = *reinterpret_cast<const RealmConfig*>(&other.m_config);
         }
         return *this;
     }
 
     realm::config::config(config&& other) {
-        new (&m_config) RealmConfig(std::move(*reinterpret_cast<RealmConfig*>(other.m_config)));
+        new (&m_config) RealmConfig(std::move(*reinterpret_cast<RealmConfig*>(&other.m_config)));
     }
 
     realm::config& realm::config::operator=(config&& other) {
         if (this != &other) {
-            *reinterpret_cast<RealmConfig*>(m_config) = std::move(*reinterpret_cast<RealmConfig*>(other.m_config));
+            *reinterpret_cast<RealmConfig*>(&m_config) = std::move(*reinterpret_cast<RealmConfig*>(&other.m_config));
         }
         return *this;
     }
@@ -165,7 +162,7 @@ namespace realm::internal::bridge {
         return m_config;
     }
     std::string realm::config::path() const {
-        return reinterpret_cast<const RealmConfig*>(m_config)->path;
+        return reinterpret_cast<const RealmConfig*>(&m_config)->path;
     }
     realm::config realm::get_config() const {
         return m_realm->config();
@@ -175,8 +172,8 @@ namespace realm::internal::bridge {
         for (auto& os : v) {
             v2.push_back(os);
         }
-        reinterpret_cast<RealmConfig*>(m_config)->schema_version = 0;
-        reinterpret_cast<RealmConfig*>(m_config)->schema = v2;
+        reinterpret_cast<RealmConfig*>(&m_config)->schema_version = 0;
+        reinterpret_cast<RealmConfig*>(&m_config)->schema = v2;
     }
     schema realm::schema() const {
         return m_realm->schema();
@@ -190,7 +187,7 @@ namespace realm::internal::bridge {
 
     }
     realm::config::operator RealmConfig() const {
-        return *reinterpret_cast<const RealmConfig*>(m_config);
+        return *reinterpret_cast<const RealmConfig*>(&m_config);
     }
     realm::realm(const config &v) {
         m_realm = Realm::get_shared_realm(static_cast<RealmConfig>(v));
@@ -208,25 +205,25 @@ namespace realm::internal::bridge {
         return reinterpret_cast<ThreadSafeReference*>(tsr.m_thread_safe_reference)->resolve<Object>(r);
     }
     void realm::config::set_scheduler(const std::shared_ptr<struct scheduler> &s) {
-        reinterpret_cast<RealmConfig*>(m_config)->scheduler = std::make_shared<internal_scheduler>(s);
+        reinterpret_cast<RealmConfig*>(&m_config)->scheduler = std::make_shared<internal_scheduler>(s);
     }
     void realm::config::set_sync_config(const std::optional<struct sync_config> &s) {
         if (s)
-            reinterpret_cast<RealmConfig*>(m_config)->sync_config = static_cast<std::shared_ptr<SyncConfig>>(*s);
+            reinterpret_cast<RealmConfig*>(&m_config)->sync_config = static_cast<std::shared_ptr<SyncConfig>>(*s);
         else
-            reinterpret_cast<RealmConfig*>(m_config)->sync_config = nullptr;
+            reinterpret_cast<RealmConfig*>(&m_config)->sync_config = nullptr;
     }
 
     realm::sync_config realm::config::sync_config() const {
-        return reinterpret_cast<const RealmConfig*>(m_config)->sync_config;
+        return reinterpret_cast<const RealmConfig*>(&m_config)->sync_config;
     }
 
     struct external_scheduler final : public scheduler {
         // Invoke the given function on the scheduler's thread.
         //
         // This function can be called from any thread.
-        void invoke(std::function<void()> &&fn) final {
-            s->invoke(fn);
+        void invoke(Function<void()> &&fn) final {
+            s->invoke(std::move(fn));
         }
 
         // Check if the caller is currently running on the scheduler's thread.
@@ -285,7 +282,7 @@ namespace realm::internal::bridge {
     }
 
     void realm::config::set_path(const std::string &path) {
-        reinterpret_cast<RealmConfig*>(m_config)->path = path;
+        reinterpret_cast<RealmConfig*>(&m_config)->path = path;
     }
 
     bool realm::refresh() {

--- a/src/cpprealm/internal/bridge/realm.hpp
+++ b/src/cpprealm/internal/bridge/realm.hpp
@@ -59,6 +59,12 @@ namespace realm::internal::bridge {
         };
 
         struct config {
+            config();
+            config(const config& other) ;
+            config& operator=(const config& other) ;
+            config(config&& other);
+            config& operator=(config&& other);
+            ~config();
             config(const RealmConfig&); //NOLINT(google-explicit-constructor)
             config(const std::optional<std::string>& path = std::nullopt,
                    const std::optional<std::shared_ptr<scheduler>>& scheduler = std::nullopt);
@@ -83,9 +89,11 @@ namespace realm::internal::bridge {
             std::aligned_storage<192, 8>::type m_config[1];
 #elif __aarch64__
     #if __ANDROID__
-            std::aligned_storage<368, 16>::type m_config[1];
-    #else
-            std::aligned_storage<312, 8>::type m_config[1];
+        std::aligned_storage<368, 16>::type m_config[1];
+    #elif defined(__clang__)
+        std::aligned_storage<312, 8>::type m_config[1];
+    #elif defined(__GNUC__) || defined(__GNUG__)
+        std::aligned_storage<328, 8>::type m_config[1];
     #endif
 #endif
         };

--- a/src/cpprealm/internal/bridge/results.cpp
+++ b/src/cpprealm/internal/bridge/results.cpp
@@ -33,29 +33,29 @@ namespace realm::internal::bridge {
     }
 
     results::results(const results& other) {
-        new (&m_results) Results(*reinterpret_cast<const Results*>(other.m_results));
+        new (&m_results) Results(*reinterpret_cast<const Results*>(&other.m_results));
     }
 
     results& results::operator=(const results& other) {
         if (this != &other) {
-            *reinterpret_cast<Results*>(m_results) = *reinterpret_cast<const Results*>(other.m_results);
+            *reinterpret_cast<Results*>(&m_results) = *reinterpret_cast<const Results*>(&other.m_results);
         }
         return *this;
     }
 
     results::results(results&& other) {
-        new (&m_results) Results(std::move(*reinterpret_cast<Results*>(other.m_results)));
+        new (&m_results) Results(std::move(*reinterpret_cast<Results*>(&other.m_results)));
     }
 
     results& results::operator=(results&& other) {
         if (this != &other) {
-            *reinterpret_cast<Results*>(m_results) = std::move(*reinterpret_cast<Results*>(other.m_results));
+            *reinterpret_cast<Results*>(&m_results) = std::move(*reinterpret_cast<Results*>(&other.m_results));
         }
         return *this;
     }
 
     results::~results() {
-        reinterpret_cast<Results*>(m_results)->~Results();
+        reinterpret_cast<Results*>(&m_results)->~Results();
     }
 
     results::results(const realm &realm, const query &query) {
@@ -67,20 +67,20 @@ namespace realm::internal::bridge {
     }
 
     size_t results::size() {
-        return reinterpret_cast<Results*>(m_results)->size();
+        return reinterpret_cast<Results*>(&m_results)->size();
     }
 
     realm results::get_realm() const {
-        return reinterpret_cast<const Results*>(m_results)->get_realm();
+        return reinterpret_cast<const Results*>(&m_results)->get_realm();
     }
 
     table results::get_table() const {
-        return reinterpret_cast<const Results*>(m_results)->get_table();
+        return reinterpret_cast<const Results*>(&m_results)->get_table();
     }
 
     template <>
     obj get(results& res, size_t v) {
-        return reinterpret_cast<Results*>(res.m_results)-> template get(v);
+        return reinterpret_cast<Results*>(&res.m_results)-> template get(v);
     }
 
     notification_token results::add_notification_callback(std::shared_ptr<collection_change_callback> &&cb) {
@@ -95,6 +95,6 @@ namespace realm::internal::bridge {
                 m_cb->after(v);
             }
         } ccb(std::move(cb));
-        return reinterpret_cast<Results*>(m_results)->add_notification_callback(ccb);
+        return reinterpret_cast<Results*>(&m_results)->add_notification_callback(ccb);
     }
 }

--- a/src/cpprealm/internal/bridge/results.hpp
+++ b/src/cpprealm/internal/bridge/results.hpp
@@ -16,6 +16,13 @@ namespace realm::internal::bridge {
     struct collection_change_set;
 
     struct results {
+        results();
+        results(const results& other) ;
+        results& operator=(const results& other) ;
+        results(results&& other);
+        results& operator=(results&& other);
+        ~results();
+
         results(const Results&); //NOLINT(google-explicit-constructor)
         size_t size();
         [[nodiscard]] realm get_realm() const;
@@ -36,7 +43,11 @@ namespace realm::internal::bridge {
 #elif __arm__
         std::aligned_storage<568, 8>::type m_results[1];
 #elif __aarch64__
+#if defined(__clang__)
         std::aligned_storage<896, 8>::type m_results[1];
+#elif defined(__GNUC__) || defined(__GNUG__)
+        std::aligned_storage<912, 8>::type m_results[1];
+#endif
 #endif
     };
 

--- a/src/cpprealm/internal/bridge/schema.cpp
+++ b/src/cpprealm/internal/bridge/schema.cpp
@@ -25,33 +25,33 @@ namespace realm::internal::bridge {
     }
 
     schema::schema(const schema& other) {
-        new (&m_schema) Schema(*reinterpret_cast<const Schema*>(other.m_schema));
+        new (&m_schema) Schema(*reinterpret_cast<const Schema*>(&other.m_schema));
     }
 
     schema& schema::operator=(const schema& other) {
         if (this != &other) {
-            *reinterpret_cast<Schema*>(m_schema) = *reinterpret_cast<const Schema*>(other.m_schema);
+            *reinterpret_cast<Schema*>(&m_schema) = *reinterpret_cast<const Schema*>(&other.m_schema);
         }
         return *this;
     }
 
     schema::schema(schema&& other) {
-        new (&m_schema) Schema(std::move(*reinterpret_cast<Schema*>(other.m_schema)));
+        new (&m_schema) Schema(std::move(*reinterpret_cast<Schema*>(&other.m_schema)));
     }
 
     schema& schema::operator=(schema&& other) {
         if (this != &other) {
-            *reinterpret_cast<Schema*>(m_schema) = std::move(*reinterpret_cast<Schema*>(other.m_schema));
+            *reinterpret_cast<Schema*>(&m_schema) = std::move(*reinterpret_cast<Schema*>(&other.m_schema));
         }
         return *this;
     }
 
     schema::~schema() {
-        reinterpret_cast<Schema*>(m_schema)->~Schema();
+        reinterpret_cast<Schema*>(&m_schema)->~Schema();
     }
 
     object_schema schema::find(const std::string &name) {
-        return *reinterpret_cast<Schema*>(m_schema)->find(name);
+        return *reinterpret_cast<Schema*>(&m_schema)->find(name);
     }
 
     schema::schema(const std::vector<object_schema> &v) {
@@ -63,7 +63,7 @@ namespace realm::internal::bridge {
     }
 
     schema::operator Schema() const {
-        return *reinterpret_cast<const Schema*>(m_schema);
+        return *reinterpret_cast<const Schema*>(&m_schema);
     }
 
     schema::schema(const realm::Schema &v) {

--- a/src/cpprealm/internal/bridge/schema.cpp
+++ b/src/cpprealm/internal/bridge/schema.cpp
@@ -20,6 +20,36 @@ namespace realm::internal::bridge {
     static_assert(SizeCheck<8, alignof(Schema)>{});
 #endif
 
+    schema::schema() {
+        new (&m_schema) Schema();
+    }
+
+    schema::schema(const schema& other) {
+        new (&m_schema) Schema(*reinterpret_cast<const Schema*>(other.m_schema));
+    }
+
+    schema& schema::operator=(const schema& other) {
+        if (this != &other) {
+            *reinterpret_cast<Schema*>(m_schema) = *reinterpret_cast<const Schema*>(other.m_schema);
+        }
+        return *this;
+    }
+
+    schema::schema(schema&& other) {
+        new (&m_schema) Schema(std::move(*reinterpret_cast<Schema*>(other.m_schema)));
+    }
+
+    schema& schema::operator=(schema&& other) {
+        if (this != &other) {
+            *reinterpret_cast<Schema*>(m_schema) = std::move(*reinterpret_cast<Schema*>(other.m_schema));
+        }
+        return *this;
+    }
+
+    schema::~schema() {
+        reinterpret_cast<Schema*>(m_schema)->~Schema();
+    }
+
     object_schema schema::find(const std::string &name) {
         return *reinterpret_cast<Schema*>(m_schema)->find(name);
     }

--- a/src/cpprealm/internal/bridge/schema.hpp
+++ b/src/cpprealm/internal/bridge/schema.hpp
@@ -11,6 +11,12 @@ namespace realm::internal::bridge {
     struct object_schema;
 
     struct schema {
+        schema();
+        schema(const schema& other) ;
+        schema& operator=(const schema& other) ;
+        schema(schema&& other);
+        schema& operator=(schema&& other);
+        ~schema();
         schema(const std::vector<object_schema>&); //NOLINT(google-explicit-constructor)
         schema(const Schema&); //NOLINT(google-explicit-constructor)
         operator Schema() const; //NOLINT(google-explicit-constructor)

--- a/src/cpprealm/internal/bridge/sync_error.cpp
+++ b/src/cpprealm/internal/bridge/sync_error.cpp
@@ -27,23 +27,23 @@ namespace realm::internal::bridge {
 #endif
 
     sync_error::sync_error(const sync_error& other) {
-        new (&m_error) SyncError(*reinterpret_cast<const SyncError*>(other.m_error));
+        new (&m_error) SyncError(*reinterpret_cast<const SyncError*>(&other.m_error));
     }
 
     sync_error& sync_error::operator=(const sync_error& other) {
         if (this != &other) {
-            *reinterpret_cast<SyncError*>(m_error) = *reinterpret_cast<const SyncError*>(other.m_error);
+            *reinterpret_cast<SyncError*>(&m_error) = *reinterpret_cast<const SyncError*>(&other.m_error);
         }
         return *this;
     }
 
     sync_error::sync_error(sync_error&& other) {
-        new (&m_error) SyncError(std::move(*reinterpret_cast<SyncError*>(other.m_error)));
+        new (&m_error) SyncError(std::move(*reinterpret_cast<SyncError*>(&other.m_error)));
     }
 
     sync_error& sync_error::operator=(sync_error&& other) {
         if (this != &other) {
-            *reinterpret_cast<SyncError*>(m_error) = std::move(*reinterpret_cast<SyncError*>(other.m_error));
+            *reinterpret_cast<SyncError*>(&m_error) = std::move(*reinterpret_cast<SyncError*>(&other.m_error));
         }
         return *this;
     }
@@ -53,27 +53,27 @@ namespace realm::internal::bridge {
     }
 
     std::string_view sync_error::message() const {
-        return reinterpret_cast<const SyncError*>(m_error)->reason();
+        return reinterpret_cast<const SyncError*>(&m_error)->reason();
     }
 
     bool sync_error::is_client_error() const {
-        return reinterpret_cast<const SyncError*>(m_error)->is_client_error();
+        return reinterpret_cast<const SyncError*>(&m_error)->is_client_error();
     }
 
     bool sync_error::is_client_reset_requested() const {
-        return reinterpret_cast<const SyncError*>(m_error)->is_client_reset_requested();
+        return reinterpret_cast<const SyncError*>(&m_error)->is_client_reset_requested();
     }
 
     bool sync_error::is_connection_level_protocol_error() const {
-        return reinterpret_cast<const SyncError*>(m_error)->is_connection_level_protocol_error();
+        return reinterpret_cast<const SyncError*>(&m_error)->is_connection_level_protocol_error();
     }
 
     bool sync_error::is_fatal() const {
-        return reinterpret_cast<const SyncError*>(m_error)->is_fatal;
+        return reinterpret_cast<const SyncError*>(&m_error)->is_fatal;
     }
 
     bool sync_error::is_session_level_protocol_error() const {
-        return reinterpret_cast<const SyncError*>(m_error)->is_session_level_protocol_error();
+        return reinterpret_cast<const SyncError*>(&m_error)->is_session_level_protocol_error();
     }
 
     sync_error::sync_error(realm::SyncError &&v) {

--- a/src/cpprealm/internal/bridge/sync_error.hpp
+++ b/src/cpprealm/internal/bridge/sync_error.hpp
@@ -9,6 +9,11 @@ namespace realm {
 
 namespace realm::internal::bridge {
     struct sync_error {
+        sync_error(const sync_error& other) ;
+        sync_error& operator=(const sync_error& other) ;
+        sync_error(sync_error&& other);
+        sync_error& operator=(sync_error&& other);
+        ~sync_error();
         sync_error(SyncError&&);
 
         [[nodiscard]] bool is_fatal() const;
@@ -38,7 +43,11 @@ namespace realm::internal::bridge {
 #elif __arm__
         std::aligned_storage<80, 4>::type m_error[1];
 #elif __aarch64__
+#if defined(__clang__)
         std::aligned_storage<128, 8>::type m_error[1];
+#elif defined(__GNUC__) || defined(__GNUG__)
+        std::aligned_storage<144, 8>::type m_error[1];
+#endif
 #endif
     };
 }

--- a/src/cpprealm/internal/bridge/table.cpp
+++ b/src/cpprealm/internal/bridge/table.cpp
@@ -29,6 +29,35 @@ namespace realm::internal::bridge {
     static_assert(SizeCheck<16, sizeof(ConstTableRef)>{});
     static_assert(SizeCheck<8, alignof(ConstTableRef)>{});
 #endif
+    table::table() {
+        new (&m_table) TableRef();
+    }
+
+    table::table(const table& other) {
+        new (&m_table) TableRef(*reinterpret_cast<const TableRef*>(other.m_table));
+    }
+
+    table& table::operator=(const table& other) {
+        if (this != &other) {
+            *reinterpret_cast<TableRef*>(m_table) = *reinterpret_cast<const TableRef*>(other.m_table);
+        }
+        return *this;
+    }
+
+    table::table(table&& other) {
+        new (&m_table) TableRef(std::move(*reinterpret_cast<TableRef*>(other.m_table)));
+    }
+
+    table& table::operator=(table&& other) {
+        if (this != &other) {
+            *reinterpret_cast<TableRef*>(m_table) = std::move(*reinterpret_cast<TableRef*>(other.m_table));
+        }
+        return *this;
+    }
+
+    table::~table() {
+        reinterpret_cast<TableRef*>(&m_table)->~TableRef();
+    }
     table::table(const TableRef & ref)
     {
         new (&m_table) TableRef(ref);

--- a/src/cpprealm/internal/bridge/table.cpp
+++ b/src/cpprealm/internal/bridge/table.cpp
@@ -34,23 +34,23 @@ namespace realm::internal::bridge {
     }
 
     table::table(const table& other) {
-        new (&m_table) TableRef(*reinterpret_cast<const TableRef*>(other.m_table));
+        new (&m_table) TableRef(*reinterpret_cast<const TableRef*>(&other.m_table));
     }
 
     table& table::operator=(const table& other) {
         if (this != &other) {
-            *reinterpret_cast<TableRef*>(m_table) = *reinterpret_cast<const TableRef*>(other.m_table);
+            *reinterpret_cast<TableRef*>(&m_table) = *reinterpret_cast<const TableRef*>(&other.m_table);
         }
         return *this;
     }
 
     table::table(table&& other) {
-        new (&m_table) TableRef(std::move(*reinterpret_cast<TableRef*>(other.m_table)));
+        new (&m_table) TableRef(std::move(*reinterpret_cast<TableRef*>(&other.m_table)));
     }
 
     table& table::operator=(table&& other) {
         if (this != &other) {
-            *reinterpret_cast<TableRef*>(m_table) = std::move(*reinterpret_cast<TableRef*>(other.m_table));
+            *reinterpret_cast<TableRef*>(&m_table) = std::move(*reinterpret_cast<TableRef*>(&other.m_table));
         }
         return *this;
     }
@@ -68,15 +68,15 @@ namespace realm::internal::bridge {
     }
 
     table::operator TableRef() const {
-        return *reinterpret_cast<const TableRef*>(m_table);
+        return *reinterpret_cast<const TableRef*>(&m_table);
     }
 
     table::operator ConstTableRef() const {
-        return *reinterpret_cast<const ConstTableRef*>(m_table);
+        return *reinterpret_cast<const ConstTableRef*>(&m_table);
     }
 
     bool table::is_embedded() const {
-        return (*reinterpret_cast<const TableRef*>(m_table))->is_embedded();
+        return (*reinterpret_cast<const TableRef*>(&m_table))->is_embedded();
     }
 
     query table::query(const std::string& a,

--- a/src/cpprealm/internal/bridge/table.hpp
+++ b/src/cpprealm/internal/bridge/table.hpp
@@ -17,6 +17,12 @@ namespace realm {
         struct query;
 
         struct table {
+            table();
+            table(const table& other) ;
+            table& operator=(const table& other) ;
+            table(table&& other);
+            table& operator=(table&& other);
+            ~table();
             table(const TableRef &);
             table(const ConstTableRef &);
             operator TableRef() const;

--- a/src/cpprealm/internal/bridge/thread_safe_reference.cpp
+++ b/src/cpprealm/internal/bridge/thread_safe_reference.cpp
@@ -26,30 +26,19 @@ namespace realm::internal::bridge {
         new (&m_thread_safe_reference) ThreadSafeReference();
     }
 
-//    thread_safe_reference::thread_safe_reference(const thread_safe_reference& other) {
-//        new (&m_thread_safe_reference) ThreadSafeReference(*reinterpret_cast<const ThreadSafeReference*>(other.m_thread_safe_reference));
-//    }
-//
-//    thread_safe_reference& thread_safe_reference::operator=(const thread_safe_reference& other) {
-//        if (this != &other) {
-//            *reinterpret_cast<ThreadSafeReference*>(m_thread_safe_reference) = *reinterpret_cast<const ThreadSafeReference*>(other.m_thread_safe_reference);
-//        }
-//        return *this;
-//    }
-
     thread_safe_reference::thread_safe_reference(thread_safe_reference&& other) {
-        new (&m_thread_safe_reference) ThreadSafeReference(std::move(*reinterpret_cast<ThreadSafeReference*>(other.m_thread_safe_reference)));
+        new (&m_thread_safe_reference) ThreadSafeReference(std::move(*reinterpret_cast<ThreadSafeReference*>(&other.m_thread_safe_reference)));
     }
 
     thread_safe_reference& thread_safe_reference::operator=(thread_safe_reference&& other) {
         if (this != &other) {
-            *reinterpret_cast<ThreadSafeReference*>(m_thread_safe_reference) = std::move(*reinterpret_cast<ThreadSafeReference*>(other.m_thread_safe_reference));
+            *reinterpret_cast<ThreadSafeReference*>(&m_thread_safe_reference) = std::move(*reinterpret_cast<ThreadSafeReference*>(&other.m_thread_safe_reference));
         }
         return *this;
     }
 
     thread_safe_reference::~thread_safe_reference() {
-        reinterpret_cast<ThreadSafeReference*>(m_thread_safe_reference)->~ThreadSafeReference();
+        reinterpret_cast<ThreadSafeReference*>(&m_thread_safe_reference)->~ThreadSafeReference();
     }
     thread_safe_reference::thread_safe_reference(const object &o) {
         new (&m_thread_safe_reference) ThreadSafeReference(static_cast<Object>(o));
@@ -58,10 +47,10 @@ namespace realm::internal::bridge {
         new (&m_thread_safe_reference) ThreadSafeReference(std::move(v));
     }
     thread_safe_reference::operator bool() const {
-        return reinterpret_cast<const ThreadSafeReference*>(m_thread_safe_reference)->operator bool();
+        return reinterpret_cast<const ThreadSafeReference*>(&m_thread_safe_reference)->operator bool();
     }
     thread_safe_reference::operator ThreadSafeReference&&() {
-        return std::move(*reinterpret_cast<ThreadSafeReference*>(m_thread_safe_reference));
+        return std::move(*reinterpret_cast<ThreadSafeReference*>(&m_thread_safe_reference));
     }
     thread_safe_reference::thread_safe_reference(const dictionary &o) {
         new (&m_thread_safe_reference) ThreadSafeReference(static_cast<Dictionary>(o));

--- a/src/cpprealm/internal/bridge/thread_safe_reference.cpp
+++ b/src/cpprealm/internal/bridge/thread_safe_reference.cpp
@@ -22,6 +22,35 @@ namespace realm::internal::bridge {
     static_assert(SizeCheck<8, sizeof(ThreadSafeReference)>{});
     static_assert(SizeCheck<8, alignof(ThreadSafeReference)>{});
 #endif
+    thread_safe_reference::thread_safe_reference() {
+        new (&m_thread_safe_reference) ThreadSafeReference();
+    }
+
+//    thread_safe_reference::thread_safe_reference(const thread_safe_reference& other) {
+//        new (&m_thread_safe_reference) ThreadSafeReference(*reinterpret_cast<const ThreadSafeReference*>(other.m_thread_safe_reference));
+//    }
+//
+//    thread_safe_reference& thread_safe_reference::operator=(const thread_safe_reference& other) {
+//        if (this != &other) {
+//            *reinterpret_cast<ThreadSafeReference*>(m_thread_safe_reference) = *reinterpret_cast<const ThreadSafeReference*>(other.m_thread_safe_reference);
+//        }
+//        return *this;
+//    }
+
+    thread_safe_reference::thread_safe_reference(thread_safe_reference&& other) {
+        new (&m_thread_safe_reference) ThreadSafeReference(std::move(*reinterpret_cast<ThreadSafeReference*>(other.m_thread_safe_reference)));
+    }
+
+    thread_safe_reference& thread_safe_reference::operator=(thread_safe_reference&& other) {
+        if (this != &other) {
+            *reinterpret_cast<ThreadSafeReference*>(m_thread_safe_reference) = std::move(*reinterpret_cast<ThreadSafeReference*>(other.m_thread_safe_reference));
+        }
+        return *this;
+    }
+
+    thread_safe_reference::~thread_safe_reference() {
+        reinterpret_cast<ThreadSafeReference*>(m_thread_safe_reference)->~ThreadSafeReference();
+    }
     thread_safe_reference::thread_safe_reference(const object &o) {
         new (&m_thread_safe_reference) ThreadSafeReference(static_cast<Object>(o));
     }

--- a/src/cpprealm/internal/bridge/thread_safe_reference.hpp
+++ b/src/cpprealm/internal/bridge/thread_safe_reference.hpp
@@ -12,6 +12,12 @@ namespace realm::internal::bridge {
     struct realm;
 
     struct thread_safe_reference {
+        thread_safe_reference();
+        thread_safe_reference(const thread_safe_reference& other) = delete;
+        thread_safe_reference& operator=(const thread_safe_reference& other) = delete;
+        thread_safe_reference(thread_safe_reference&& other);
+        thread_safe_reference& operator=(thread_safe_reference&& other);
+        ~thread_safe_reference();
         thread_safe_reference(const object&);
         thread_safe_reference(const dictionary&);
         thread_safe_reference(ThreadSafeReference&&);

--- a/src/cpprealm/internal/bridge/timestamp.cpp
+++ b/src/cpprealm/internal/bridge/timestamp.cpp
@@ -17,6 +17,36 @@ namespace realm::internal::bridge {
     static_assert(SizeCheck<8, alignof(Timestamp)>{});
 #endif
 
+    timestamp::timestamp() {
+        new (&m_timestamp) Timestamp();
+    }
+
+    timestamp::timestamp(const timestamp& other) {
+        new (&m_timestamp) Timestamp(*reinterpret_cast<const Timestamp*>(other.m_timestamp));
+    }
+
+    timestamp& timestamp::operator=(const timestamp& other) {
+        if (this != &other) {
+            *reinterpret_cast<Timestamp*>(m_timestamp) = *reinterpret_cast<const Timestamp*>(other.m_timestamp);
+        }
+        return *this;
+    }
+
+    timestamp::timestamp(timestamp&& other) {
+        new (&m_timestamp) Timestamp(std::move(*reinterpret_cast<Timestamp*>(other.m_timestamp)));
+    }
+
+    timestamp& timestamp::operator=(timestamp&& other) {
+        if (this != &other) {
+            *reinterpret_cast<Timestamp*>(m_timestamp) = std::move(*reinterpret_cast<Timestamp*>(other.m_timestamp));
+        }
+        return *this;
+    }
+
+    timestamp::~timestamp() {
+        reinterpret_cast<Timestamp*>(m_timestamp)->~Timestamp();
+    }
+
     timestamp::timestamp(const realm::Timestamp &v) {
         new (&m_timestamp) Timestamp(v);
     }
@@ -37,10 +67,6 @@ namespace realm::internal::bridge {
 
     int32_t timestamp::get_nanoseconds() const noexcept {
         return reinterpret_cast<const Timestamp*>(m_timestamp)->get_nanoseconds();
-    }
-
-    timestamp::timestamp() {
-        new (&m_timestamp) Timestamp();
     }
 
     timestamp::operator Timestamp() const {

--- a/src/cpprealm/internal/bridge/timestamp.cpp
+++ b/src/cpprealm/internal/bridge/timestamp.cpp
@@ -22,29 +22,29 @@ namespace realm::internal::bridge {
     }
 
     timestamp::timestamp(const timestamp& other) {
-        new (&m_timestamp) Timestamp(*reinterpret_cast<const Timestamp*>(other.m_timestamp));
+        new (&m_timestamp) Timestamp(*reinterpret_cast<const Timestamp*>(&other.m_timestamp));
     }
 
     timestamp& timestamp::operator=(const timestamp& other) {
         if (this != &other) {
-            *reinterpret_cast<Timestamp*>(m_timestamp) = *reinterpret_cast<const Timestamp*>(other.m_timestamp);
+            *reinterpret_cast<Timestamp*>(&m_timestamp) = *reinterpret_cast<const Timestamp*>(&other.m_timestamp);
         }
         return *this;
     }
 
     timestamp::timestamp(timestamp&& other) {
-        new (&m_timestamp) Timestamp(std::move(*reinterpret_cast<Timestamp*>(other.m_timestamp)));
+        new (&m_timestamp) Timestamp(std::move(*reinterpret_cast<Timestamp*>(&other.m_timestamp)));
     }
 
     timestamp& timestamp::operator=(timestamp&& other) {
         if (this != &other) {
-            *reinterpret_cast<Timestamp*>(m_timestamp) = std::move(*reinterpret_cast<Timestamp*>(other.m_timestamp));
+            *reinterpret_cast<Timestamp*>(&m_timestamp) = std::move(*reinterpret_cast<Timestamp*>(&other.m_timestamp));
         }
         return *this;
     }
 
     timestamp::~timestamp() {
-        reinterpret_cast<Timestamp*>(m_timestamp)->~Timestamp();
+        reinterpret_cast<Timestamp*>(&m_timestamp)->~Timestamp();
     }
 
     timestamp::timestamp(const realm::Timestamp &v) {
@@ -58,19 +58,19 @@ namespace realm::internal::bridge {
         new (&m_timestamp) Timestamp(tp);
     }
     timestamp::operator std::chrono::time_point<std::chrono::system_clock>() const {
-        return reinterpret_cast<const Timestamp*>(m_timestamp)->get_time_point();
+        return reinterpret_cast<const Timestamp*>(&m_timestamp)->get_time_point();
     }
 
     int64_t timestamp::get_seconds() const noexcept {
-        return reinterpret_cast<const Timestamp*>(m_timestamp)->get_seconds();
+        return reinterpret_cast<const Timestamp*>(&m_timestamp)->get_seconds();
     }
 
     int32_t timestamp::get_nanoseconds() const noexcept {
-        return reinterpret_cast<const Timestamp*>(m_timestamp)->get_nanoseconds();
+        return reinterpret_cast<const Timestamp*>(&m_timestamp)->get_nanoseconds();
     }
 
     timestamp::operator Timestamp() const {
-        return *reinterpret_cast<const Timestamp*>(m_timestamp);
+        return *reinterpret_cast<const Timestamp*>(&m_timestamp);
     }
 
 

--- a/src/cpprealm/internal/bridge/timestamp.hpp
+++ b/src/cpprealm/internal/bridge/timestamp.hpp
@@ -10,6 +10,11 @@ namespace realm {
 namespace realm::internal::bridge {
     struct timestamp : core_binding<Timestamp> {
         timestamp();
+        timestamp(const timestamp& other) ;
+        timestamp& operator=(const timestamp& other) ;
+        timestamp(timestamp&& other);
+        timestamp& operator=(timestamp&& other);
+        ~timestamp();
         timestamp(const Timestamp&); //NOLINT(google-explicit-constructor)
         operator Timestamp() const final; //NOLINT(google-explicit-constructor)
         operator std::chrono::time_point<std::chrono::system_clock>() const; //NOLINT(google-explicit-constructor)

--- a/src/cpprealm/internal/bridge/uuid.cpp
+++ b/src/cpprealm/internal/bridge/uuid.cpp
@@ -21,29 +21,29 @@ namespace realm::internal::bridge {
         new (&m_uuid) UUID();
     }
     uuid::uuid(const uuid& other) {
-        new (&m_uuid) UUID(*reinterpret_cast<const UUID*>(other.m_uuid));
+        new (&m_uuid) UUID(*reinterpret_cast<const UUID*>(&other.m_uuid));
     }
 
     uuid& uuid::operator=(const uuid& other) {
         if (this != &other) {
-            *reinterpret_cast<UUID*>(m_uuid) = *reinterpret_cast<const UUID*>(other.m_uuid);
+            *reinterpret_cast<UUID*>(&m_uuid) = *reinterpret_cast<const UUID*>(&other.m_uuid);
         }
         return *this;
     }
 
     uuid::uuid(uuid&& other) {
-        new (&m_uuid) UUID(std::move(*reinterpret_cast<UUID*>(other.m_uuid)));
+        new (&m_uuid) UUID(std::move(*reinterpret_cast<UUID*>(&other.m_uuid)));
     }
 
     uuid& uuid::operator=(uuid&& other) {
         if (this != &other) {
-            *reinterpret_cast<UUID*>(m_uuid) = std::move(*reinterpret_cast<UUID*>(other.m_uuid));
+            *reinterpret_cast<UUID*>(&m_uuid) = std::move(*reinterpret_cast<UUID*>(&other.m_uuid));
         }
         return *this;
     }
 
     uuid::~uuid() {
-        reinterpret_cast<UUID*>(m_uuid)->~UUID();
+        reinterpret_cast<UUID*>(&m_uuid)->~UUID();
     }
     uuid::uuid(const std::string &v) {
         new (&m_uuid) UUID(v);
@@ -57,7 +57,7 @@ namespace realm::internal::bridge {
     }
 
     std::string uuid::to_string() const {
-        return reinterpret_cast<const UUID*>(m_uuid)->to_string();
+        return reinterpret_cast<const UUID*>(&m_uuid)->to_string();
     }
 
     uuid::operator ::realm::uuid() const {
@@ -65,15 +65,15 @@ namespace realm::internal::bridge {
     }
 
     uuid::operator UUID() const {
-        return *reinterpret_cast<const UUID*>(m_uuid);
+        return *reinterpret_cast<const UUID*>(&m_uuid);
     }
 
     std::string uuid::to_base64() const {
-        return reinterpret_cast<const UUID*>(m_uuid)->to_base64();
+        return reinterpret_cast<const UUID*>(&m_uuid)->to_base64();
     }
 
     std::array<uint8_t, 16> uuid::to_bytes() const {
-        return reinterpret_cast<const UUID*>(m_uuid)->to_bytes();
+        return reinterpret_cast<const UUID*>(&m_uuid)->to_bytes();
     }
 
 #define __cpp_realm_gen_uuid_op(op) \

--- a/src/cpprealm/internal/bridge/uuid.cpp
+++ b/src/cpprealm/internal/bridge/uuid.cpp
@@ -20,6 +20,31 @@ namespace realm::internal::bridge {
     uuid::uuid() {
         new (&m_uuid) UUID();
     }
+    uuid::uuid(const uuid& other) {
+        new (&m_uuid) UUID(*reinterpret_cast<const UUID*>(other.m_uuid));
+    }
+
+    uuid& uuid::operator=(const uuid& other) {
+        if (this != &other) {
+            *reinterpret_cast<UUID*>(m_uuid) = *reinterpret_cast<const UUID*>(other.m_uuid);
+        }
+        return *this;
+    }
+
+    uuid::uuid(uuid&& other) {
+        new (&m_uuid) UUID(std::move(*reinterpret_cast<UUID*>(other.m_uuid)));
+    }
+
+    uuid& uuid::operator=(uuid&& other) {
+        if (this != &other) {
+            *reinterpret_cast<UUID*>(m_uuid) = std::move(*reinterpret_cast<UUID*>(other.m_uuid));
+        }
+        return *this;
+    }
+
+    uuid::~uuid() {
+        reinterpret_cast<UUID*>(m_uuid)->~UUID();
+    }
     uuid::uuid(const std::string &v) {
         new (&m_uuid) UUID(v);
     }

--- a/src/cpprealm/internal/bridge/uuid.hpp
+++ b/src/cpprealm/internal/bridge/uuid.hpp
@@ -12,6 +12,11 @@ namespace realm {
 namespace realm::internal::bridge {
     struct uuid : core_binding<UUID> {
         uuid();
+        uuid(const uuid& other) ;
+        uuid& operator=(const uuid& other) ;
+        uuid(uuid&& other);
+        uuid& operator=(uuid&& other);
+        ~uuid();
         uuid(const UUID&); //NOLINT(google-explicit-constructor);
         explicit uuid(const std::string&);
         uuid(const struct ::realm::uuid&); //NOLINT(google-explicit-constructor);

--- a/src/cpprealm/persisted_list.hpp
+++ b/src/cpprealm/persisted_list.hpp
@@ -99,6 +99,10 @@ namespace realm {
                 *this = v;
             }
             persisted_list_base& operator=(const persisted_list_base& v) {
+                if (this->m_object) {
+                    reinterpret_cast<bridge::list*>(&m_list)->~list();
+                }
+
                 if (v.is_managed()) {
                     this->m_object = v.m_object;
                     new (&m_list) bridge::list(v.m_list);

--- a/src/cpprealm/persisted_list.hpp
+++ b/src/cpprealm/persisted_list.hpp
@@ -94,12 +94,6 @@ namespace realm {
                 if (this->is_managed()) m_list.remove_all();
                 else this->unmanaged.clear();
             }
-            persisted_list_base(persisted_list_base&& v) {
-                abort();
-            }
-            persisted_list_base& operator=(persisted_list_base&& v) {
-                abort();
-            }
 
             persisted_list_base(const persisted_list_base& v) {
                 *this = v;

--- a/src/cpprealm/persisted_list.hpp
+++ b/src/cpprealm/persisted_list.hpp
@@ -145,13 +145,13 @@ namespace realm {
             }
             void assign_accessor(internal::bridge::object *object,
                                  internal::bridge::col_key &&col_key) final {
+                // We need to free what was previously stored.
                 if (this->m_object) {
                     reinterpret_cast<bridge::list*>(&m_list)->~list();
                 } else {
                     reinterpret_cast<T*>(&unmanaged)->~T();
                 }
                 this->m_object = *object;
-
                 new (&m_list) bridge::list(object->get_list(std::move(col_key)));
             }
 

--- a/src/cpprealm/persisted_map.hpp
+++ b/src/cpprealm/persisted_map.hpp
@@ -114,6 +114,8 @@ namespace realm {
             }
         }
         ~persisted_map_base() {
+            if (this->should_detect_usage_for_queries)
+                return;
             if (this->is_managed()) {
                 this->managed.~dictionary();
             } else {

--- a/src/cpprealm/persisted_mixed.hpp
+++ b/src/cpprealm/persisted_mixed.hpp
@@ -85,8 +85,9 @@ namespace realm {
                 case internal::bridge::data_type::Int: return value.operator int64_t();
                 case internal::bridge::data_type::Bool: return value.operator bool();
                 case internal::bridge::data_type::String: return static_cast<std::string>(value);
-                case internal::bridge::data_type::Binary:
+                case internal::bridge::data_type::Binary: {
                     return static_cast<std::vector<uint8_t>>(static_cast<internal::bridge::binary>(value));
+                }
                 case internal::bridge::data_type::Timestamp: return static_cast<internal::bridge::timestamp>(value);
                 case internal::bridge::data_type::Float:
                 case internal::bridge::data_type::Double: return static_cast<double>(value);

--- a/src/cpprealm/persisted_mixed.hpp
+++ b/src/cpprealm/persisted_mixed.hpp
@@ -63,7 +63,7 @@ namespace realm {
         }
     protected:
         static internal::bridge::mixed serialize(const T& value, const std::optional<internal::bridge::realm>& realm = std::nullopt) {
-            return std::visit([&realm](auto& arg) {
+            return std::visit([&realm](auto&& arg) {
                 using M = std::decay_t<decltype(arg)>;
                 if constexpr (std::is_base_of<object_base<M>, M>::value) {
                     internal::bridge::realm r = *realm;
@@ -73,7 +73,7 @@ namespace realm {
                     const_cast<M&>(arg).manage(table, r);
                     return internal::bridge::mixed(const_cast<M&>(arg).m_object->get_obj().get_link());
                 } else {
-                    return internal::bridge::mixed(static_cast<M>(arg));
+                    return internal::bridge::mixed(static_cast<M>(std::move(arg)));
                 }
             }, value);
         }

--- a/src/cpprealm/persisted_mixed.hpp
+++ b/src/cpprealm/persisted_mixed.hpp
@@ -85,9 +85,8 @@ namespace realm {
                 case internal::bridge::data_type::Int: return value.operator int64_t();
                 case internal::bridge::data_type::Bool: return value.operator bool();
                 case internal::bridge::data_type::String: return static_cast<std::string>(value);
-                case internal::bridge::data_type::Binary: {
+                case internal::bridge::data_type::Binary:
                     return static_cast<std::vector<uint8_t>>(static_cast<internal::bridge::binary>(value));
-                }
                 case internal::bridge::data_type::Timestamp: return static_cast<internal::bridge::timestamp>(value);
                 case internal::bridge::data_type::Float:
                 case internal::bridge::data_type::Double: return static_cast<double>(value);

--- a/src/cpprealm/scheduler.hpp
+++ b/src/cpprealm/scheduler.hpp
@@ -6,6 +6,13 @@
 #include <queue>
 
 namespace realm {
+namespace util {
+    template <typename Function>
+    class UniqueFunction;
+}
+
+template <typename Fn>
+using Function = util::UniqueFunction<Fn>;
 
     struct scheduler {
         static std::shared_ptr<scheduler> make_default();
@@ -15,7 +22,7 @@ namespace realm {
         // Invoke the given function on the scheduler's thread.
         //
         // This function can be called from any thread.
-        virtual void invoke(std::function<void()> &&) = 0;
+        virtual void invoke(Function<void()> &&) = 0;
 
         // Check if the caller is currently running on the scheduler's thread.
         //
@@ -34,166 +41,6 @@ namespace realm {
         //
         // This function is not thread-safe.
         [[nodiscard]] virtual bool can_invoke() const noexcept = 0;
-    };
-
-    struct looper {
-        using task = std::packaged_task<void()>;
-        std::queue<task> tasks;
-        std::atomic<bool> is_running = true;
-        bool is_moved = false;
-
-        looper(const looper &) = delete;
-
-        looper(looper &&l) noexcept
-                : tasks(std::move(l.tasks)), t(std::move(l.t)) {
-            l.is_moved = true;
-        }
-
-        ~looper() {
-            if (!is_moved) {
-                is_running = false;
-                t.join();
-            }
-        }
-
-        looper() {
-            t = std::thread([&] {
-                while (is_running) {
-                    if (size()) {
-                        front()();
-                        pop();
-                    }
-                }
-            });
-        }
-
-        task &front() {
-            std::lock_guard<std::mutex> lock(m_mutex);
-            return tasks.front();
-        }
-
-        size_t size() {
-            std::lock_guard<std::mutex> lock(m_mutex);
-            return tasks.size();
-        }
-
-        task &push(task &&value) {
-            std::lock_guard<std::mutex> lock(m_mutex);
-            tasks.push(std::move(value));
-            return tasks.front();
-        }
-
-        task &push(std::function<void()> &&value) {
-            std::lock_guard<std::mutex> lock(m_mutex);
-            tasks.push(std::packaged_task<void()>(std::move(value)));
-            return tasks.front();
-        }
-
-        void pop() {
-            std::lock_guard<std::mutex> lock(m_mutex);
-            tasks.pop();
-        }
-
-        std::thread t;
-        mutable std::mutex m_mutex;
-    };
-
-    struct NoPlatformScheduler : public scheduler {
-        static inline std::shared_ptr<scheduler> make() {
-            return std::make_shared<NoPlatformScheduler>();
-        };
-
-        NoPlatformScheduler() = default;
-
-        NoPlatformScheduler(const NoPlatformScheduler &) = delete;
-
-        NoPlatformScheduler(NoPlatformScheduler &&l) noexcept
-                : l(std::move(l.l)) {
-        }
-
-        looper l;
-
-        void invoke(std::function<void()> &&f) override {
-            l.push(std::packaged_task<void()>([f = std::move(f)] {
-                f();
-            }));
-        }
-
-        // Check if the caller is currently running on the scheduler's thread.
-        //
-        // This function can be called from any thread.
-        bool is_on_thread() const noexcept override {
-//            if (!m_thread) {
-//                return false;
-//            }
-            return l.t.get_id() == std::this_thread::get_id();
-        }
-
-        // Checks if this scheduler instance wraps the same underlying instance.
-        // This is up to the platforms to define, but if this method returns true,
-        // caching may occur.
-        bool is_same_as(const scheduler *other) const noexcept override {
-            return true;
-        }
-
-        // Check if this scehduler actually can support invoke(). Invoking may be
-        // either not implemented, not applicable to a scheduler type, or simply not
-        // be possible currently (e.g. if the associated event loop is not actually
-        // running).
-        //
-        // This function is not thread-safe.
-        bool can_invoke() const noexcept override { return true; }
-    };
-
-    struct this_thread_scheduler : public scheduler {
-        static inline std::shared_ptr<scheduler> make() {
-            return std::make_shared<this_thread_scheduler>();
-        };
-
-        std::thread::id m_id = std::this_thread::get_id();
-        this_thread_scheduler() = default;
-
-        this_thread_scheduler(const NoPlatformScheduler &) = delete;
-//
-//        NoPlatformScheduler(NoPlatformScheduler &&l) noexcept
-//                : l(std::move(l.l)) {
-//        }
-
-//        looper l;
-
-        void invoke(std::function<void()> &&f) override {
-            f();
-//            l.push(std::packaged_task<void()>([f = std::move(f)] {
-//                f();
-//            }));
-        }
-
-        // Check if the caller is currently running on the scheduler's thread.
-        //
-        // This function can be called from any thread.
-        bool is_on_thread() const noexcept override {
-            return std::this_thread::get_id() == m_id;
-//            if (!m_thread) {
-//                return false;
-//            }
-//            return l.t.get_id() == std::this_thread::get_id();
-
-        }
-
-        // Checks if this scheduler instance wraps the same underlying instance.
-        // This is up to the platforms to define, but if this method returns true,
-        // caching may occur.
-        bool is_same_as(const scheduler *other) const noexcept override {
-            return true;
-        }
-
-        // Check if this scehduler actually can support invoke(). Invoking may be
-        // either not implemented, not applicable to a scheduler type, or simply not
-        // be possible currently (e.g. if the associated event loop is not actually
-        // running).
-        //
-        // This function is not thread-safe.
-        bool can_invoke() const noexcept override { return true; }
     };
 }
 #endif //CPP_REALM_SCHEDULER_HPP

--- a/tests/admin_utils.cpp
+++ b/tests/admin_utils.cpp
@@ -260,7 +260,7 @@ struct RealmServer {
     RealmServer() = default;
 public:
     static void setup() {
-        if (system("./evergreen/install_baas.sh -w baas -b master") == -1) {
+        if (system("./Debug/evergreen/install_baas.sh -w baas -b master") == -1) {
             REALM_TERMINATE("Failed to run setup_baas.rb");
         }
     }

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -38,7 +38,7 @@ int main(int argc, char* argv[]) {
 #else
         config.showDurations = Catch::ShowDurations::Always; // this is to help debug hangs
 //        config.testsOrTags.emplace_back("~[performance]");
-        Admin::shared().cache_app_id(Admin::shared().create_app({"str_col", "_id"}));
+//        Admin::shared().cache_app_id(Admin::shared().create_app({"str_col", "_id"}));
 #endif
     }
 

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -38,7 +38,7 @@ int main(int argc, char* argv[]) {
 #else
         config.showDurations = Catch::ShowDurations::Always; // this is to help debug hangs
 //        config.testsOrTags.emplace_back("~[performance]");
-//        Admin::shared().cache_app_id(Admin::shared().create_app({"str_col", "_id"}));
+        Admin::shared().cache_app_id(Admin::shared().create_app({"str_col", "_id"}));
 #endif
     }
 

--- a/tests/map_tests.cpp
+++ b/tests/map_tests.cpp
@@ -7,6 +7,10 @@ TEST_CASE("map", "[map]") {
     realm_path path;
     SECTION("unmanaged_managed_map_get_set", "[mixed]") {
         auto obj = AllTypesObject();
+        auto link = AllTypesObjectLink();
+        link.str_col = "foo";
+        auto embedded = AllTypesObjectEmbedded();
+        embedded.str_col = "bar";
         obj.map_int_col = {
             {"a", 42}
         };
@@ -29,10 +33,10 @@ TEST_CASE("map", "[map]") {
                 {"a", std::chrono::system_clock::now()}
         };
         obj.map_link_col = {
-                {"a", AllTypesObjectLink()}
+                {"a", link}
         };
         obj.map_embedded_col = {
-                {"a", AllTypesObjectEmbedded()}
+                {"a", embedded}
         };
         CHECK(obj.map_int_col["a"] == 42);
         CHECK(obj.map_str_col["a"] == "foo");
@@ -52,18 +56,25 @@ TEST_CASE("map", "[map]") {
         CHECK(obj.map_enum_col["a"] == AllTypesObject::Enum::one);
         CHECK(obj.map_uuid_col["a"] == realm::uuid());
         CHECK(obj.map_binary_col["a"] == std::vector<uint8_t>{0, 1, 2});
-        CHECK(obj.map_link_col["a"] == AllTypesObjectLink());
-        CHECK(obj.map_embedded_col["a"] == AllTypesObjectEmbedded());
+        CHECK(obj.map_link_col["a"] == link);
+        CHECK(obj.map_embedded_col["a"] == embedded);
+        CHECK((*obj.map_link_col["a"])->str_col == "foo");
+        CHECK((*obj.map_embedded_col["a"])->str_col == "bar");
 
-        realm.write([&obj] {
+        auto link2 = AllTypesObjectLink();
+        link2.str_col = "foo";
+        auto embedded2 = AllTypesObjectEmbedded();
+        embedded2.str_col = "bar";
+
+        realm.write([&obj, &link2, &embedded2] {
             obj.map_int_col["b"] = 84;
             obj.map_str_col["b"] = "bar";
             obj.map_bool_col["b"] = true;
             obj.map_enum_col["b"] = AllTypesObject::Enum::two;
             obj.map_uuid_col["b"] = realm::uuid();
             obj.map_binary_col["b"] = std::vector<uint8_t>{3,4,5};
-            obj.map_link_col["b"] = AllTypesObjectLink();
-            obj.map_embedded_col["b"] = AllTypesObjectEmbedded();
+            obj.map_link_col["b"] = link2;
+            obj.map_embedded_col["b"] = embedded2;
         });
         CHECK(obj.map_int_col["a"] == 42);
         CHECK(obj.map_int_col["b"] == 84);
@@ -77,8 +88,12 @@ TEST_CASE("map", "[map]") {
         CHECK(obj.map_uuid_col["b"] == realm::uuid());
         CHECK(obj.map_binary_col["a"] == std::vector<uint8_t>{0, 1, 2});
         CHECK(obj.map_binary_col["b"] == std::vector<uint8_t>{3, 4, 5});
-        CHECK(obj.map_link_col["b"] == AllTypesObjectLink());
-        CHECK(obj.map_embedded_col["b"] == AllTypesObjectEmbedded());
+        CHECK(obj.map_link_col["a"] == link);
+        CHECK(obj.map_embedded_col["a"] == embedded);
+        CHECK(obj.map_link_col["b"] == link2);
+        CHECK(obj.map_embedded_col["b"] == embedded2);
+        CHECK((*obj.map_link_col["b"])->str_col == "foo");
+        CHECK((*obj.map_embedded_col["b"])->str_col == "bar");
 
         realm.write([&obj] {
             obj.map_link_col["b"] = std::nullopt;

--- a/tests/run_loop_tests.cpp
+++ b/tests/run_loop_tests.cpp
@@ -16,15 +16,15 @@
 
 class InvocationQueue {
 public:
-    void push(std::function<void()>&&);
+    void push(realm::Function<void()>&&);
     void invoke_all();
 
 private:
     std::mutex m_mutex;
-    std::vector<std::function<void()>> m_functions;
+    std::vector<realm::Function<void()>> m_functions;
 };
 
-void InvocationQueue::push(std::function<void()>&& fn)
+void InvocationQueue::push(realm::Function<void()>&& fn)
 {
     std::lock_guard lock(m_mutex);
     m_functions.push_back(std::move(fn));
@@ -32,7 +32,7 @@ void InvocationQueue::push(std::function<void()>&& fn)
 
 void InvocationQueue::invoke_all()
 {
-    std::vector<std::function<void()>> functions;
+    std::vector<realm::Function<void()>> functions;
     {
         std::lock_guard lock(m_mutex);
         functions.swap(m_functions);
@@ -54,7 +54,7 @@ public:
     RunLoopScheduler(CFRunLoopRef run_loop = nullptr);
     ~RunLoopScheduler();
 
-    void invoke(std::function<void()>&&) override;
+    void invoke(realm::Function<void()>&&) override;
 
     bool is_on_thread() const noexcept override;
     bool is_same_as(const scheduler* other) const noexcept override;
@@ -103,7 +103,7 @@ RunLoopScheduler::~RunLoopScheduler()
     CFRelease(m_runloop);
 }
 
-void RunLoopScheduler::invoke(std::function<void()>&& fn)
+void RunLoopScheduler::invoke(realm::Function<void()>&& fn)
 {
     m_queue.queue.push(std::move(fn));
 
@@ -182,7 +182,7 @@ public:
         return true;
     }
 
-    void invoke(std::function<void()> &&fn) override {
+    void invoke(realm::Function<void()> &&fn) override {
         auto &data = *static_cast<Data *>(m_handle->data);
         data.queue.push(std::move(fn));
         uv_async_send(m_handle.get());


### PR DESCRIPTION
- Xcode reported leaks on types using std::aligned_storage due to them not implementing the rule of 5.
- Bumps core to 13.9.2
- Schedulers were being compared by `std::thread::id` which did not work in some scenarios due to certain execution contexts allowing a `std::thread::id` to be reused once a thread is no longer used. Instead forward the scheduler::is_same_as call to Core which uses the default platform internals to compare (i.e CFRunLoop)