### PR TITLE
Add ability to set custom http headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ x.y.z Release notes (yyyy-MM-dd)
 * Add support for the Decimal128 data type (`realm::decimal128`).
 * Add app::get_current_user()
 * Add user::is_logged_in()
+* Add ability to set custom http headers. The http headers should be passed when constructing a `realm::App` and when in 
+  possession of a config derived from `realm::user::flexible_sync_configuration()` by calling `foo_config.set_custom_http_headers(...);`.
 
 ### Breaking Changes
 * None

--- a/src/cpprealm/app.cpp
+++ b/src/cpprealm/app.cpp
@@ -343,7 +343,10 @@ namespace realm {
         return credentials(app::AppCredentials::function(payload));
     }
 
-    App::App(const std::string &app_id, const std::optional<std::string> &base_url, const std::optional<std::string> &path) {
+    App::App(const std::string &app_id,
+             const std::optional<std::string> &base_url,
+             const std::optional<std::string> &path,
+             const std::optional<std::map<std::string, std::string>> &custom_http_headers) {
 #if QT_CORE_LIB
         util::Scheduler::set_default_factory(util::make_qt);
 #endif
@@ -372,7 +375,7 @@ namespace realm {
 
         auto app_config = app::App::Config();
         app_config.app_id = app_id;
-        app_config.transport = std::make_shared<internal::DefaultTransport>();
+        app_config.transport = std::make_shared<internal::DefaultTransport>(custom_http_headers);
         app_config.base_url = base_url ? base_url : util::Optional<std::string>();
         auto device_info = app::App::Config::DeviceInfo();
 
@@ -384,7 +387,6 @@ namespace realm {
 
         m_app = app::App::get_shared_app(std::move(app_config), config);
     }
-
 
     std::future<void> App::register_user(const std::string &username, const std::string &password) {
         std::promise<void> p;

--- a/src/cpprealm/app.hpp
+++ b/src/cpprealm/app.hpp
@@ -222,7 +222,10 @@ bool operator!=(const user& lhs, const user& rhs);
 
 class App {
 public:
-    explicit App(const std::string& app_id, const std::optional<std::string>& base_url = {}, const std::optional<std::string>& path = {});
+    explicit App(const std::string& app_id,
+                 const std::optional<std::string>& base_url = {},
+                 const std::optional<std::string>& path = {},
+                 const std::optional<std::map<std::string, std::string>>& custom_http_headers = {});
 
     struct credentials {
         using auth_code = util::TaggedString<class auth_code_tag>;

--- a/src/cpprealm/internal/apple/network_transport.mm
+++ b/src/cpprealm/internal/apple/network_transport.mm
@@ -53,6 +53,12 @@ void DefaultTransport::send_request_to_server(const app::Request& request,
             [urlRequest addValue:[NSString stringWithCString:header.second.c_str() encoding:NSUTF8StringEncoding]
               forHTTPHeaderField:[NSString stringWithCString:header.first.c_str() encoding:NSUTF8StringEncoding]];
         }
+        if (m_custom_http_headers) {
+            for (auto& header : *m_custom_http_headers) {
+                [urlRequest addValue:[NSString stringWithCString:header.second.c_str() encoding:NSUTF8StringEncoding]
+                        forHTTPHeaderField:[NSString stringWithCString:header.first.c_str() encoding:NSUTF8StringEncoding]];
+            }
+        }
         if (request.method != app::HttpMethod::get && !request.body.empty()) {
             [urlRequest setHTTPBody:[[NSString stringWithCString:request.body.c_str() encoding:NSUTF8StringEncoding]
                     dataUsingEncoding:NSUTF8StringEncoding]];

--- a/src/cpprealm/internal/bridge/realm.cpp
+++ b/src/cpprealm/internal/bridge/realm.cpp
@@ -254,7 +254,7 @@ namespace realm::internal::bridge {
         if (reinterpret_cast<RealmConfig*>(&m_config)->sync_config) {
             reinterpret_cast<const RealmConfig*>(&m_config)->sync_config->custom_http_headers = headers;
         } else {
-            throw std::exception();
+            throw std::logic_error("HTTP headers can only be set on a config for a synced Realm.");
         }
     }
 

--- a/src/cpprealm/internal/bridge/realm.cpp
+++ b/src/cpprealm/internal/bridge/realm.cpp
@@ -250,6 +250,14 @@ namespace realm::internal::bridge {
             reinterpret_cast<RealmConfig*>(&m_config)->sync_config = nullptr;
     }
 
+    void realm::config::set_custom_http_headers(const std::map<std::string, std::string>& headers) {
+        if (reinterpret_cast<RealmConfig*>(&m_config)->sync_config) {
+            reinterpret_cast<const RealmConfig*>(&m_config)->sync_config->custom_http_headers = headers;
+        } else {
+            throw std::exception();
+        }
+    }
+
     realm::sync_config realm::config::sync_config() const {
         return reinterpret_cast<const RealmConfig*>(&m_config)->sync_config;
     }

--- a/src/cpprealm/internal/bridge/realm.hpp
+++ b/src/cpprealm/internal/bridge/realm.hpp
@@ -6,6 +6,7 @@
 #include <optional>
 #include <string>
 #include <vector>
+#include <map>
 
 namespace realm {
     class Realm;
@@ -147,6 +148,7 @@ namespace realm::internal::bridge {
             void set_schema_mode(schema_mode);
             void set_scheduler(const std::shared_ptr<struct scheduler>&);
             void set_sync_config(const std::optional<struct sync_config>&);
+            void set_custom_http_headers(const std::map<std::string, std::string>& headers);
         private:
 #ifdef __i386__
             std::aligned_storage<192, 8>::type m_config[1];

--- a/src/cpprealm/internal/curl/network_transport.cpp
+++ b/src/cpprealm/internal/curl/network_transport.cpp
@@ -135,12 +135,6 @@ namespace realm::internal {
                 auto header_str = util::format("%1: %2", header.first, header.second);
                 list = curl_slist_append(list, header_str.c_str());
             }
-            if (m_custom_http_headers) {
-                for (auto& header : *m_custom_http_headers) {
-                    auto header_str = util::format("%1: %2", header.first, header.second);
-                    list = curl_slist_append(list, header_str.c_str());
-                }
-            }
             curl_easy_setopt(curl, CURLOPT_HTTPHEADER, list);
             curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, curl_write_cb);
             curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response);
@@ -166,6 +160,12 @@ namespace realm::internal {
     void DefaultTransport::send_request_to_server(const app::Request& request,
                                                   util::UniqueFunction<void(const app::Response&)>&& completion_block)
     {
+        if (m_custom_http_headers) {
+            auto req_copy = request;
+            req_copy.headers.insert(m_custom_http_headers->begin(), m_custom_http_headers->end());
+            completion_block(do_http_request(req_copy));
+            return;
+        }
         completion_block(do_http_request(request));
     }
 

--- a/src/cpprealm/internal/curl/network_transport.cpp
+++ b/src/cpprealm/internal/curl/network_transport.cpp
@@ -135,7 +135,12 @@ namespace realm::internal {
                 auto header_str = util::format("%1: %2", header.first, header.second);
                 list = curl_slist_append(list, header_str.c_str());
             }
-
+            if (m_custom_http_headers) {
+                for (auto& header : *m_custom_http_headers) {
+                    auto header_str = util::format("%1: %2", header.first, header.second);
+                    list = curl_slist_append(list, header_str.c_str());
+                }
+            }
             curl_easy_setopt(curl, CURLOPT_HTTPHEADER, list);
             curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, curl_write_cb);
             curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response);

--- a/src/cpprealm/internal/generic_network_transport.hpp
+++ b/src/cpprealm/internal/generic_network_transport.hpp
@@ -21,13 +21,18 @@
 
 #include <realm/object-store/sync/impl/sync_client.hpp>
 #include <realm/object-store/sync/generic_network_transport.hpp>
+#include <map>
+#include <optional>
 
 namespace realm::internal {
 
 class DefaultTransport : public app::GenericNetworkTransport {
 public:
+    DefaultTransport(const std::optional<std::map<std::string, std::string>>& custom_http_headers = std::nullopt) : m_custom_http_headers(custom_http_headers) {}
     void send_request_to_server(const app::Request& request,
                                 util::UniqueFunction<void(const app::Response&)>&& completion);
+private:
+    std::optional<std::map<std::string, std::string>> m_custom_http_headers;
 };
 
 } // namespace realm

--- a/src/cpprealm/internal/network/network_transport.cpp
+++ b/src/cpprealm/internal/network/network_transport.cpp
@@ -125,6 +125,12 @@ namespace realm::internal {
             headers["Content-Length"] = util::to_string(request.body.size());
         }
 
+        if (m_custom_http_headers) {
+            for (auto& header : *m_custom_http_headers) {
+                headers.emplace(header);
+            }
+        }
+
         std::shared_ptr<realm::util::StderrLogger> logger = std::make_shared<realm::util::StderrLogger>();
         realm::sync::HTTPClient<DefaultSocket> m_http_client = realm::sync::HTTPClient<DefaultSocket>(socket, logger);
 


### PR DESCRIPTION
Adds ability to set custom http headers. Usage:
```cpp
auto headers = std::map<std::string, std::string>({{"Proxy-Authorization", "some-type some-credentials"}});
auto app = realm::App(Admin::shared().cached_app_id(), std::nullopt, std::nullopt, headers);
auto user = app.login(realm::App::credentials::anonymous()).get();
auto flx_sync_config = user.flexible_sync_configuration();
flx_sync_config.set_custom_http_headers(headers);
```