### PR TITLE
Add support for Windows in Release configuration

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -472,8 +472,6 @@ jobs:
         configuration:
           - Debug
           - Release
-        exclude:
-          - configuration: ${{ (github.event_name == 'pull_request' && 'Release') || 'none' }}
     needs:
       - deploy-cluster
     env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-0.2.0 Preview Release notes (2023-06-21)
+x.y.z Release notes (yyyy-MM-dd)
 =============================================================
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,30 @@
 0.2.0 Preview Release notes (2023-06-21)
 =============================================================
 
+### Fixed
+* Windows would not compile under Release build configuration as `aligned_storage` parameters were
+  incorrectly set.
+
+### Enhancements
+* None
+
+### Other API enhancements:
+* None
+
+### Breaking Changes
+* None
+
+### Compatibility
+* Fileformat: Generates files with format v22.
+
+### Internals
+* None
+
+----------------------------------------------
+
+0.2.0 Preview Release notes (2023-06-21)
+=============================================================
+
 ### Enhancements
 This preview introduces a new way to declare your object model, bringing you closer to feeling like you're interfacing with POCO's.
 ```

--- a/examples/windows/CMakeLists.txt
+++ b/examples/windows/CMakeLists.txt
@@ -16,7 +16,7 @@ Include(FetchContent)
 FetchContent_Declare(
   cpprealm
   GIT_REPOSITORY https://github.com/realm/realm-cpp.git
-  GIT_TAG        b6c2b8be5b620c92eaa8ba76d96d2d16ea73501a
+  GIT_TAG        origin/main
 
 )
 

--- a/examples/windows/helloworld.cpp
+++ b/examples/windows/helloworld.cpp
@@ -2,7 +2,7 @@
 #include <cpprealm/sdk.hpp>
 #include <cpprealm/experimental/sdk.hpp>
 
-#if REALM_HAVE_UV
+#if _WIN32
 #include <uv.h>
 #elif REALM_PLATFORM_APPLE
 #include <realm/util/cf_ptr.hpp>
@@ -68,7 +68,7 @@ int main() {
     // time to push the changes. If you prefer a synchronous approach you can do
     // `synced_realm.get_sync_session()->wait_for_upload_completion().get();`
 
-#if REALM_HAVE_UV
+#if _WIN32
     uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 #elif REALM_PLATFORM_APPLE
     CFRunLoopRun();

--- a/src/cpprealm/app.cpp
+++ b/src/cpprealm/app.cpp
@@ -39,9 +39,14 @@ namespace realm {
 #endif
     static_assert(internal::bridge::SizeCheck<8, alignof(realm::app::AppError)>{});
 #elif _WIN32
+    #if _DEBUG
+    static_assert(internal::bridge::SizeCheck<80, sizeof(realm::app::AppError)>{});
+    #else
+    static_assert(internal::bridge::SizeCheck<72, sizeof(realm::app::AppError)>{});
+    #endif
     static_assert(internal::bridge::SizeCheck<16, sizeof(realm::app::AppCredentials)>{});
     static_assert(internal::bridge::SizeCheck<8, alignof(realm::app::AppCredentials)>{});
-    static_assert(internal::bridge::SizeCheck<80, sizeof(realm::app::AppError)>{});
+    
     static_assert(internal::bridge::SizeCheck<8, alignof(realm::app::AppError)>{});
 #endif
 

--- a/src/cpprealm/app.hpp
+++ b/src/cpprealm/app.hpp
@@ -73,7 +73,11 @@ private:
 #ifdef __i386__
     std::aligned_storage<28, 4>::type m_error[1];
 #elif _WIN32
+    #if _DEBUG
     std::aligned_storage<80, 8>::type m_error[1];
+    #else
+    std::aligned_storage<72, 8>::type m_error[1];
+    #endif   
 #elif __x86_64__
     #if defined(__clang__)
 std::aligned_storage<48, 8>::type m_error[1];

--- a/src/cpprealm/experimental/accessors.hpp
+++ b/src/cpprealm/experimental/accessors.hpp
@@ -238,7 +238,7 @@ namespace realm::experimental {
                 internal::bridge::obj m_obj;
                 if constexpr (managed<T>::schema.HasPrimaryKeyProperty) {
                     auto pk = (*lnk).*(managed<T>::schema.primary_key().ptr);
-                    m_obj = table.create_object_with_primary_key(serialize(pk.value));
+                    m_obj = table.create_object_with_primary_key(realm::internal::bridge::mixed(serialize(pk.value)));
                 } else if (managed<T>::schema.is_embedded_experimental()) {
                     m_obj = list.create_and_insert_linked_object(i);
                 } else {
@@ -329,7 +329,7 @@ namespace realm::experimental {
             internal::bridge::obj m_obj;
             if constexpr (managed<T>::schema.HasPrimaryKeyProperty) {
                 auto pk = (*value).*(managed<T>::schema.primary_key().ptr);
-                m_obj = table.create_object_with_primary_key(serialize(pk.value));
+                m_obj = table.create_object_with_primary_key(realm::internal::bridge::mixed(serialize(pk.value)));
                 obj.set(key, m_obj.get_key());
             } else if (managed<T>::schema.is_embedded_experimental()) {
                 m_obj = obj.create_and_set_linked_object(key);

--- a/src/cpprealm/experimental/db.hpp
+++ b/src/cpprealm/experimental/db.hpp
@@ -85,7 +85,7 @@ namespace realm::experimental {
                 internal::bridge::obj m_obj;
                 if constexpr (managed<T>::schema.HasPrimaryKeyProperty) {
                     auto pk = obj.*(managed<T>::schema.primary_key().ptr);
-                    m_obj = table.create_object_with_primary_key(serialize(pk.value));
+                    m_obj = table.create_object_with_primary_key(realm::internal::bridge::mixed(serialize(pk.value)));
                 } else {
                     m_obj = table.create_object();
                 }
@@ -274,7 +274,7 @@ namespace realm::experimental {
                 internal::bridge::obj m_obj;
                 if constexpr (managed<T>::schema.HasPrimaryKeyProperty) {
                     auto pk = obj.*(managed<T>::schema.primary_key().ptr);
-                    m_obj = table.create_object_with_primary_key(serialize(pk.value));
+                    m_obj = table.create_object_with_primary_key(realm::internal::bridge::mixed(serialize(pk.value)));
                 } else {
                     m_obj = table.create_object();
                 }

--- a/src/cpprealm/experimental/link.hpp
+++ b/src/cpprealm/experimental/link.hpp
@@ -59,7 +59,7 @@ namespace realm {
                     return *this;
                 } else if constexpr (managed<T>::schema.HasPrimaryKeyProperty) {
                     auto pk = (*o).*(managed<T>::schema.primary_key().ptr);
-                    obj = table.create_object_with_primary_key(pk.value);
+                    obj = table.create_object_with_primary_key(realm::internal::bridge::mixed(serialize(pk.value)));
                     m_obj->set(m_key, obj.get_key());
                 } else if (managed<T>::schema.is_embedded_experimental()) {
                     obj = m_obj->create_and_set_linked_object(m_key);

--- a/src/cpprealm/experimental/managed_list.hpp
+++ b/src/cpprealm/experimental/managed_list.hpp
@@ -137,7 +137,7 @@ namespace realm::experimental {
             internal::bridge::obj m_obj;
             if constexpr (managed<T>::schema.HasPrimaryKeyProperty) {
                 auto pk = (*value).*(managed<T>::schema.primary_key().ptr);
-                m_obj = table.create_object_with_primary_key(serialize(pk.value));
+                m_obj = table.create_object_with_primary_key(realm::internal::bridge::mixed(serialize(pk.value)));
             } else if (managed<T>::schema.is_embedded_experimental()) {
                 m_obj = list.add_embedded();
             } else {

--- a/src/cpprealm/flex_sync.cpp
+++ b/src/cpprealm/flex_sync.cpp
@@ -34,10 +34,16 @@ namespace realm {
     static_assert(internal::bridge::SizeCheck<8, alignof(sync::SubscriptionSet)>{});
     static_assert(internal::bridge::SizeCheck<8, alignof(sync::MutableSubscriptionSet)>{});
 #elif _WIN32
-    static_assert(internal::bridge::SizeCheck<120, sizeof(sync::SubscriptionSet)>{});
     static_assert(internal::bridge::SizeCheck<8, alignof(sync::SubscriptionSet)>{});
-    static_assert(internal::bridge::SizeCheck<208, sizeof(sync::MutableSubscriptionSet)>{});
     static_assert(internal::bridge::SizeCheck<8, alignof(sync::MutableSubscriptionSet)>{});
+
+    #if _DEBUG
+    static_assert(internal::bridge::SizeCheck<120, sizeof(sync::SubscriptionSet)>{});
+    static_assert(internal::bridge::SizeCheck<208, sizeof(sync::MutableSubscriptionSet)>{});
+    #else
+    static_assert(internal::bridge::SizeCheck<104, sizeof(sync::SubscriptionSet)>{});
+    static_assert(internal::bridge::SizeCheck<192, sizeof(sync::MutableSubscriptionSet)>{});
+    #endif
 #endif
     sync_subscription::sync_subscription(const sync::Subscription &v)
     {

--- a/src/cpprealm/flex_sync.hpp
+++ b/src/cpprealm/flex_sync.hpp
@@ -174,7 +174,11 @@ namespace realm {
         std::aligned_storage<192, 8>::type m_subscription_set[1];
 #endif
 #elif _WIN32
+        #if _DEBUG
         std::aligned_storage<208, 8>::type m_subscription_set[1];
+        #else
+        std::aligned_storage<192, 8>::type m_subscription_set[1];
+        #endif
 #endif
         std::reference_wrapper<internal::bridge::realm> m_realm;
         friend struct sync_subscription_set;
@@ -220,7 +224,11 @@ namespace realm {
         std::aligned_storage<104, 8>::type m_subscription_set[1];
 #endif
 #elif _WIN32
+#if _DEBUG
         std::aligned_storage<120, 8>::type m_subscription_set[1];
+#else
+        std::aligned_storage<104, 8>::type m_subscription_set[1];
+#endif
 #endif
         std::reference_wrapper<internal::bridge::realm> m_realm;
     };

--- a/src/cpprealm/internal/bridge/lnklst.cpp
+++ b/src/cpprealm/internal/bridge/lnklst.cpp
@@ -19,8 +19,12 @@ namespace realm::internal::bridge {
     static_assert(SizeCheck<160, sizeof(LnkLst)>{});
     static_assert(SizeCheck<8, alignof(LnkLst)>{});
 #elif _WIN32
-    static_assert(SizeCheck<168, sizeof(LnkLst)>{});
     static_assert(SizeCheck<8, alignof(LnkLst)>{});
+    #if _DEBUG
+    static_assert(SizeCheck<168, sizeof(LnkLst)>{});
+    #else
+    static_assert(SizeCheck<160, sizeof(LnkLst)>{});
+    #endif
 #endif
     
     lnklst::lnklst() {

--- a/src/cpprealm/internal/bridge/lnklst.hpp
+++ b/src/cpprealm/internal/bridge/lnklst.hpp
@@ -32,7 +32,11 @@ namespace realm::internal::bridge {
 #elif __aarch64__
         std::aligned_storage<160, 8>::type m_lnk_lst[1];
 #elif _WIN32
+        #if _DEBUG
         std::aligned_storage<168, 8>::type m_lnk_lst[1];
+        #else
+        std::aligned_storage<160, 8>::type m_lnk_lst[1];
+        #endif
 #endif
     };
 

--- a/src/cpprealm/internal/bridge/obj.hpp
+++ b/src/cpprealm/internal/bridge/obj.hpp
@@ -187,7 +187,7 @@ namespace realm::internal::bridge {
                     internal::bridge::obj m_obj;
                     if constexpr (experimental::managed<std::remove_pointer_t<ValueType>, void>::schema.HasPrimaryKeyProperty) {
                         auto pk = (*v).*(experimental::managed<std::remove_pointer_t<ValueType>, void>::schema.primary_key().ptr);
-                        m_obj = this->get_table().create_object_with_primary_key(pk.value);
+                        m_obj = this->get_table().create_object_with_primary_key(internal::bridge::mixed(serialize(pk.value)));
                     } else {
                         m_obj = m_obj = this->get_table().create_object();
                     }

--- a/src/cpprealm/internal/bridge/object.cpp
+++ b/src/cpprealm/internal/bridge/object.cpp
@@ -75,13 +75,20 @@ namespace realm::internal::bridge {
     static_assert(SizeCheck<24, sizeof(NotificationToken)>{});
     static_assert(SizeCheck<8, alignof(NotificationToken)>{});
 #elif _WIN32
+    #if _DEBUG
+    static_assert(SizeCheck<32, sizeof(IndexSet)>{});
+    static_assert(SizeCheck<248, sizeof(CollectionChangeSet)>{});
+    static_assert(SizeCheck<64, sizeof(IndexSet::IndexIterator)>{});
+    #else
+    static_assert(SizeCheck<24, sizeof(IndexSet)>{});
+    static_assert(SizeCheck<192, sizeof(CollectionChangeSet)>{});
+    static_assert(SizeCheck<32, sizeof(IndexSet::IndexIterator)>{});
+    #endif
+
     static_assert(SizeCheck<104, sizeof(Object)>{});
     static_assert(SizeCheck<8, alignof(Object)>{});
-    static_assert(SizeCheck<32, sizeof(IndexSet)>{});
     static_assert(SizeCheck<8, alignof(IndexSet)>{});
-    static_assert(SizeCheck<248, sizeof(CollectionChangeSet)>{});
     static_assert(SizeCheck<8, alignof(CollectionChangeSet)>{});
-    static_assert(SizeCheck<64, sizeof(IndexSet::IndexIterator)>{});
     static_assert(SizeCheck<8, alignof(IndexSet::IndexIterator)>{});
     static_assert(SizeCheck<8, sizeof(IndexSet::IndexIteratableAdaptor)>{});
     static_assert(SizeCheck<8, alignof(IndexSet::IndexIteratableAdaptor)>{});

--- a/src/cpprealm/internal/bridge/object.hpp
+++ b/src/cpprealm/internal/bridge/object.hpp
@@ -83,7 +83,11 @@ namespace realm::internal::bridge {
 #elif __aarch64__
             std::aligned_storage<32, 8>::type m_iterator[1];
 #elif _WIN32
+            #if _DEBUG
             std::aligned_storage<64, 8>::type m_iterator[1];
+            #else
+            std::aligned_storage<32, 8>::type m_iterator[1];
+            #endif
 #endif
         };
 
@@ -123,7 +127,11 @@ namespace realm::internal::bridge {
 #elif __aarch64__
         std::aligned_storage<24, 8>::type m_idx_set[1];
 #elif _WIN32
+        #if _DEBUG
         std::aligned_storage<32, 8>::type m_idx_set[1];
+        #else
+        std::aligned_storage<24, 8>::type m_idx_set[1];
+        #endif
 #endif
     };
     struct collection_change_set {
@@ -159,7 +167,11 @@ namespace realm::internal::bridge {
         std::aligned_storage<184, 8>::type m_change_set[1];
 #endif
 #elif _WIN32
+        #if _DEBUG
         std::aligned_storage<248, 8>::type m_change_set[1];
+        #else
+        std::aligned_storage<192, 8>::type m_change_set[1];
+        #endif
 #endif
     };
     struct collection_change_callback {

--- a/src/cpprealm/internal/bridge/object_schema.cpp
+++ b/src/cpprealm/internal/bridge/object_schema.cpp
@@ -27,7 +27,11 @@ namespace realm::internal::bridge {
 #endif
     static_assert(SizeCheck<8, alignof(ObjectSchema)>{});
 #elif _WIN32
+    #if _DEBUG
     static_assert(SizeCheck<192, sizeof(ObjectSchema)>{});
+    #else
+    static_assert(SizeCheck<152, sizeof(ObjectSchema)>{});
+    #endif
     static_assert(SizeCheck<8, alignof(ObjectSchema)>{});
 #endif
 

--- a/src/cpprealm/internal/bridge/object_schema.hpp
+++ b/src/cpprealm/internal/bridge/object_schema.hpp
@@ -55,7 +55,11 @@ namespace realm::internal::bridge {
         std::aligned_storage<152, 8>::type m_schema[1];
 #endif
 #elif _WIN32
+        #if _DEBUG
         std::aligned_storage<192, 8>::type m_schema[1];
+        #else
+        std::aligned_storage<152, 8>::type m_schema[1];
+        #endif
 #endif
     };
 }

--- a/src/cpprealm/internal/bridge/property.cpp
+++ b/src/cpprealm/internal/bridge/property.cpp
@@ -26,8 +26,12 @@ namespace realm::internal::bridge {
 #endif
     static_assert(SizeCheck<8, alignof(Property)>{});
 #elif _WIN32
-    static_assert(SizeCheck<184, sizeof(Property)>{});
     static_assert(SizeCheck<8, alignof(Property)>{});
+    #if _DEBUG
+    static_assert(SizeCheck<184, sizeof(Property)>{});
+    #else
+    static_assert(SizeCheck<152, sizeof(Property)>{});
+    #endif
 #endif
 
 

--- a/src/cpprealm/internal/bridge/property.hpp
+++ b/src/cpprealm/internal/bridge/property.hpp
@@ -79,7 +79,11 @@ namespace realm::internal::bridge {
         std::aligned_storage<152, 8>::type m_property[1];
 #endif
 #elif _WIN32
+        #if _DEBUG
         std::aligned_storage<184, 8>::type m_property[1];
+        #else
+        std::aligned_storage<152, 8>::type m_property[1];
+        #endif
 #endif
     };
 

--- a/src/cpprealm/internal/bridge/query.cpp
+++ b/src/cpprealm/internal/bridge/query.cpp
@@ -48,8 +48,12 @@ namespace realm::internal::bridge {
 #endif
     static_assert(SizeCheck<8, alignof(Query)>{});
 #elif _WIN32
-    static_assert(SizeCheck<160, sizeof(Query)>{});
     static_assert(SizeCheck<8, alignof(Query)>{});
+    #if _DEBUG
+    static_assert(SizeCheck<160, sizeof(Query)>{});
+    #else
+    static_assert(SizeCheck<136, sizeof(Query)>{});
+    #endif
 #endif
 
     query::query() {

--- a/src/cpprealm/internal/bridge/query.hpp
+++ b/src/cpprealm/internal/bridge/query.hpp
@@ -131,7 +131,11 @@ namespace realm::internal::bridge {
         std::aligned_storage<136, 8>::type m_query[1];
 #endif
 #elif _WIN32
+        #if _DEBUG
         std::aligned_storage<160, 8>::type m_query[1];
+        #else
+        std::aligned_storage<136, 8>::type m_query[1];
+        #endif
 #endif
 
     };

--- a/src/cpprealm/internal/bridge/realm.cpp
+++ b/src/cpprealm/internal/bridge/realm.cpp
@@ -57,7 +57,11 @@ namespace realm::internal::bridge {
     static_assert(SizeCheck<8, alignof(Realm::Config)>{});
     #endif
 #elif _WIN32
+    #if _DEBUG
     static_assert(SizeCheck<456, sizeof(Realm::Config)>{});
+    #else
+    static_assert(SizeCheck<424, sizeof(Realm::Config)>{});
+    #endif
     static_assert(SizeCheck<8, alignof(Realm::Config)>{});
 #endif
 

--- a/src/cpprealm/internal/bridge/realm.hpp
+++ b/src/cpprealm/internal/bridge/realm.hpp
@@ -87,7 +87,11 @@ namespace realm::internal::bridge {
         std::aligned_storage<328, 8>::type m_config[1];
     #endif
 #elif _WIN32
-            std::aligned_storage<456, 8>::type m_config[1];
+        #if _DEBUG
+        std::aligned_storage<456, 8>::type m_config[1];
+        #else
+        std::aligned_storage<424, 8>::type m_config[1];
+        #endif
 #endif
         };
 

--- a/src/cpprealm/internal/bridge/results.cpp
+++ b/src/cpprealm/internal/bridge/results.cpp
@@ -28,8 +28,12 @@ namespace realm::internal::bridge {
 #endif
     static_assert(SizeCheck<8, alignof(Results)>{});
 #elif _WIN32
-    static_assert(SizeCheck<1008, sizeof(Results)>{});
     static_assert(SizeCheck<8, alignof(Results)>{});
+    #if _DEBUG
+    static_assert(SizeCheck<1008, sizeof(Results)>{});
+    #else
+    static_assert(SizeCheck<912, sizeof(Results)>{});
+    #endif
 #endif
 
     results::results() {

--- a/src/cpprealm/internal/bridge/results.hpp
+++ b/src/cpprealm/internal/bridge/results.hpp
@@ -50,7 +50,11 @@ namespace realm::internal::bridge {
         std::aligned_storage<912, 8>::type m_results[1];
 #endif
 #elif _WIN32
+#if _DEBUG
         std::aligned_storage<1008, 8>::type m_results[1];
+#else
+        std::aligned_storage<912, 8>::type m_results[1];
+#endif
 #endif
     };
 

--- a/src/cpprealm/internal/bridge/schema.cpp
+++ b/src/cpprealm/internal/bridge/schema.cpp
@@ -19,7 +19,11 @@ namespace realm::internal::bridge {
     static_assert(SizeCheck<24, sizeof(Schema)>{});
     static_assert(SizeCheck<8, alignof(Schema)>{});
 #elif _WIN32
+    #if _DEBUG
     static_assert(SizeCheck<32, sizeof(Schema)>{});
+    #else
+    static_assert(SizeCheck<24, sizeof(Schema)>{});
+    #endif
     static_assert(SizeCheck<8, alignof(Schema)>{});
 #endif
 

--- a/src/cpprealm/internal/bridge/schema.hpp
+++ b/src/cpprealm/internal/bridge/schema.hpp
@@ -31,7 +31,11 @@ namespace realm::internal::bridge {
 #elif __aarch64__
         std::aligned_storage<24, 8>::type m_schema[1];
 #elif _WIN32
+        #if _DEBUG
         std::aligned_storage<32, 8>::type m_schema[1];
+        #else
+        std::aligned_storage<24, 8>::type m_schema[1];
+        #endif
 #endif
     };
 }

--- a/src/cpprealm/internal/bridge/sync_error.cpp
+++ b/src/cpprealm/internal/bridge/sync_error.cpp
@@ -25,7 +25,11 @@ namespace realm::internal::bridge {
 #endif
     static_assert(SizeCheck<8, alignof(SyncError)>{});
 #elif _WIN32
+    #if _DEBUG
     static_assert(SizeCheck<192, sizeof(SyncError)>{});
+    #else
+    static_assert(SizeCheck<168, sizeof(SyncError)>{});
+    #endif
     static_assert(SizeCheck<8, alignof(SyncError)>{});
 #endif
 

--- a/src/cpprealm/internal/bridge/sync_error.hpp
+++ b/src/cpprealm/internal/bridge/sync_error.hpp
@@ -50,7 +50,11 @@ namespace realm::internal::bridge {
         std::aligned_storage<144, 8>::type m_error[1];
 #endif
 #elif _WIN32
+        #if _DEBUG
         std::aligned_storage<192, 8>::type m_error[1];
+        #else
+        std::aligned_storage<168, 8>::type m_error[1];
+        #endif
 #endif
     };
 }

--- a/src/cpprealm/internal/bridge/table.cpp
+++ b/src/cpprealm/internal/bridge/table.cpp
@@ -151,7 +151,11 @@ namespace realm::internal::bridge {
     static_assert(SizeCheck<8, alignof(TableView)>{});
 #endif
 #elif _WIN32
+    #if _DEBUG
     static_assert(SizeCheck<624, sizeof(TableView)>{});
+    #else
+    static_assert(SizeCheck<576, sizeof(TableView)>{});
+    #endif
     static_assert(SizeCheck<8, alignof(TableView)>{});
 #endif
 

--- a/src/cpprealm/internal/bridge/table.hpp
+++ b/src/cpprealm/internal/bridge/table.hpp
@@ -85,7 +85,11 @@ namespace realm {
             std::aligned_storage<624, 8>::type m_table_view[1];
 #endif
 #elif _WIN32
-            std::aligned_storage<568, 8>::type m_table_view[1];
+            #if _DEBUG
+            std::aligned_storage<624, 8>::type m_table_view[1];
+            #else
+            std::aligned_storage<576, 8>::type m_table_view[1];
+            #endif
 #endif
         };
 

--- a/tests/experimental/sync/test_objects.hpp
+++ b/tests/experimental/sync/test_objects.hpp
@@ -56,8 +56,8 @@ namespace realm::experimental {
         std::optional<realm::uuid> opt_uuid_col;
         std::optional<realm::object_id> opt_object_id_col;
         std::optional<std::vector<uint8_t>> opt_binary_col;
-        AllTypesObjectLink* opt_obj_col;
-        AllTypesObjectEmbedded* opt_embedded_obj_col;
+        AllTypesObjectLink* opt_obj_col = nullptr;
+        AllTypesObjectEmbedded* opt_embedded_obj_col = nullptr;
 
         std::vector<int64_t> list_int_col;
         std::vector<double> list_double_col;


### PR DESCRIPTION
Fixes issue where Windows would not compile under Release build configuration as `aligned_storage` parameters were incorrectly set.