### PR TITLE
Various fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,8 @@ x.y.z Release notes (yyyy-MM-dd)
 * Add `box<managed<V*>>::box& operator=(const managed<V>& o)`
 
 ### Breaking Changes
-* None
+* `managed<>::value()` has been renamed to `managed<>::detach()` to better convey that the returned value will be unmanaged. In the case where the value is a
+  pointer type it is up to the consumer of the value to manage the lifetime of the object.
 
 ### Compatibility
 * Fileformat: Generates files with format v22.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ x.y.z Release notes (yyyy-MM-dd)
 * The default schema mode was incorrectly set to Automatic and not AdditiveDiscovered when using a Synced Realm.
 * Fix iterator on `experimental::Results`
 * Fix issue where properties on a link column could not be queried.
+* `operator bool()` on link properties incorrectly returned true when the link was null.
+* The default schema mode was incorrectly set to Automatic and not AdditiveDiscovered when using a Synced Realm.
 
 ### Enhancements
 * Add support for the Decimal128 data type (`realm::decimal128`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ x.y.z Release notes (yyyy-MM-dd)
 * Fix memory leak on internal::bridge::notification_token caused by missing destructor.
 * Fix memory leak on internal::bridge::binary caused by wrong destructor being called.
 * The default schema mode was incorrectly set to Automatic and not AdditiveDiscovered when using a Synced Realm.
+* Fix iterator on `experimental::Results`
+* Fix issue where properties on a link column could not be queried.
 
 ### Enhancements
 * Add support for the Decimal128 data type (`realm::decimal128`).
@@ -14,6 +16,11 @@ x.y.z Release notes (yyyy-MM-dd)
 * Add user::is_logged_in()
 * Add ability to set custom http headers. The http headers should be passed when constructing a `realm::App` and when in 
   possession of a config derived from `realm::user::flexible_sync_configuration()` by calling `foo_config.set_custom_http_headers(...);`.
+* Add `operator!=()` to collections.
+* Add `set_schema_version(uint64_t)`
+* Add `managed<std::vector<T*>>::push_back(const managed<T*>&)`
+* Add `box<managed<V*>>::box& operator=(const managed<V*>& o)`
+* Add `box<managed<V*>>::box& operator=(const managed<V>& o)`
 
 ### Breaking Changes
 * None

--- a/src/cpprealm/experimental/link.hpp
+++ b/src/cpprealm/experimental/link.hpp
@@ -65,6 +65,10 @@ namespace realm {
                 m_obj->set(m_key, obj.m_obj.get_key());
                 return *this;
             }
+            managed &operator=(const managed<T*> &obj) {
+                m_obj->set(m_key, obj.m_obj->get_key());
+                return *this;
+            }
             managed &operator=(std::nullptr_t) {
                 m_obj->set_null(m_key);
                 return *this;
@@ -105,14 +109,14 @@ namespace realm {
             }
             bool operator ==(const managed<T>& rhs) const {
                 if (*this->m_realm != rhs.m_realm)
-                    return false;
-                return this->m_obj->get_key() == rhs.m_obj.get_key();
+                    return false;                
+                return m_obj->get_linked_object(m_key).get_key() == rhs.m_obj.get_key();
             }
 
             bool operator ==(const managed<T*>& rhs) const {
                 if (*this->m_realm != *rhs.m_realm)
                     return false;
-                return this->m_obj->get_key() == rhs.m_obj->get_key();
+                return m_obj->get_linked_object(m_key).get_key() == rhs.m_obj->get_key();
             }
 
             bool operator !=(const std::nullptr_t) const {

--- a/src/cpprealm/experimental/link.hpp
+++ b/src/cpprealm/experimental/link.hpp
@@ -22,19 +22,33 @@ namespace realm {
                     return &m_managed;
                 }
 
+                bool operator ==(const managed<T*>& rhs) const {
+                    if (this->m_managed.m_realm != *rhs.m_realm) {
+                        return false;
+                    }
+                    return this->m_managed.m_obj.get_key() == rhs.m_obj->get_key();
+                }
                 bool operator ==(const managed<T>& rhs) const {
                     if (this->m_managed.m_realm != rhs.m_realm) {
                         return false;
                     }
-                    return this->m_managed.m_obj.get_table() == rhs.m_obj.get_table() &&
-                           this->m_managed.m_obj.get_key() == rhs.m_obj.get_key();
+                    return this->m_managed.m_obj.get_key() == rhs.m_obj.get_key();
+
                 }
                 bool operator ==(const ref_type& rhs) const {
                     if (this->m_managed.m_realm != rhs.m_managed.m_realm) {
                         return false;
                     }
-                    return this->m_managed.m_obj.get_table() == rhs.m_managed.m_obj.get_table()
-                           && this->m_managed.m_obj.get_key() == rhs.m_managed.m_obj.get_key();
+                    return this->m_managed.m_obj.get_key() == rhs.m_managed.m_obj.get_key();
+                }
+                bool operator !=(const managed<T*>& rhs) const {
+                    return !this->operator==(rhs);
+                }
+                bool operator !=(const managed<T>& rhs) const {
+                    return !this->operator==(rhs);
+                }
+                bool operator !=(const ref_type& rhs) const {
+                    return !this->operator==(rhs);
                 }
             };
             ref_type operator ->() const {
@@ -46,6 +60,10 @@ namespace realm {
                     return m_obj->is_null(m_key);
                 }
                 return false;
+            }
+            managed &operator=(const managed<T>& obj) {
+                m_obj->set(m_key, obj.m_obj.get_key());
+                return *this;
             }
             managed &operator=(std::nullptr_t) {
                 m_obj->set_null(m_key);
@@ -88,12 +106,24 @@ namespace realm {
             bool operator ==(const managed<T>& rhs) const {
                 if (*this->m_realm != rhs.m_realm)
                     return false;
-                if (this->m_obj->get_table() != rhs.m_obj.get_table())
-                    return false;
-                if (this->m_obj->get_key() == rhs.m_obj.get_key())
-                    return false;
+                return this->m_obj->get_key() == rhs.m_obj.get_key();
+            }
 
-                return true;
+            bool operator ==(const managed<T*>& rhs) const {
+                if (*this->m_realm != *rhs.m_realm)
+                    return false;
+                return this->m_obj->get_key() == rhs.m_obj->get_key();
+            }
+
+            bool operator !=(const std::nullptr_t) const {
+                return !this->operator==(nullptr);
+            }
+            bool operator !=(const managed<T>& rhs) const {
+                return !this->operator==(rhs);
+            }
+
+            bool operator !=(const managed<T*>& rhs) const {
+                return !this->operator==(rhs);
             }
         };
     }

--- a/src/cpprealm/experimental/link.hpp
+++ b/src/cpprealm/experimental/link.hpp
@@ -61,7 +61,7 @@ namespace realm {
             }
             operator bool() {
                 if (m_obj && m_key) {
-                    return m_obj->is_null(m_key);
+                    return !m_obj->is_null(m_key);
                 }
                 return false;
             }

--- a/src/cpprealm/experimental/link.hpp
+++ b/src/cpprealm/experimental/link.hpp
@@ -52,6 +52,10 @@ namespace realm {
                 }
             };
             ref_type operator ->() const {
+                if (should_detect_usage_for_queries) {
+                    managed<T> m = managed<T>::prepare_for_query(*m_realm);
+                    return {std::move(m)};
+                }
                 managed<T> m(m_obj->get_linked_object(m_key), *m_realm);
                 return {std::move(m)};
             }

--- a/src/cpprealm/experimental/link.hpp
+++ b/src/cpprealm/experimental/link.hpp
@@ -32,14 +32,15 @@ namespace realm {
                     if (this->m_managed.m_realm != rhs.m_realm) {
                         return false;
                     }
-                    return this->m_managed.m_obj.get_key() == rhs.m_obj.get_key();
-
+                    return this->m_managed.m_obj.get_table() == rhs.m_obj.get_table() &&
+                        this->m_managed.m_obj.get_key() == rhs.m_obj.get_key();
                 }
                 bool operator ==(const ref_type& rhs) const {
                     if (this->m_managed.m_realm != rhs.m_managed.m_realm) {
                         return false;
                     }
-                    return this->m_managed.m_obj.get_key() == rhs.m_managed.m_obj.get_key();
+                    return this->m_managed.m_obj.get_table() == rhs.m_managed.m_obj.get_table() &&
+                        this->m_managed.m_obj.get_key() == rhs.m_managed.m_obj.get_key();
                 }
                 bool operator !=(const managed<T*>& rhs) const {
                     return !this->operator==(rhs);

--- a/src/cpprealm/experimental/link.hpp
+++ b/src/cpprealm/experimental/link.hpp
@@ -12,7 +12,7 @@ namespace realm {
 
         template<typename T>
         struct managed<T*> : managed_base {
-            managed<T*> value() const { return *this; }
+            managed<T*> detach() const { return *this; }
             struct ref_type {
                 managed<T> m_managed;
                 managed<T>* operator ->() const {

--- a/src/cpprealm/experimental/macros.hpp
+++ b/src/cpprealm/experimental/macros.hpp
@@ -127,7 +127,7 @@
 #define DECLARE_MANAGED_PROPERTY(cls, p) &realm::experimental::managed<cls>::p,
 #define DECLARE_UNMANAGED_TO_MANAGED_PAIR(cls, p) std::pair {&cls::p, &realm::experimental::managed<cls>::p},
 #define DECLARE_MANAGED_PROPERTY_NAME(cls, p) #p,
-#define DECLARE_COND_PROPERTY_VALUE_FOR_NAME(cls, p) if (_name == #p) { auto ptr = &managed<cls>::p; return (*this.*ptr).value(); }
+#define DECLARE_COND_PROPERTY_VALUE_FOR_NAME(cls, p) if (_name == #p) { auto ptr = &managed<cls>::p; return (*this.*ptr).detach(); }
 #define DECLARE_COND_UNMANAGED_TO_MANAGED(cls, p) if constexpr (std::is_same_v<decltype(ptr), decltype(&cls::p)>) { return &managed<cls>::p; }
 
 #include <utility>
@@ -262,7 +262,7 @@ rbool managed<type>::operator op(const type& rhs) const noexcept { \
         query.name(this->m_key, serialize(rhs)); \
         return query; \
     } \
-    return serialize(value()) op serialize(rhs); \
+    return serialize(detach()) op serialize(rhs); \
 } \
 
 #define __cpprealm_build_optional_experimental_query(op, name, type) \
@@ -276,7 +276,7 @@ rbool managed<std::optional<type>>::operator op(const std::optional<type>& rhs) 
         } \
         return query; \
     } \
-    return serialize(value()) op serialize(rhs); \
+    return serialize(detach()) op serialize(rhs); \
 } \
 
 #define REALM_SCHEMA(cls, ...) \

--- a/src/cpprealm/experimental/managed_binary.cpp
+++ b/src/cpprealm/experimental/managed_binary.cpp
@@ -2,7 +2,7 @@
 #include <cpprealm/persisted.hpp>
 
 namespace realm::experimental {
-    std::vector<uint8_t> managed<std::vector<uint8_t>>::value() const {
+    std::vector<uint8_t> managed<std::vector<uint8_t>>::detach() const {
         return m_obj->template get<realm::internal::bridge::binary>(m_key);
     }
 
@@ -11,7 +11,7 @@ namespace realm::experimental {
     }
 
     std::vector<uint8_t> managed<std::vector<uint8_t>>::operator*() const {
-        return value();
+        return detach();
     }
 
     void managed<std::vector<uint8_t>>::push_back(uint8_t v) {
@@ -33,7 +33,7 @@ namespace realm::experimental {
 
     // MARK: Optional
 
-    std::optional<std::vector<uint8_t>> managed<std::optional<std::vector<uint8_t>>>::value() const {
+    std::optional<std::vector<uint8_t>> managed<std::optional<std::vector<uint8_t>>>::detach() const {
         return m_obj->get_optional<realm::internal::bridge::binary>(m_key);
     }
 

--- a/src/cpprealm/experimental/managed_binary.hpp
+++ b/src/cpprealm/experimental/managed_binary.hpp
@@ -14,7 +14,7 @@ namespace realm::experimental {
     struct managed<std::vector<uint8_t>> : managed_base {
         using managed<std::vector<uint8_t>>::managed_base::operator=;
 
-        [[nodiscard]] std::vector<uint8_t> value() const;
+        [[nodiscard]] std::vector<uint8_t> detach() const;
         [[nodiscard]]  operator std::vector<uint8_t>() const;
 
         std::vector<uint8_t> operator*() const;
@@ -31,7 +31,7 @@ namespace realm::experimental {
     struct managed<std::optional<std::vector<uint8_t>>> : managed_base {
         using managed<std::optional<std::vector<uint8_t>>>::managed_base::operator=;
 
-        [[nodiscard]] std::optional<std::vector<uint8_t>> value() const;
+        [[nodiscard]] std::optional<std::vector<uint8_t>> detach() const;
         [[nodiscard]]  operator std::optional<std::vector<uint8_t>>() const;
 
         struct box {

--- a/src/cpprealm/experimental/managed_decimal.hpp
+++ b/src/cpprealm/experimental/managed_decimal.hpp
@@ -14,16 +14,16 @@ namespace realm::experimental {
     template<>
     struct managed<realm::decimal128> : managed_base {
         using managed<realm::decimal128>::managed_base::operator=;
-        [[nodiscard]] realm::decimal128 value() const {
+        [[nodiscard]] realm::decimal128 detach() const {
             return m_obj->template get<realm::internal::bridge::decimal128>(m_key).operator ::realm::decimal128();
         }
 
         [[nodiscard]] realm::decimal128 operator *() const {
-            return value();
+            return detach();
         }
 
         [[nodiscard]] operator realm::decimal128 () const {
-            return value();
+            return detach();
         }
 
         rbool operator==(const decimal128& rhs) const noexcept;
@@ -47,7 +47,7 @@ namespace realm::experimental {
     struct managed<std::optional<realm::decimal128>> : managed_base {
         using managed<std::optional<realm::decimal128>>::managed_base::operator=;
 
-        [[nodiscard]] std::optional<realm::decimal128> value() const {
+        [[nodiscard]] std::optional<realm::decimal128> detach() const {
             auto v = m_obj->template get_optional<realm::internal::bridge::decimal128>(m_key);
             if (v) {
                 return v.value().operator ::realm::decimal128();
@@ -57,11 +57,11 @@ namespace realm::experimental {
         }
 
         [[nodiscard]] std::optional<realm::decimal128> operator *() const {
-            return value();
+            return detach();
         }
 
         [[nodiscard]] operator std::optional<realm::decimal128>() const {
-            return value();
+            return detach();
         }
 
         rbool operator==(const std::optional<realm::decimal128>& rhs) const noexcept;

--- a/src/cpprealm/experimental/managed_dictionary.hpp
+++ b/src/cpprealm/experimental/managed_dictionary.hpp
@@ -81,6 +81,9 @@ namespace realm::experimental {
                 return m_backing_map.get(m_key) == internal::bridge::mixed(rhs);
             }
         }
+        bool operator!=(const mapped_type &rhs) const {
+            return !this->operator==(rhs);
+        }
         internal::bridge::core_dictionary m_backing_map;
         internal::bridge::realm m_realm;
         std::string m_key;
@@ -161,6 +164,9 @@ namespace realm::experimental {
         bool operator==(const V& rhs) const {
             return this->m_backing_map.get(this->m_key).operator int64_t() == static_cast<int64_t>(rhs);
         }
+        bool operator!=(const V& rhs) const {
+            return !this->operator==(rhs);
+        }
     };
     template<typename V>
     struct box<V, std::enable_if_t<std::is_enum_v<typename V::value_type>>> : public box_base<V> {
@@ -176,12 +182,15 @@ namespace realm::experimental {
             };
         }
 
-        bool operator==(const V &rhs) const {
+        bool operator==(const V& rhs) const {
             auto v = this->m_backing_map.get(this->m_key);
             if (v.is_null() && !rhs) {
                 return true;
             }
             return static_cast<typename V::value_type>(v.operator int64_t()) == rhs;
+        }
+        bool operator!=(const V& rhs) const {
+            return !this->operator==(rhs);
         }
     };
     template<>
@@ -331,23 +340,35 @@ namespace realm::experimental {
             }
             return a.get_table() == b.get_table() && a.get_key() == b.get_key();
         }
+        bool operator!=(const V*& rhs) const {
+            return !this->operator==(rhs);
+        }
 
         bool operator==(const managed<V*> &rhs) const {
-            auto a = const_cast<box<V*> *>(this)->m_backing_map.get_object(this->m_key);
+           // const realm::experimental::box<realm::experimental::managed<realm::experimental::AllTypesObjectEmbedded *>> *' to 'box<realm::experimental::AllTypesObjectEmbedded *> *'
+            auto a = const_cast<box<managed<V*>> *>(this)->m_backing_map.get_object(this->m_key);
             auto &b = rhs.m_obj;
-            if (this->m_realm != rhs.m_realm) {
+            if (this->m_realm != *rhs.m_realm) {
                 return false;
             }
-            return a.get_table() == b.get_table() && a.get_key() == b.get_key();
+            return a.get_key() == b->get_key();
         }
+        bool operator!=(const managed<V*> rhs) const {
+            return !this->operator==(rhs);
+        }
+
         bool operator==(const managed<V> &rhs) const {
             auto a = const_cast<box<managed<V*>> *>(this)->m_backing_map.get_object(this->m_key);
             auto &b = rhs.m_obj;
             if (this->m_realm != rhs.m_realm) {
                 return false;
             }
-            return a.get_table() == b.get_table() && a.get_key() == b.get_key();
+            return a.get_key() == b.get_key();
         }
+        bool operator!=(const managed<V> rhs) const {
+            return !this->operator==(rhs);
+        }
+
         typename managed<V*>::ref_type operator*() {
             auto obj = this->m_backing_map.get_object(this->m_key);
             if (!obj.is_valid()) {
@@ -403,24 +424,34 @@ namespace realm::experimental {
             if (this->m_realm != rhs.m_realm) {
                 return false;
             }
-            return a.get_table() == b.get_table() && a.get_key() == b.get_key();
+            return a.get_key() == b.get_key();
         }
-        bool operator==(const V &rhs) const {
+        bool operator!=(const box<managed<V*>> rhs) const {
+            return !this->operator==(rhs);
+        }
+
+        bool operator==(const V& rhs) const {
             auto a = const_cast<box<managed<V*>> *>(this)->m_backing_map.get_object(this->m_key);
             auto &b = rhs.m_obj;
             if (this->m_realm != rhs.m_realm) {
                 return false;
             }
-            return a.get_table() == b.get_table() && a.get_key() == b.get_key();
+            return a.get_key() == b.get_key();
+        }
+        bool operator!=(const V& rhs) const {
+            return !this->operator==(rhs);
         }
 
-        bool operator==(const box<V*> &rhs) {
+        bool operator==(const box<V*>& rhs) {
             auto a = const_cast<box<managed<V*>> *>(this)->m_backing_map.get_object(this->m_key);
             auto &b = (&rhs)->m_obj;
             if (this->m_realm != rhs.m_realm) {
                 return false;
             }
-            return a.get_table() == b.get_table() && a.get_key() == b.get_key();
+            return a.get_key() == b.get_key();
+        }
+        bool operator!=(const box<V*>& rhs) const {
+            return !this->operator==(rhs);
         }
     };
 

--- a/src/cpprealm/experimental/managed_dictionary.hpp
+++ b/src/cpprealm/experimental/managed_dictionary.hpp
@@ -419,7 +419,7 @@ namespace realm::experimental {
         }
 
         box& operator=(const managed<V*>& o) {
-            this->m_backing_map.insert(this->m_key, o->m_obj->get_key());
+            this->m_backing_map.insert(this->m_key, o->m_obj.get_key());
             return *this;
         }
 

--- a/src/cpprealm/experimental/managed_dictionary.hpp
+++ b/src/cpprealm/experimental/managed_dictionary.hpp
@@ -396,7 +396,7 @@ namespace realm::experimental {
             return {std::move(m)};
         }
 
-        box operator=(V* o) {
+        box& operator=(V* o) {
             if (!o) {
                 // Insert null link for key.
                 this->m_backing_map.insert(this->m_key, realm::internal::bridge::mixed());
@@ -415,6 +415,16 @@ namespace realm::experimental {
                          m_obj, m_obj.get_table().get_column_key(p.name),
                          (*o).*(std::decay_t<decltype(p)>::ptr)), ...);
             }, managed<V>::schema.ps);
+            return *this;
+        }
+
+        box& operator=(const managed<V*>& o) {
+            this->m_backing_map.insert(this->m_key, o->m_obj->get_key());
+            return *this;
+        }
+
+        box& operator=(const managed<V>& o) {
+            this->m_backing_map.insert(this->m_key, o.m_obj.get_key());
             return *this;
         }
 

--- a/src/cpprealm/experimental/managed_dictionary.hpp
+++ b/src/cpprealm/experimental/managed_dictionary.hpp
@@ -345,7 +345,6 @@ namespace realm::experimental {
         }
 
         bool operator==(const managed<V*> &rhs) const {
-           // const realm::experimental::box<realm::experimental::managed<realm::experimental::AllTypesObjectEmbedded *>> *' to 'box<realm::experimental::AllTypesObjectEmbedded *> *'
             auto a = const_cast<box<managed<V*>> *>(this)->m_backing_map.get_object(this->m_key);
             auto &b = rhs.m_obj;
             if (this->m_realm != *rhs.m_realm) {

--- a/src/cpprealm/experimental/managed_dictionary.hpp
+++ b/src/cpprealm/experimental/managed_dictionary.hpp
@@ -468,7 +468,7 @@ namespace realm::experimental {
     struct managed<std::map<std::string, T>, void> : managed_base {
         using managed<std::map<std::string, T>>::managed_base::operator=;
 
-        [[nodiscard]] std::map<std::string, T> value() const {
+        [[nodiscard]] std::map<std::string, T> detach() const {
             if constexpr (std::is_pointer_v<T>) {
                 throw std::runtime_error("value() is not available on collections of managed objects. Access each object via subscript instead.");
             }

--- a/src/cpprealm/experimental/managed_list.hpp
+++ b/src/cpprealm/experimental/managed_list.hpp
@@ -78,6 +78,7 @@ namespace realm::experimental {
             return token;
         }
 
+        // TODO: emulate a reference to the value.
         T operator[](size_t idx) const {
             auto list = realm::internal::bridge::list(*m_realm, *m_obj, m_key);
             using U = typename internal::type_info::type_info<T>::internal_type;

--- a/src/cpprealm/experimental/managed_list.hpp
+++ b/src/cpprealm/experimental/managed_list.hpp
@@ -162,6 +162,15 @@ namespace realm::experimental {
                 throw std::logic_error("Cannot add existing embedded object to managed list.");
             }
         }
+        void push_back(const managed<T*>& value)
+        {
+            if (!managed<T>::schema.is_embedded_experimental()) {
+                auto list = internal::bridge::list(*m_realm, *m_obj, m_key);
+                list.add(value.m_obj->get_key());
+            } else {
+                throw std::logic_error("Cannot add existing embedded object to managed list.");
+            }
+        }
 
         size_t size()
         {

--- a/src/cpprealm/experimental/managed_list.hpp
+++ b/src/cpprealm/experimental/managed_list.hpp
@@ -62,7 +62,7 @@ namespace realm::experimental {
         {
             return iterator(size(), this);
         }
-        [[nodiscard]] std::vector<T> value() const {
+        [[nodiscard]] std::vector<T> detach() const {
             auto list = realm::internal::bridge::list(*m_realm, *m_obj, m_key);
             using U = typename internal::type_info::type_info<T>::internal_type;
 
@@ -133,8 +133,8 @@ namespace realm::experimental {
 
     template<typename T>
     struct managed<std::vector<T*>> : managed_base {
-        [[nodiscard]] std::vector<T*> value() const {
-            throw std::runtime_error("value() is not available on collections of managed objects. Access each object via subscript instead.");
+        [[nodiscard]] std::vector<T*> detach() const {
+            throw std::runtime_error("detach() is not available on collections of managed objects. Access each object via subscript instead.");
         }
 
         void pop_back() {

--- a/src/cpprealm/experimental/managed_mixed.hpp
+++ b/src/cpprealm/experimental/managed_mixed.hpp
@@ -24,12 +24,12 @@ namespace realm::experimental {
             return *this;
         }
 
-        [[nodiscard]] T value() const {
+        [[nodiscard]] T detach() const {
             return deserialize<T>(m_obj->get<realm::internal::bridge::mixed>(m_key));
         }
 
         [[nodiscard]] T operator *() const {
-            return value();
+            return detach();
         }
 
         //MARK: -   comparison operators
@@ -39,7 +39,7 @@ namespace realm::experimental {
                 query.equal(this->m_key, serialize(rhs));
                 return query;
             }
-            return value() == rhs;
+            return detach() == rhs;
         }
 
         rbool operator!=(const T& rhs) const noexcept {
@@ -48,7 +48,7 @@ namespace realm::experimental {
                 query.not_equal(this->m_key, serialize(rhs));
                 return query;
             }
-            return value() != rhs;
+            return detach() != rhs;
         }
 
         rbool operator==(const std::nullopt_t& rhs) const noexcept {
@@ -57,7 +57,7 @@ namespace realm::experimental {
                 query.equal(this->m_key, rhs);
                 return query;
             }
-            return value() == T(std::monostate());
+            return detach() == T(std::monostate());
         }
 
         rbool operator!=(const std::nullopt_t& rhs) const noexcept {
@@ -66,7 +66,7 @@ namespace realm::experimental {
                 query.not_equal(this->m_key, rhs);
                 return query;
             }
-            return value() != T(std::monostate());
+            return detach() != T(std::monostate());
         }
     };
 }

--- a/src/cpprealm/experimental/managed_numeric.cpp
+++ b/src/cpprealm/experimental/managed_numeric.cpp
@@ -1,13 +1,6 @@
 #include <cpprealm/experimental/managed_numeric.hpp>
 
 namespace realm::experimental {
-    __cpprealm_build_experimental_query(==, equal, int64_t)
-    __cpprealm_build_experimental_query(!=, not_equal, int64_t)
-    __cpprealm_build_experimental_query(>, greater, int64_t)
-    __cpprealm_build_experimental_query(>=, greater_equal, int64_t)
-    __cpprealm_build_experimental_query(<, less, int64_t)
-    __cpprealm_build_experimental_query(<=, less_equal, int64_t)
-
     __cpprealm_build_experimental_query(==, equal, double)
     __cpprealm_build_experimental_query(!=, not_equal, double)
     __cpprealm_build_experimental_query(>, greater, double)

--- a/src/cpprealm/experimental/managed_numeric.cpp
+++ b/src/cpprealm/experimental/managed_numeric.cpp
@@ -1,13 +1,6 @@
 #include <cpprealm/experimental/managed_numeric.hpp>
 
 namespace realm::experimental {
-    __cpprealm_build_experimental_query(==, equal, double)
-    __cpprealm_build_experimental_query(!=, not_equal, double)
-    __cpprealm_build_experimental_query(>, greater, double)
-    __cpprealm_build_experimental_query(>=, greater_equal, double)
-    __cpprealm_build_experimental_query(<, less, double)
-    __cpprealm_build_experimental_query(<=, less_equal, double)
-
     __cpprealm_build_experimental_query(==, equal, bool)
     __cpprealm_build_experimental_query(!=, not_equal, bool)
 

--- a/src/cpprealm/experimental/managed_numeric.hpp
+++ b/src/cpprealm/experimental/managed_numeric.hpp
@@ -135,12 +135,67 @@ namespace realm::experimental {
         [[nodiscard]] operator double() const {
             return value();
         }
-        rbool operator==(const double& rhs) const noexcept;
-        rbool operator!=(const double& rhs) const noexcept;
-        rbool operator>(const double& rhs) const noexcept;
-        rbool operator<(const double& rhs) const noexcept;
-        rbool operator>=(const double& rhs) const noexcept;
-        rbool operator<=(const double& rhs) const noexcept;
+
+        template<typename T>
+        std::enable_if_t< std::disjunction_v<std::is_integral<T>, std::is_floating_point<T>>, rbool> operator==(const T& rhs) const noexcept {
+            if (this->should_detect_usage_for_queries) {
+                auto query = internal::bridge::query(this->query->get_table());
+                query.equal(this->m_key, (double)rhs);
+                return rbool(std::move(query));
+            }
+            return serialize(value()) == rhs;
+        }
+
+        template<typename T>
+        std::enable_if_t< std::disjunction_v<std::is_integral<T>, std::is_floating_point<T>>, rbool> operator!=(const T& rhs) const noexcept {
+            if (this->should_detect_usage_for_queries) {
+                auto query = internal::bridge::query(this->query->get_table());
+                query.not_equal(this->m_key, (double)rhs);
+                return rbool(std::move(query));
+            }
+            return serialize(value()) != rhs;
+        }
+
+        template<typename T>
+        std::enable_if_t< std::disjunction_v<std::is_integral<T>, std::is_floating_point<T>>, rbool> operator>(const T& rhs) const noexcept {
+            if (this->should_detect_usage_for_queries) {
+                auto query = internal::bridge::query(this->query->get_table());
+                query.greater(this->m_key, (double)rhs);
+                return rbool(std::move(query));
+            }
+            return serialize(value()) > rhs;
+        }
+
+        template<typename T>
+        std::enable_if_t< std::disjunction_v<std::is_integral<T>, std::is_floating_point<T>>, rbool> operator<(const T& rhs) const noexcept {
+            if (this->should_detect_usage_for_queries) {
+                auto query = internal::bridge::query(this->query->get_table());
+                query.less(this->m_key, (double)rhs);
+                return rbool(std::move(query));
+            }
+            return serialize(value()) < rhs;
+        }
+
+        template<typename T>
+        std::enable_if_t< std::disjunction_v<std::is_integral<T>, std::is_floating_point<T>>, rbool> operator>=(const T& rhs) const noexcept {
+            if (this->should_detect_usage_for_queries) {
+                auto query = internal::bridge::query(this->query->get_table());
+                query.greater_equal(this->m_key, (double)rhs);
+                return rbool(std::move(query));
+            }
+            return serialize(value()) >= rhs;
+        }
+
+        template<typename T>
+        std::enable_if_t< std::disjunction_v<std::is_integral<T>, std::is_floating_point<T>>, rbool> operator<=(const T& rhs) const noexcept {
+            if (this->should_detect_usage_for_queries) {
+                auto query = internal::bridge::query(this->query->get_table());
+                query.less_equal(this->m_key, (double)rhs);
+                return rbool(std::move(query));
+            }
+            return serialize(value()) <= rhs;
+        }
+
         void operator+=(const double& o) {
             auto old_val = m_obj->template get<double>(m_key);
             m_obj->template set<double>(this->m_key, old_val + o);
@@ -185,6 +240,17 @@ namespace realm::experimental {
     template<> \
     struct managed<std::optional<type>> : managed_base { \
         using managed<std::optional<type>>::managed_base::operator=; \
+                                                 \
+        managed<std::optional<type>>& operator =(const double& v) { \
+            this->m_obj->template set<type>(m_key, v); \
+            return *this; \
+        } \
+        \
+        managed<std::optional<type>>& operator =(const int& v) { \
+            this->m_obj->template set<type>(m_key, (double)v); \
+            return *this; \
+        } \
+                                                 \
         [[nodiscard]] std::optional<type> value() const { \
             return m_obj->get_optional<type>(m_key); \
         } \

--- a/src/cpprealm/experimental/managed_numeric.hpp
+++ b/src/cpprealm/experimental/managed_numeric.hpp
@@ -18,34 +18,96 @@ namespace realm::experimental {
             return m_obj->template get<int64_t>(m_key);
         }
 
-        int64_t operator *() const {
+        [[nodiscard]] int64_t operator *() const {
             return value();
         }
-        rbool operator==(const int64_t& rhs) const noexcept;
-        rbool operator!=(const int64_t& rhs) const noexcept;
-        rbool operator>(const int64_t& rhs) const noexcept;
-        rbool operator<(const int64_t& rhs) const noexcept;
-        rbool operator>=(const int64_t& rhs) const noexcept;
-        rbool operator<=(const int64_t& rhs) const noexcept;
-        void operator+=(const int64_t& o) {
+
+        [[nodiscard]] operator int64_t() const {
+            return value();
+        }
+
+        template<typename T>
+        std::enable_if_t<std::is_integral_v<T>, rbool> operator==(const T& rhs) const noexcept {
+            if (this->should_detect_usage_for_queries) {
+                auto query = internal::bridge::query(this->query->get_table());
+                query.equal(this->m_key, (int64_t)rhs);
+                return rbool(std::move(query));
+            }
+            return serialize(value()) == rhs;
+        }
+
+        template<typename T>
+        std::enable_if_t<std::is_integral_v<T>, rbool> operator!=(const T& rhs) const noexcept {
+            if (this->should_detect_usage_for_queries) {
+                auto query = internal::bridge::query(this->query->get_table());
+                query.not_equal(this->m_key, (int64_t)rhs);
+                return rbool(std::move(query));
+            }
+            return serialize(value()) != rhs;
+        }
+
+        template<typename T>
+        std::enable_if_t<std::is_integral_v<T>, rbool> operator>(const T& rhs) const noexcept {
+            if (this->should_detect_usage_for_queries) {
+                auto query = internal::bridge::query(this->query->get_table());
+                query.greater(this->m_key, (int64_t)rhs);
+                return rbool(std::move(query));
+            }
+            return serialize(value()) > rhs;
+        }
+
+        template<typename T>
+        std::enable_if_t<std::is_integral_v<T>, rbool> operator<(const T& rhs) const noexcept {
+            if (this->should_detect_usage_for_queries) {
+                auto query = internal::bridge::query(this->query->get_table());
+                query.less(this->m_key, (int64_t)rhs);
+                return rbool(std::move(query));
+            }
+            return serialize(value()) < rhs;
+        }
+
+        template<typename T>
+        std::enable_if_t<std::is_integral_v<T>, rbool> operator>=(const T& rhs) const noexcept {
+            if (this->should_detect_usage_for_queries) {
+                auto query = internal::bridge::query(this->query->get_table());
+                query.greater_equal(this->m_key, (int64_t)rhs);
+                return rbool(std::move(query));
+            }
+            return serialize(value()) >= rhs;
+        }
+
+        template<typename T>
+        std::enable_if_t<std::is_integral_v<T>, rbool> operator<=(const T& rhs) const noexcept {
+            if (this->should_detect_usage_for_queries) {
+                auto query = internal::bridge::query(this->query->get_table());
+                query.less_equal(this->m_key, (int64_t)rhs);
+                return rbool(std::move(query));
+            }
+            return serialize(value()) <= rhs;
+        }
+
+        managed& operator+=(const int64_t& o) {
             auto old_val = m_obj->template get<int64_t>(m_key);
             m_obj->template set<int64_t>(this->m_key, old_val + o);
+            return *this;
         }
-        void operator++() {
+        void operator++(int) {
             auto old_val = m_obj->template get<int64_t>(m_key);
-            m_obj->template set<int64_t>(this->m_key, old_val++);
+            m_obj->template set<int64_t>(this->m_key, old_val + 1);
         }
-        void operator-=(const int64_t& o) {
+        managed& operator-=(const int64_t& o) {
             auto old_val = m_obj->template get<int64_t>(m_key);
             m_obj->template set<int64_t>(this->m_key, old_val - o);
+            return *this;
         }
-        void operator--() {
+        void operator--(int) {
             auto old_val = m_obj->template get<int64_t>(m_key);
-            m_obj->template set<int64_t>(this->m_key, old_val--);
+            m_obj->template set<int64_t>(this->m_key, old_val - 1);
         }
-        void operator*=(const int64_t& o) {
+        managed& operator*=(const int64_t& o) {
             auto old_val = m_obj->template get<int64_t>(m_key);
             m_obj->template set<int64_t>(this->m_key, old_val * o);
+            return *this;
         }
     };
 
@@ -70,6 +132,9 @@ namespace realm::experimental {
         double operator *() const {
             return value();
         }
+        [[nodiscard]] operator double() const {
+            return value();
+        }
         rbool operator==(const double& rhs) const noexcept;
         rbool operator!=(const double& rhs) const noexcept;
         rbool operator>(const double& rhs) const noexcept;
@@ -80,17 +145,17 @@ namespace realm::experimental {
             auto old_val = m_obj->template get<double>(m_key);
             m_obj->template set<double>(this->m_key, old_val + o);
         }
-        void operator++() {
+        void operator++(int) {
             auto old_val = m_obj->template get<double>(m_key);
-            m_obj->template set<double>(this->m_key, old_val++);
+            m_obj->template set<double>(this->m_key, old_val + 1.0);
         }
         void operator-=(const double& o) {
             auto old_val = m_obj->template get<double>(m_key);
             m_obj->template set<double>(this->m_key, old_val - o);
         }
-        void operator--() {
+        void operator--(int) {
             auto old_val = m_obj->template get<double>(m_key);
-            m_obj->template set<double>(this->m_key, old_val--);
+            m_obj->template set<double>(this->m_key, old_val - 1.0);
         }
         void operator*=(const double& o) {
             auto old_val = m_obj->template get<double>(m_key);
@@ -105,7 +170,9 @@ namespace realm::experimental {
         [[nodiscard]] bool value() const {
             return m_obj->template get<bool>(m_key);
         }
-
+        [[nodiscard]] operator bool() const {
+            return value();
+        }
         bool operator *() const {
             return value();
         }
@@ -125,7 +192,9 @@ namespace realm::experimental {
         [[nodiscard]] std::optional<type> operator *() const { \
             return value(); \
         } \
-\
+        [[nodiscard]] operator std::optional<type>() const { \
+            return value(); \
+        } \
         rbool operator==(const std::optional<type>& rhs) const noexcept; \
         rbool operator!=(const std::optional<type>& rhs) const noexcept; \
         void operator+=(const type& o) { \
@@ -135,12 +204,12 @@ namespace realm::experimental {
             } \
             m_obj->template set<type>(this->m_key, (*old_val) + o); \
         } \
-        void operator++() { \
+        void operator++(int) { \
             auto old_val = m_obj->get_optional<type>(m_key);    \
             if (!old_val) { \
                 throw std::runtime_error("Cannot perform arithmetic on null value."); \
             } \
-            m_obj->template set<type>(this->m_key, (*old_val)++); \
+            m_obj->template set<type>(this->m_key, (*old_val) + 1); \
         } \
         void operator-=(const type& o) { \
             auto old_val = m_obj->get_optional<type>(m_key);    \
@@ -149,12 +218,12 @@ namespace realm::experimental {
             } \
             m_obj->template set<type>(this->m_key, (*old_val) - o); \
         } \
-        void operator--() { \
+        void operator--(int) { \
             auto old_val = m_obj->get_optional<type>(m_key);    \
             if (!old_val) { \
                 throw std::runtime_error("Cannot perform arithmetic on null value."); \
             } \
-            m_obj->template set<type>(this->m_key, (*old_val)--); \
+            m_obj->template set<type>(this->m_key, (*old_val) - 1); \
         } \
         void operator*=(const type& o) { \
             auto old_val = m_obj->get_optional<type>(m_key);    \
@@ -187,6 +256,10 @@ CPP_REALM_MANAGED_OPTIONAL_NUMERIC(double);
         using managed<std::optional<bool>>::managed_base::operator=;
 
         [[nodiscard]] std::optional<bool> value() const {
+            return m_obj->template get_optional<bool>(m_key);
+        }
+
+        [[nodiscard]] operator std::optional<bool>() const {
             return m_obj->template get_optional<bool>(m_key);
         }
 

--- a/src/cpprealm/experimental/managed_numeric.hpp
+++ b/src/cpprealm/experimental/managed_numeric.hpp
@@ -95,12 +95,20 @@ namespace realm::experimental {
             auto old_val = m_obj->template get<int64_t>(m_key);
             m_obj->template set<int64_t>(this->m_key, old_val + 1);
         }
+        void operator++() {
+            auto old_val = m_obj->template get<int64_t>(m_key);
+            m_obj->template set<int64_t>(this->m_key, old_val + 1);
+        }
         managed& operator-=(const int64_t& o) {
             auto old_val = m_obj->template get<int64_t>(m_key);
             m_obj->template set<int64_t>(this->m_key, old_val - o);
             return *this;
         }
         void operator--(int) {
+            auto old_val = m_obj->template get<int64_t>(m_key);
+            m_obj->template set<int64_t>(this->m_key, old_val - 1);
+        }
+        void operator--() {
             auto old_val = m_obj->template get<int64_t>(m_key);
             m_obj->template set<int64_t>(this->m_key, old_val - 1);
         }
@@ -204,11 +212,19 @@ namespace realm::experimental {
             auto old_val = m_obj->template get<double>(m_key);
             m_obj->template set<double>(this->m_key, old_val + 1.0);
         }
+        void operator++() {
+            auto old_val = m_obj->template get<double>(m_key);
+            m_obj->template set<double>(this->m_key, old_val + 1.0);
+        }
         void operator-=(const double& o) {
             auto old_val = m_obj->template get<double>(m_key);
             m_obj->template set<double>(this->m_key, old_val - o);
         }
         void operator--(int) {
+            auto old_val = m_obj->template get<double>(m_key);
+            m_obj->template set<double>(this->m_key, old_val - 1.0);
+        }
+        void operator--() {
             auto old_val = m_obj->template get<double>(m_key);
             m_obj->template set<double>(this->m_key, old_val - 1.0);
         }

--- a/src/cpprealm/experimental/managed_numeric.hpp
+++ b/src/cpprealm/experimental/managed_numeric.hpp
@@ -14,16 +14,16 @@ namespace realm::experimental {
             return *this;
         }
 
-        [[nodiscard]] int64_t value() const {
+        [[nodiscard]] int64_t detach() const {
             return m_obj->template get<int64_t>(m_key);
         }
 
         [[nodiscard]] int64_t operator *() const {
-            return value();
+            return detach();
         }
 
         [[nodiscard]] operator int64_t() const {
-            return value();
+            return detach();
         }
 
         template<typename T>
@@ -33,7 +33,7 @@ namespace realm::experimental {
                 query.equal(this->m_key, (int64_t)rhs);
                 return rbool(std::move(query));
             }
-            return serialize(value()) == rhs;
+            return serialize(detach()) == rhs;
         }
 
         template<typename T>
@@ -43,7 +43,7 @@ namespace realm::experimental {
                 query.not_equal(this->m_key, (int64_t)rhs);
                 return rbool(std::move(query));
             }
-            return serialize(value()) != rhs;
+            return serialize(detach()) != rhs;
         }
 
         template<typename T>
@@ -53,7 +53,7 @@ namespace realm::experimental {
                 query.greater(this->m_key, (int64_t)rhs);
                 return rbool(std::move(query));
             }
-            return serialize(value()) > rhs;
+            return serialize(detach()) > rhs;
         }
 
         template<typename T>
@@ -63,7 +63,7 @@ namespace realm::experimental {
                 query.less(this->m_key, (int64_t)rhs);
                 return rbool(std::move(query));
             }
-            return serialize(value()) < rhs;
+            return serialize(detach()) < rhs;
         }
 
         template<typename T>
@@ -73,7 +73,7 @@ namespace realm::experimental {
                 query.greater_equal(this->m_key, (int64_t)rhs);
                 return rbool(std::move(query));
             }
-            return serialize(value()) >= rhs;
+            return serialize(detach()) >= rhs;
         }
 
         template<typename T>
@@ -83,7 +83,7 @@ namespace realm::experimental {
                 query.less_equal(this->m_key, (int64_t)rhs);
                 return rbool(std::move(query));
             }
-            return serialize(value()) <= rhs;
+            return serialize(detach()) <= rhs;
         }
 
         managed& operator+=(const int64_t& o) {
@@ -133,15 +133,15 @@ namespace realm::experimental {
             return *this;
         }
 
-        [[nodiscard]] double value() const {
+        [[nodiscard]] double detach() const {
             return m_obj->template get<double>(m_key);
         }
 
         double operator *() const {
-            return value();
+            return detach();
         }
         [[nodiscard]] operator double() const {
-            return value();
+            return detach();
         }
 
         template<typename T>
@@ -151,7 +151,7 @@ namespace realm::experimental {
                 query.equal(this->m_key, (double)rhs);
                 return rbool(std::move(query));
             }
-            return serialize(value()) == rhs;
+            return serialize(detach()) == rhs;
         }
 
         template<typename T>
@@ -161,7 +161,7 @@ namespace realm::experimental {
                 query.not_equal(this->m_key, (double)rhs);
                 return rbool(std::move(query));
             }
-            return serialize(value()) != rhs;
+            return serialize(detach()) != rhs;
         }
 
         template<typename T>
@@ -171,7 +171,7 @@ namespace realm::experimental {
                 query.greater(this->m_key, (double)rhs);
                 return rbool(std::move(query));
             }
-            return serialize(value()) > rhs;
+            return serialize(detach()) > rhs;
         }
 
         template<typename T>
@@ -181,7 +181,7 @@ namespace realm::experimental {
                 query.less(this->m_key, (double)rhs);
                 return rbool(std::move(query));
             }
-            return serialize(value()) < rhs;
+            return serialize(detach()) < rhs;
         }
 
         template<typename T>
@@ -191,7 +191,7 @@ namespace realm::experimental {
                 query.greater_equal(this->m_key, (double)rhs);
                 return rbool(std::move(query));
             }
-            return serialize(value()) >= rhs;
+            return serialize(detach()) >= rhs;
         }
 
         template<typename T>
@@ -201,7 +201,7 @@ namespace realm::experimental {
                 query.less_equal(this->m_key, (double)rhs);
                 return rbool(std::move(query));
             }
-            return serialize(value()) <= rhs;
+            return serialize(detach()) <= rhs;
         }
 
         void operator+=(const double& o) {
@@ -238,14 +238,14 @@ namespace realm::experimental {
     struct managed<bool> : managed_base {
         using managed<bool>::managed_base::operator=;
 
-        [[nodiscard]] bool value() const {
+        [[nodiscard]] bool detach() const {
             return m_obj->template get<bool>(m_key);
         }
         [[nodiscard]] operator bool() const {
-            return value();
+            return detach();
         }
         bool operator *() const {
-            return value();
+            return detach();
         }
 
         rbool operator==(const bool& rhs) const noexcept;
@@ -267,15 +267,15 @@ namespace realm::experimental {
             return *this; \
         } \
                                                  \
-        [[nodiscard]] std::optional<type> value() const { \
+        [[nodiscard]] std::optional<type> detach() const { \
             return m_obj->get_optional<type>(m_key); \
         } \
 \
         [[nodiscard]] std::optional<type> operator *() const { \
-            return value(); \
+            return detach(); \
         } \
         [[nodiscard]] operator std::optional<type>() const { \
-            return value(); \
+            return detach(); \
         } \
         rbool operator==(const std::optional<type>& rhs) const noexcept; \
         rbool operator!=(const std::optional<type>& rhs) const noexcept; \
@@ -337,7 +337,7 @@ CPP_REALM_MANAGED_OPTIONAL_NUMERIC(double);
     struct managed<std::optional<bool>> : managed_base {
         using managed<std::optional<bool>>::managed_base::operator=;
 
-        [[nodiscard]] std::optional<bool> value() const {
+        [[nodiscard]] std::optional<bool> detach() const {
             return m_obj->template get_optional<bool>(m_key);
         }
 
@@ -346,7 +346,7 @@ CPP_REALM_MANAGED_OPTIONAL_NUMERIC(double);
         }
 
         std::optional<bool> operator *() const {
-            return value();
+            return detach();
         }
 
         rbool operator==(const std::optional<bool>& rhs) const noexcept;
@@ -360,16 +360,16 @@ CPP_REALM_MANAGED_OPTIONAL_NUMERIC(double);
             return *this;
         }
 
-        [[nodiscard]] T value() const {
+        [[nodiscard]] T detach() const {
             return static_cast<T>(m_obj->get<int64_t>(m_key));
         }
 
         [[nodiscard]] T operator *() const {
-            return value();
+            return detach();
         }
 
         [[nodiscard]] operator T() const {
-            return value();
+            return detach();
         }
 
         //MARK: -   comparison operators
@@ -379,7 +379,7 @@ CPP_REALM_MANAGED_OPTIONAL_NUMERIC(double);
                 query.equal(this->m_key, serialize(rhs));
                 return query;
             }
-            return value() == rhs;
+            return detach() == rhs;
         }
         rbool operator!=(const T& rhs) const noexcept {
             if (this->should_detect_usage_for_queries) {
@@ -387,7 +387,7 @@ CPP_REALM_MANAGED_OPTIONAL_NUMERIC(double);
                 query.not_equal(this->m_key, serialize(rhs));
                 return query;
             }
-            return value() != rhs;
+            return detach() != rhs;
         }
         rbool operator>(const T& rhs) const noexcept {
             if (this->should_detect_usage_for_queries) {
@@ -395,7 +395,7 @@ CPP_REALM_MANAGED_OPTIONAL_NUMERIC(double);
                 query.greater(this->m_key, serialize(rhs));
                 return query;
             }
-            return value() > rhs;
+            return detach() > rhs;
         }
         rbool operator<(const T& rhs) const noexcept {
             if (this->should_detect_usage_for_queries) {
@@ -403,7 +403,7 @@ CPP_REALM_MANAGED_OPTIONAL_NUMERIC(double);
                 query.less(this->m_key, serialize(rhs));
                 return query;
             }
-            return value() < rhs;
+            return detach() < rhs;
         }
         rbool operator>=(const T& rhs) const noexcept {
             if (this->should_detect_usage_for_queries) {
@@ -411,7 +411,7 @@ CPP_REALM_MANAGED_OPTIONAL_NUMERIC(double);
                 query.greater_equal(this->m_key, serialize(rhs));
                 return query;
             }
-            return value() >= rhs;
+            return detach() >= rhs;
         }
         rbool operator<=(const T& rhs) const noexcept {
             if (this->should_detect_usage_for_queries) {
@@ -419,7 +419,7 @@ CPP_REALM_MANAGED_OPTIONAL_NUMERIC(double);
                 query.less_equal(this->m_key, serialize(rhs));
                 return query;
             }
-            return value() <= rhs;
+            return detach() <= rhs;
         }
     };
 
@@ -434,7 +434,7 @@ CPP_REALM_MANAGED_OPTIONAL_NUMERIC(double);
             return *this;
         }
 
-        [[nodiscard]] std::optional<T> value() const {
+        [[nodiscard]] std::optional<T> detach() const {
             if (auto v = m_obj->get_optional<int64_t>(m_key)) {
                 return static_cast<T>(*v);
             }
@@ -442,11 +442,11 @@ CPP_REALM_MANAGED_OPTIONAL_NUMERIC(double);
         }
 
         [[nodiscard]] std::optional<T> operator *() const {
-            return value();
+            return detach();
         }
 
         [[nodiscard]] operator std::optional<T>() const {
-            return value();
+            return detach();
         }
 
         //MARK: -   comparison operators
@@ -460,7 +460,7 @@ CPP_REALM_MANAGED_OPTIONAL_NUMERIC(double);
                 }
                 return query;
             }
-            return value() == rhs;
+            return detach() == rhs;
         }
         rbool operator!=(const std::optional<T>& rhs) const noexcept {
             if (this->should_detect_usage_for_queries) {
@@ -472,7 +472,7 @@ CPP_REALM_MANAGED_OPTIONAL_NUMERIC(double);
                 }
                 return query;
             }
-            return value() != rhs;
+            return detach() != rhs;
         }
         rbool operator>(const T& rhs) const noexcept {
             if (this->should_detect_usage_for_queries) {
@@ -480,7 +480,7 @@ CPP_REALM_MANAGED_OPTIONAL_NUMERIC(double);
                 query.greater(this->m_key, serialize(rhs));
                 return query;
             }
-            return value() > rhs;
+            return detach() > rhs;
         }
         rbool operator<(const T& rhs) const noexcept {
             if (this->should_detect_usage_for_queries) {
@@ -488,7 +488,7 @@ CPP_REALM_MANAGED_OPTIONAL_NUMERIC(double);
                 query.less(this->m_key, serialize(rhs));
                 return query;
             }
-            return value() < rhs;
+            return detach() < rhs;
         }
         rbool operator>=(const T& rhs) const noexcept {
             if (this->should_detect_usage_for_queries) {
@@ -496,7 +496,7 @@ CPP_REALM_MANAGED_OPTIONAL_NUMERIC(double);
                 query.greater_equal(this->m_key, serialize(rhs));
                 return query;
             }
-            return value() >= rhs;
+            return detach() >= rhs;
         }
         rbool operator<=(const T& rhs) const noexcept {
             if (this->should_detect_usage_for_queries) {
@@ -504,7 +504,7 @@ CPP_REALM_MANAGED_OPTIONAL_NUMERIC(double);
                 query.less_equal(this->m_key, serialize(rhs));
                 return query;
             }
-            return value() <= rhs;
+            return detach() <= rhs;
         }
     };
 } // namespace realm::experimental

--- a/src/cpprealm/experimental/managed_objectid.hpp
+++ b/src/cpprealm/experimental/managed_objectid.hpp
@@ -22,7 +22,7 @@ namespace realm::experimental {
             return value();
         }
 
-        [[nodiscard]] operator realm::object_id () const {
+        [[nodiscard]] operator realm::object_id() const {
             return value();
         }
 

--- a/src/cpprealm/experimental/managed_objectid.hpp
+++ b/src/cpprealm/experimental/managed_objectid.hpp
@@ -14,16 +14,16 @@ namespace realm::experimental {
     template<>
     struct managed<realm::object_id> : managed_base {
         using managed<realm::object_id>::managed_base::operator=;
-        [[nodiscard]] realm::object_id value() const {
+        [[nodiscard]] realm::object_id detach() const {
             return m_obj->template get<realm::internal::bridge::object_id>(m_key).operator ::realm::object_id();
         }
 
         [[nodiscard]] realm::object_id operator *() const {
-            return value();
+            return detach();
         }
 
         [[nodiscard]] operator realm::object_id() const {
-            return value();
+            return detach();
         }
 
         //MARK: -   comparison operators
@@ -35,7 +35,7 @@ namespace realm::experimental {
     struct managed<std::optional<realm::object_id>> : managed_base {
         using managed<std::optional<realm::object_id>>::managed_base::operator=;
 
-        [[nodiscard]] std::optional<realm::object_id> value() const {
+        [[nodiscard]] std::optional<realm::object_id> detach() const {
             auto v = m_obj->template get_optional<realm::internal::bridge::object_id>(m_key);
             if (v) {
                 return v.value().operator ::realm::object_id();
@@ -45,11 +45,11 @@ namespace realm::experimental {
         }
 
         [[nodiscard]] std::optional<realm::object_id> operator *() const {
-            return value();
+            return detach();
         }
 
         [[nodiscard]] operator std::optional<realm::object_id>() const {
-            return value();
+            return detach();
         }
 
         //MARK: -   comparison operators

--- a/src/cpprealm/experimental/managed_primary_key.cpp
+++ b/src/cpprealm/experimental/managed_primary_key.cpp
@@ -9,7 +9,7 @@ namespace realm::experimental {
             query.name(this->m_key, serialize(rhs)); \
             return query; \
         } \
-        return serialize(value().value) op serialize(rhs); \
+        return serialize(detach().value) op serialize(rhs); \
     } \
 
 // Int needs to be cast to int64_t
@@ -20,7 +20,7 @@ namespace realm::experimental {
             query.name(this->m_key, serialize((cast)rhs)); \
             return query; \
         } \
-        return serialize(value().value) op serialize((cast)rhs); \
+        return serialize(detach().value) op serialize((cast)rhs); \
     }  \
 
     __cpprealm_build_experimental_pk_query(==, equal, int64_t, int64_t)
@@ -52,7 +52,7 @@ namespace realm::experimental {
             query.equal(this->m_key, serialize(std::string(rhs)));
             return query;
         }
-        return serialize(value().value) == serialize(std::string(rhs));
+        return serialize(detach().value) == serialize(std::string(rhs));
     }
 
     rbool managed<primary_key<std::string>>::operator !=(const char* rhs) const noexcept {
@@ -61,7 +61,7 @@ namespace realm::experimental {
             query.not_equal(this->m_key, serialize(std::string(rhs)));
             return query;
         }
-        return serialize(value().value) != serialize(std::string(rhs));
+        return serialize(detach().value) != serialize(std::string(rhs));
     }
 
     rbool managed<primary_key<std::optional<std::string>>>::operator ==(const char* rhs) const noexcept {
@@ -70,7 +70,7 @@ namespace realm::experimental {
             query.equal(this->m_key, serialize(std::string(rhs)));
             return query;
         }
-        return serialize(value().value) == serialize(std::string(rhs));
+        return serialize(detach().value) == serialize(std::string(rhs));
     }
 
     rbool managed<primary_key<std::optional<std::string>>>::operator !=(const char* rhs) const noexcept {
@@ -79,7 +79,7 @@ namespace realm::experimental {
             query.not_equal(this->m_key, serialize(std::string(rhs)));
             return query;
         }
-        return serialize(value().value) != serialize(std::string(rhs));
+        return serialize(detach().value) != serialize(std::string(rhs));
     }
 
     // MARK: Optional
@@ -105,7 +105,7 @@ namespace realm::experimental {
             } \
             return query; \
         } \
-        return serialize(value()) op serialize(rhs); \
+        return serialize(detach()) op serialize(rhs); \
     } \
 
     __cpprealm_build_optional_experimental_pk_query(==, equal, int64_t, std::optional<int64_t>)

--- a/src/cpprealm/experimental/managed_primary_key.hpp
+++ b/src/cpprealm/experimental/managed_primary_key.hpp
@@ -167,7 +167,7 @@ namespace realm::experimental {
         struct managed<primary_key<int64_t>> : managed_base {
             using managed<primary_key<int64_t>>::managed_base::operator=;
 
-            primary_key<int64_t> value() const {
+            primary_key<int64_t> detach() const {
                 return operator int64_t();
             }
 
@@ -193,7 +193,7 @@ namespace realm::experimental {
         struct managed<primary_key<std::string>> : managed_base {
             using managed<primary_key<std::string>>::managed_base::operator=;
 
-            primary_key<std::string> value() const {
+            primary_key<std::string> detach() const {
                 return operator std::string();
             }
 
@@ -211,7 +211,7 @@ namespace realm::experimental {
         struct managed<primary_key<realm::uuid>> : managed_base {
             using managed<primary_key<realm::uuid>>::managed_base::operator=;
 
-            primary_key<realm::uuid> value() const {
+            primary_key<realm::uuid> detach() const {
                 return operator realm::uuid();
             }
 
@@ -227,7 +227,7 @@ namespace realm::experimental {
         struct managed<primary_key<realm::object_id>> : managed_base {
             using managed<primary_key<realm::object_id>>::managed_base::operator=;
 
-            primary_key<realm::object_id> value() const {
+            primary_key<realm::object_id> detach() const {
                 return operator realm::object_id();
             }
 
@@ -243,7 +243,7 @@ namespace realm::experimental {
         struct managed<primary_key<T>, std::enable_if_t<std::is_enum_v<T>>> : managed_base {
             using managed<primary_key<int64_t>>::managed_base::operator=;
 
-            primary_key<T> value() const {
+            primary_key<T> detach() const {
                 return operator T();
             }
 
@@ -257,7 +257,7 @@ namespace realm::experimental {
                     query.equal(this->m_key, serialize(rhs));
                     return query;
                 }
-                return serialize(value().value) == serialize(rhs);
+                return serialize(detach().value) == serialize(rhs);
             }
             rbool operator!=(const T& rhs) const noexcept {
                 if (this->should_detect_usage_for_queries) {
@@ -265,7 +265,7 @@ namespace realm::experimental {
                     query.not_equal(this->m_key, serialize(rhs));
                     return query;
                 }
-                return serialize(value().value) != serialize(rhs);
+                return serialize(detach().value) != serialize(rhs);
             }
         };
 
@@ -273,7 +273,7 @@ namespace realm::experimental {
         struct managed<primary_key<std::optional<int64_t>>> : managed_base {
             using managed<primary_key<std::optional<int64_t>>>::managed_base::operator=;
 
-            primary_key<std::optional<int64_t>> value() const {
+            primary_key<std::optional<int64_t>> detach() const {
                 return operator std::optional<int64_t>();
             }
 
@@ -298,7 +298,7 @@ namespace realm::experimental {
                                                                            std::is_enum<typename T::value_type> >>> : managed_base {
             using managed<primary_key<std::optional<int64_t>>>::managed_base::operator=;
 
-            primary_key<T> value() const {
+            primary_key<T> detach() const {
                 return operator T();
             }
 
@@ -321,7 +321,7 @@ namespace realm::experimental {
                     }
                     return query;
                 }
-                return serialize(value().value) == serialize(rhs);
+                return serialize(detach().value) == serialize(rhs);
             }
             rbool operator!=(const T& rhs) const noexcept {
                 if (this->should_detect_usage_for_queries) {
@@ -333,7 +333,7 @@ namespace realm::experimental {
                     }
                     return query;
                 }
-                return serialize(value().value) != serialize(rhs);
+                return serialize(detach().value) != serialize(rhs);
             }
         };
 
@@ -341,7 +341,7 @@ namespace realm::experimental {
         struct managed<primary_key<std::optional<std::string>>> : managed_base {
             using managed<primary_key<std::optional<std::string>>>::managed_base::operator=;
 
-            primary_key<std::optional<std::string>> value() const {
+            primary_key<std::optional<std::string>> detach() const {
                 return operator std::optional<std::string>();
             }
 
@@ -359,7 +359,7 @@ namespace realm::experimental {
         struct managed<primary_key<std::optional<realm::uuid>>> : managed_base {
             using managed<primary_key<std::optional<realm::uuid>>>::managed_base::operator=;
 
-            primary_key<std::optional<realm::uuid>> value() const {
+            primary_key<std::optional<realm::uuid>> detach() const {
                 return operator std::optional<realm::uuid>();
             }
 
@@ -379,7 +379,7 @@ namespace realm::experimental {
         struct managed<primary_key<std::optional<realm::object_id>>> : managed_base {
             using managed<primary_key<std::optional<realm::object_id>>>::managed_base::operator=;
 
-            std::optional<realm::object_id> value() const {
+            std::optional<realm::object_id> detach() const {
                 return operator std::optional<realm::object_id>();
             }
 

--- a/src/cpprealm/experimental/managed_string.cpp
+++ b/src/cpprealm/experimental/managed_string.cpp
@@ -89,12 +89,12 @@ namespace realm::experimental {
         set(value);
     }
 
-    std::string managed_string::value() const {
+    std::string managed_string::detach() const {
         return get();
     }
 
     managed_string::operator std::string() const {
-        return value();
+        return detach();
     };
 
     rbool managed_string::operator==(const char* rhs) const noexcept {
@@ -103,7 +103,7 @@ namespace realm::experimental {
             query.equal(this->m_key, std::string(rhs));
             return query;
         }
-        return value() == rhs;
+        return detach() == rhs;
     }
 
     rbool managed_string::operator!=(const char* rhs) const noexcept {
@@ -112,7 +112,7 @@ namespace realm::experimental {
             query.not_equal(this->m_key, std::string(rhs));
             return query;
         }
-        return value() != rhs;
+        return detach() != rhs;
     }
 
     rbool managed_string::contains(const std::string &rhs) const noexcept {
@@ -121,7 +121,7 @@ namespace realm::experimental {
             query.contains(this->m_key, std::string(rhs));
             return query;
         }
-        return value().find(rhs) != cpprealm::npos;
+        return detach().find(rhs) != cpprealm::npos;
     }
 
     rbool managed_string::empty() const noexcept {
@@ -130,7 +130,7 @@ namespace realm::experimental {
             query.equal(this->m_key, std::string());
             return query;
         } else {
-            return value().empty();
+            return detach().empty();
         }
     }
 

--- a/src/cpprealm/experimental/managed_string.hpp
+++ b/src/cpprealm/experimental/managed_string.hpp
@@ -50,7 +50,7 @@ namespace realm::experimental {
         using managed<std::string>::managed_base::managed_base;
         using managed<std::string>::managed_base::operator=;
 
-        [[nodiscard]] std::string value() const;
+        [[nodiscard]] std::string detach() const;
 
         using reference = char_reference;
         using const_reference = const_char_reference;
@@ -131,16 +131,16 @@ namespace realm::experimental {
         managed& operator =(const std::optional<std::string>& v) { set(v); return *this; }
         managed& operator =(const char* v) { set(v); return *this; }
 
-        [[nodiscard]] std::optional<std::string> value() const {
+        [[nodiscard]] std::optional<std::string> detach() const {
             return m_obj->template get_optional<std::string>(m_key);
         }
 
         [[nodiscard]] std::optional<std::string> operator *() const {
-            return value();
+            return detach();
         }
 
         [[nodiscard]] operator std::optional<std::string>() const {
-            return value();
+            return detach();
         }
 
         rbool operator==(const std::optional<std::string>& rhs) const noexcept;

--- a/src/cpprealm/experimental/managed_timestamp.hpp
+++ b/src/cpprealm/experimental/managed_timestamp.hpp
@@ -13,12 +13,12 @@ namespace realm::experimental {
     struct managed<std::chrono::time_point<std::chrono::system_clock>> : public managed_base {
         using managed<std::chrono::time_point<std::chrono::system_clock>>::managed_base::operator=;
 
-        [[nodiscard]] std::chrono::time_point<std::chrono::system_clock> value() const {
+        [[nodiscard]] std::chrono::time_point<std::chrono::system_clock> detach() const {
             return m_obj->template get<realm::internal::bridge::timestamp>(m_key);
         }
 
         [[nodiscard]] operator std::chrono::time_point<std::chrono::system_clock>() const {
-            return value();
+            return detach();
         }
 
         auto time_since_epoch() const {
@@ -45,12 +45,12 @@ namespace realm::experimental {
     struct managed<std::optional<std::chrono::time_point<std::chrono::system_clock>>> : managed_base {
         using managed<std::optional<std::chrono::time_point<std::chrono::system_clock>>>::managed_base::operator=;
 
-        [[nodiscard]] std::optional<std::chrono::time_point<std::chrono::system_clock>> value() const {
+        [[nodiscard]] std::optional<std::chrono::time_point<std::chrono::system_clock>> detach() const {
             return m_obj->get_optional<realm::internal::bridge::timestamp>(m_key);
         }
 
         [[nodiscard]] operator std::optional<std::chrono::time_point<std::chrono::system_clock>>() const {
-            return value();
+            return detach();
         }
 
         struct box {

--- a/src/cpprealm/experimental/managed_uuid.hpp
+++ b/src/cpprealm/experimental/managed_uuid.hpp
@@ -13,16 +13,16 @@ namespace realm::experimental {
     struct managed<realm::uuid> : managed_base {
         using managed<realm::uuid>::managed_base::operator=;
 
-        [[nodiscard]] realm::uuid value() const {
+        [[nodiscard]] realm::uuid detach() const {
             return m_obj->template get<realm::internal::bridge::uuid>(m_key).operator ::realm::uuid();
         }
 
         [[nodiscard]] realm::uuid operator *() const {
-            return value();
+            return detach();
         }
 
         [[nodiscard]] operator realm::uuid() const {
-            return value();
+            return detach();
         }
 
         //MARK: -   comparison operators
@@ -34,7 +34,7 @@ namespace realm::experimental {
     struct managed<std::optional<realm::uuid>> : managed_base {
         using managed<std::optional<realm::uuid>>::managed_base::operator=;
 
-        [[nodiscard]] std::optional<realm::uuid> value() const {
+        [[nodiscard]] std::optional<realm::uuid> detach() const {
             auto v = m_obj->template get_optional<realm::internal::bridge::uuid>(m_key);
             if (v) {
                 return v.value().operator ::realm::uuid();
@@ -44,11 +44,11 @@ namespace realm::experimental {
         }
 
         [[nodiscard]] std::optional<realm::uuid> operator *() const {
-            return value();
+            return detach();
         }
 
         [[nodiscard]] operator std::optional<realm::uuid>() const {
-            return value();
+            return detach();
         }
 
         //MARK: -   comparison operators

--- a/src/cpprealm/experimental/observation.hpp
+++ b/src/cpprealm/experimental/observation.hpp
@@ -119,7 +119,7 @@ namespace realm::experimental {
 
             std::vector<typename decltype(T::schema)::variant_t> values;
             for (auto &name: *property_names) {
-                auto value = T::schema.property_value_for_name(name, object);
+                auto value = T::schema.property_value_for_name(name, object, true);
                 values.push_back(value);
             }
             return values;

--- a/src/cpprealm/experimental/results.hpp
+++ b/src/cpprealm/experimental/results.hpp
@@ -71,7 +71,7 @@ namespace realm::experimental {
         class iterator {
         public:
             using difference_type = size_t;
-            using value_type = T;
+            using value_type = managed<T, void>;
             using pointer = std::unique_ptr<value_type>;
             using reference = value_type &;
             using iterator_category = std::input_iterator_tag;
@@ -85,8 +85,8 @@ namespace realm::experimental {
             }
 
             reference operator*() noexcept {
-                auto obj = internal::bridge::get<internal::bridge::obj>(*m_parent, m_idx);
-                value = std::move(T::schema.create(std::move(obj), m_parent->m_parent.get_realm()));
+                internal::bridge::obj obj = internal::bridge::get<internal::bridge::obj>(m_parent->m_parent, m_idx);
+                value = managed<T, void>(std::move(obj), this->m_parent->m_parent.get_realm());
                 return value;
             }
 
@@ -112,7 +112,7 @@ namespace realm::experimental {
 
             size_t m_idx;
             results<T> *m_parent;
-            T value;
+            managed<T, void> value;
 
             template<auto>
             friend struct linking_objects;

--- a/src/cpprealm/experimental/results.hpp
+++ b/src/cpprealm/experimental/results.hpp
@@ -222,7 +222,7 @@ namespace realm::experimental {
         using iterator = typename results<typename internal::ptr_type_extractor<ptr>::class_type>::iterator;
         using Class = typename internal::ptr_type_extractor<ptr>::class_type;
 
-        linking_objects<ptr> value() const {
+        linking_objects<ptr> detach() const {
             return {};
         }
 

--- a/src/cpprealm/experimental/types.hpp
+++ b/src/cpprealm/experimental/types.hpp
@@ -283,6 +283,8 @@ namespace realm::experimental {
             return static_cast<internal::bridge::object_id>(value).operator ::realm::object_id();
         } else if constexpr (std::is_same_v<T, realm::decimal128>) {
             return static_cast<internal::bridge::decimal128>(value).operator ::realm::decimal128();
+        } else if constexpr (std::is_enum_v<T>) {
+            return static_cast<T>(value.operator int64_t());
         } else {
             abort();
         }

--- a/src/cpprealm/flex_sync.hpp
+++ b/src/cpprealm/flex_sync.hpp
@@ -113,7 +113,7 @@ namespace realm {
             auto builder = internal::bridge::query(table_ref);
 
             if (query_fn) {
-                auto q = realm::experimental::query<experimental::managed<T>>(builder, std::move(schema));
+                auto q = realm::experimental::query<experimental::managed<T>>(builder, std::move(schema), m_realm);
                 auto full_query = (*query_fn)(q).q;
                 insert_or_assign(name, full_query);
             } else {

--- a/src/cpprealm/internal/bridge/list.hpp
+++ b/src/cpprealm/internal/bridge/list.hpp
@@ -65,8 +65,6 @@ namespace realm::internal::bridge {
         }
         obj add_embedded();
 
-       // [[nodiscard]] realm get_realm() const;
-
         void set(size_t pos, const int64_t &);
         void set(size_t pos, const double &);
         void set(size_t pos, const bool &);

--- a/src/cpprealm/internal/bridge/obj_key.cpp
+++ b/src/cpprealm/internal/bridge/obj_key.cpp
@@ -68,7 +68,7 @@ namespace realm::internal::bridge {
     }
 
     bool operator!=(obj_key const &lhs, obj_key const &rhs) {
-        return static_cast<ObjKey>(lhs) == static_cast<ObjKey>(rhs);
+        return static_cast<ObjKey>(lhs) != static_cast<ObjKey>(rhs);
     }
 
 #ifdef __i386__

--- a/src/cpprealm/internal/bridge/realm.cpp
+++ b/src/cpprealm/internal/bridge/realm.cpp
@@ -258,6 +258,10 @@ namespace realm::internal::bridge {
         }
     }
 
+    void realm::config::set_schema_version(uint64_t version) {
+        reinterpret_cast<RealmConfig*>(&m_config)->schema_version = version;
+    }
+
     realm::sync_config realm::config::sync_config() const {
         return reinterpret_cast<const RealmConfig*>(&m_config)->sync_config;
     }

--- a/src/cpprealm/internal/bridge/realm.hpp
+++ b/src/cpprealm/internal/bridge/realm.hpp
@@ -149,6 +149,7 @@ namespace realm::internal::bridge {
             void set_scheduler(const std::shared_ptr<struct scheduler>&);
             void set_sync_config(const std::optional<struct sync_config>&);
             void set_custom_http_headers(const std::map<std::string, std::string>& headers);
+            void set_schema_version(uint64_t version);
         private:
 #ifdef __i386__
             std::aligned_storage<192, 8>::type m_config[1];

--- a/src/cpprealm/schema.hpp
+++ b/src/cpprealm/schema.hpp
@@ -299,13 +299,21 @@ namespace realm {
                 if constexpr (N + 1 == sizeof...(Properties)) {
                     if (property_name == std::string_view(names[N])) {
                         auto ptr = experimental::managed<Class, void>::template unmanaged_to_managed_pointer(property.ptr);
-                        return (cls.*ptr).detach();
+                        if constexpr (std::is_pointer_v<typename P::Result>) {
+                            return (cls.*ptr);
+                        } else {
+                            return (cls.*ptr).detach();
+                        }
                     }
                     return variant_t{};
                 } else {
                     if (property_name == std::string_view(names[N])) {
                         auto ptr = experimental::managed<Class, void>::template unmanaged_to_managed_pointer(property.ptr);
-                        return (cls.*ptr).detach();
+                        if constexpr (std::is_pointer_v<typename P::Result>) {
+                            return (cls.*ptr);
+                        } else {
+                            return (cls.*ptr).detach();
+                        }
                     }
                     return property_value_for_name<N + 1>(property_name, cls, std::get<N + 1>(properties));
                 }

--- a/src/cpprealm/schema.hpp
+++ b/src/cpprealm/schema.hpp
@@ -299,13 +299,13 @@ namespace realm {
                 if constexpr (N + 1 == sizeof...(Properties)) {
                     if (property_name == std::string_view(names[N])) {
                         auto ptr = experimental::managed<Class, void>::template unmanaged_to_managed_pointer(property.ptr);
-                        return (cls.*ptr).value();
+                        return (cls.*ptr).detach();
                     }
                     return variant_t{};
                 } else {
                     if (property_name == std::string_view(names[N])) {
                         auto ptr = experimental::managed<Class, void>::template unmanaged_to_managed_pointer(property.ptr);
-                        return (cls.*ptr).value();
+                        return (cls.*ptr).detach();
                     }
                     return property_value_for_name<N + 1>(property_name, cls, std::get<N + 1>(properties));
                 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -104,7 +104,8 @@ else()
             experimental/db/results_tests.cpp
             experimental/db/run_loop_tests.cpp
             experimental/db/string_tests.cpp
-            experimental/db/performance_tests.cpp)
+            experimental/db/performance_tests.cpp
+            experimental/db/numeric_tests.cpp)
     target_compile_definitions(cpprealm_sync_tests PUBLIC CPPREALM_ENABLE_SYNC_TESTS)
     target_link_libraries(cpprealm_alpha_tests cpprealm Catch2::Catch2)
     target_compile_definitions(cpprealm_alpha_tests PUBLIC CPPREALM_ENABLE_SYNC_TESTS)

--- a/tests/experimental/db/binary_tests.cpp
+++ b/tests/experimental/db/binary_tests.cpp
@@ -172,4 +172,53 @@ TEST_CASE("binary", "[binary]") {
         CHECK(managed_obj.list_binary_col[2] == std::vector<uint8_t>({ static_cast<uint8_t>(2) }));
         CHECK(managed_obj.list_binary_col[3] == std::vector<uint8_t>({ static_cast<uint8_t>(3) }));
     }
+
+    SECTION("operator") {
+        auto realm = realm::experimental::db(std::move(config));
+        auto obj = realm::experimental::AllTypesObject();
+        obj.binary_col.push_back(1);
+        obj.binary_col.push_back(2);
+        obj.binary_col.push_back(3);
+        auto managed_obj = realm.write([&realm, &obj] {
+            return realm.add(std::move(obj));
+        });
+        CHECK(managed_obj.binary_col.size() == 3);
+        realm.write([&managed_obj] {
+            managed_obj.binary_col.push_back(4);
+        });
+        std::vector<uint8_t> vector = managed_obj.binary_col;
+        CHECK(vector.size() == 4);
+        CHECK(vector[0] == 1);
+        CHECK(vector[1] == 2);
+        CHECK(vector[2] == 3);
+        CHECK(vector[3] == 4);
+        CHECK(vector == std::vector<uint8_t>({1, 2, 3, 4}));
+        CHECK(vector != std::vector<uint8_t>({1, 2, 3}));
+    }
+
+    SECTION("optional operator") {
+        auto realm = realm::experimental::db(std::move(config));
+        auto obj = realm::experimental::AllTypesObject();
+        CHECK(obj.opt_binary_col == std::nullopt);
+        obj.opt_binary_col = std::vector<uint8_t>();
+        obj.opt_binary_col->push_back(1);
+        obj.opt_binary_col->push_back(2);
+        obj.opt_binary_col->push_back(3);
+        auto managed_obj = realm.write([&realm, &obj] {
+            return realm.add(std::move(obj));
+        });
+        CHECK(managed_obj.opt_binary_col->size() == 3);
+        realm.write([&managed_obj] {
+            managed_obj.opt_binary_col->push_back(4);
+        });
+
+        std::optional<std::vector<uint8_t>> vector = managed_obj.opt_binary_col;
+        CHECK(vector->size() == 4);
+        CHECK((*vector)[0] == 1);
+        CHECK((*vector)[1] == 2);
+        CHECK((*vector)[2] == 3);
+        CHECK((*vector)[3] == 4);
+        CHECK(vector == std::vector<uint8_t>({1, 2, 3, 4}));
+        CHECK(vector != std::vector<uint8_t>({1, 2, 3}));
+    }
 }

--- a/tests/experimental/db/date_tests.cpp
+++ b/tests/experimental/db/date_tests.cpp
@@ -108,5 +108,31 @@ TEST_CASE("date", "[date]") {
         });
         CHECK(results.size() == 0);
     }
+
+    SECTION("operator_time_since_epoch", "[date]") {
+        auto realm = realm::experimental::db(std::move(config));
+        auto ts = std::chrono::time_point<std::chrono::system_clock>();
+        realm::experimental::AllTypesObject object;
+        object.date_col = ts;
+        CHECK(object.date_col.time_since_epoch() == ts.time_since_epoch());
+        auto managed_obj = realm.write([&] {
+            return realm.add(std::move(object));
+        });
+        std::chrono::time_point<std::chrono::system_clock> val = managed_obj.date_col;
+        CHECK(val == ts);
+    }
+
+    SECTION("optional_operator_time_since_epoch", "[date]") {
+        auto realm = realm::experimental::db(std::move(config));
+        auto ts = std::chrono::time_point<std::chrono::system_clock>();
+        realm::experimental::AllTypesObject object;
+        object.opt_date_col = ts;
+        CHECK(object.opt_date_col->time_since_epoch() == ts.time_since_epoch());
+        auto managed_obj = realm.write([&] {
+            return realm.add(std::move(object));
+        });
+        std::optional<std::chrono::time_point<std::chrono::system_clock>> val = managed_obj.opt_date_col;
+        CHECK(val == ts);
+    }
 }
 

--- a/tests/experimental/db/list_tests.cpp
+++ b/tests/experimental/db/list_tests.cpp
@@ -388,43 +388,43 @@ TEST_CASE("list", "[list]") {
     }
 
     SECTION("list_mixed") {
-        auto realm = realm::experimental::db(std::move(config));
-        auto obj = realm::experimental::AllTypesObject();
-        obj.list_mixed_col.push_back((int64_t)42);
-        obj.list_mixed_col.push_back(true);
-        obj.list_mixed_col.push_back(std::string("hello world"));
-        obj.list_mixed_col.push_back(42.42);
-        obj.list_mixed_col.push_back(std::vector<uint8_t>{0,1,2});
-        auto ts = std::chrono::time_point<std::chrono::system_clock>();
-        obj.list_mixed_col.push_back(ts);
-
-        auto managed_obj = realm.write([&]() {
-            return realm.add(std::move(obj));
-        });
-
-        CHECK(std::holds_alternative<int64_t>(managed_obj.list_mixed_col[0]));
-        CHECK(std::get<int64_t>(managed_obj.list_mixed_col[0]) == 42);
-
-        CHECK(std::holds_alternative<bool>(managed_obj.list_mixed_col[1]));
-        CHECK(std::get<bool>(managed_obj.list_mixed_col[1]) == true);
-
-        CHECK(std::holds_alternative<std::string>(managed_obj.list_mixed_col[2]));
-        CHECK(std::get<std::string>(managed_obj.list_mixed_col[2]) == "hello world");
-
-        CHECK(std::holds_alternative<double>(managed_obj.list_mixed_col[3]));
-        CHECK(std::get<double>(managed_obj.list_mixed_col[3]) == 42.42);
-
-        CHECK(std::holds_alternative<std::vector<uint8_t>>(managed_obj.list_mixed_col[4]));
-        CHECK(std::get<std::vector<uint8_t>>(managed_obj.list_mixed_col[4]) == std::vector<uint8_t>{0,1,2});
-
-        CHECK(std::holds_alternative<std::chrono::time_point<std::chrono::system_clock>>(managed_obj.list_mixed_col[5]));
-        CHECK(std::get<std::chrono::time_point<std::chrono::system_clock>>(managed_obj.list_mixed_col[5]) == ts);
-
-        realm.write([&managed_obj] {
-            managed_obj.list_mixed_col.push_back(realm::uuid());
-        });
-
-        CHECK(std::holds_alternative<realm::uuid>(managed_obj.list_mixed_col[6]));
-        CHECK(std::get<realm::uuid>(managed_obj.list_mixed_col[6]) == realm::uuid());
+//        auto realm = realm::experimental::db(std::move(config));
+//        auto obj = realm::experimental::AllTypesObject();
+//        obj.list_mixed_col.push_back((int64_t)42);
+//        obj.list_mixed_col.push_back(true);
+//        obj.list_mixed_col.push_back(std::string("hello world"));
+//        obj.list_mixed_col.push_back(42.42);
+//        obj.list_mixed_col.push_back(std::vector<uint8_t>{0,1,2});
+//        auto ts = std::chrono::time_point<std::chrono::system_clock>();
+//        obj.list_mixed_col.push_back(ts);
+//
+//        auto managed_obj = realm.write([&]() {
+//            return realm.add(std::move(obj));
+//        });
+//
+//        CHECK(std::holds_alternative<int64_t>(managed_obj.list_mixed_col[0]));
+//        CHECK(std::get<int64_t>(managed_obj.list_mixed_col[0]) == 42);
+//
+//        CHECK(std::holds_alternative<bool>(managed_obj.list_mixed_col[1]));
+//        CHECK(std::get<bool>(managed_obj.list_mixed_col[1]) == true);
+//
+//        CHECK(std::holds_alternative<std::string>(managed_obj.list_mixed_col[2]));
+//        CHECK(std::get<std::string>(managed_obj.list_mixed_col[2]) == "hello world");
+//
+//        CHECK(std::holds_alternative<double>(managed_obj.list_mixed_col[3]));
+//        CHECK(std::get<double>(managed_obj.list_mixed_col[3]) == 42.42);
+//
+//        CHECK(std::holds_alternative<std::vector<uint8_t>>(managed_obj.list_mixed_col[4]));
+//        CHECK(std::get<std::vector<uint8_t>>(managed_obj.list_mixed_col[4]) == std::vector<uint8_t>{0,1,2});
+//
+//        CHECK(std::holds_alternative<std::chrono::time_point<std::chrono::system_clock>>(managed_obj.list_mixed_col[5]));
+//        CHECK(std::get<std::chrono::time_point<std::chrono::system_clock>>(managed_obj.list_mixed_col[5]) == ts);
+//
+//        realm.write([&managed_obj] {
+//            managed_obj.list_mixed_col.push_back(realm::uuid());
+//        });
+//
+//        CHECK(std::holds_alternative<realm::uuid>(managed_obj.list_mixed_col[6]));
+//        CHECK(std::get<realm::uuid>(managed_obj.list_mixed_col[6]) == realm::uuid());
     }
 }

--- a/tests/experimental/db/list_tests.cpp
+++ b/tests/experimental/db/list_tests.cpp
@@ -427,4 +427,41 @@ TEST_CASE("list", "[list]") {
         CHECK(std::holds_alternative<realm::uuid>(managed_obj.list_mixed_col[6]));
         CHECK(std::get<realm::uuid>(managed_obj.list_mixed_col[6]) == realm::uuid());
     }
+
+    SECTION("list_value") {
+        auto realm = realm::experimental::db(std::move(config));
+        auto obj = realm::experimental::AllTypesObject();
+        obj.list_int_col.push_back((int64_t)1);
+        obj.list_int_col.push_back((int64_t)2);
+        obj.list_int_col.push_back((int64_t)3);
+
+        auto o1 = realm::experimental::AllTypesObjectLink();
+        o1._id = 1;
+        o1.str_col = "foo";
+        auto o2 = realm::experimental::AllTypesObjectLink();
+        o2._id = 2;
+        o2.str_col = "bar";
+        auto o3 = realm::experimental::AllTypesObjectLink();
+        o3._id = 3;
+        o3.str_col = "baz";
+        auto o4 = realm::experimental::AllTypesObjectLink();
+        o4._id = 4;
+        o4.str_col = "foo baz";
+        auto o5 = realm::experimental::AllTypesObjectLink();
+        o5._id = 5;
+        o5.str_col = "foo bar";
+        auto o6 = realm::experimental::AllTypesObjectLink();
+
+        // unmanaged
+        obj.list_obj_col.push_back(&o1);
+        obj.list_obj_col.push_back(&o2);
+        obj.list_obj_col.push_back(&o3);
+
+        auto managed_obj = realm.write([&]() {
+            return realm.add(std::move(obj));
+        });
+
+        std::vector<int64_t> as_value = managed_obj.list_int_col.value();
+        CHECK(as_value == std::vector<int64_t>{1, 2, 3});
+    }
 }

--- a/tests/experimental/db/list_tests.cpp
+++ b/tests/experimental/db/list_tests.cpp
@@ -388,43 +388,43 @@ TEST_CASE("list", "[list]") {
     }
 
     SECTION("list_mixed") {
-//        auto realm = realm::experimental::db(std::move(config));
-//        auto obj = realm::experimental::AllTypesObject();
-//        obj.list_mixed_col.push_back((int64_t)42);
-//        obj.list_mixed_col.push_back(true);
-//        obj.list_mixed_col.push_back(std::string("hello world"));
-//        obj.list_mixed_col.push_back(42.42);
-//        obj.list_mixed_col.push_back(std::vector<uint8_t>{0,1,2});
-//        auto ts = std::chrono::time_point<std::chrono::system_clock>();
-//        obj.list_mixed_col.push_back(ts);
-//
-//        auto managed_obj = realm.write([&]() {
-//            return realm.add(std::move(obj));
-//        });
-//
-//        CHECK(std::holds_alternative<int64_t>(managed_obj.list_mixed_col[0]));
-//        CHECK(std::get<int64_t>(managed_obj.list_mixed_col[0]) == 42);
-//
-//        CHECK(std::holds_alternative<bool>(managed_obj.list_mixed_col[1]));
-//        CHECK(std::get<bool>(managed_obj.list_mixed_col[1]) == true);
-//
-//        CHECK(std::holds_alternative<std::string>(managed_obj.list_mixed_col[2]));
-//        CHECK(std::get<std::string>(managed_obj.list_mixed_col[2]) == "hello world");
-//
-//        CHECK(std::holds_alternative<double>(managed_obj.list_mixed_col[3]));
-//        CHECK(std::get<double>(managed_obj.list_mixed_col[3]) == 42.42);
-//
-//        CHECK(std::holds_alternative<std::vector<uint8_t>>(managed_obj.list_mixed_col[4]));
-//        CHECK(std::get<std::vector<uint8_t>>(managed_obj.list_mixed_col[4]) == std::vector<uint8_t>{0,1,2});
-//
-//        CHECK(std::holds_alternative<std::chrono::time_point<std::chrono::system_clock>>(managed_obj.list_mixed_col[5]));
-//        CHECK(std::get<std::chrono::time_point<std::chrono::system_clock>>(managed_obj.list_mixed_col[5]) == ts);
-//
-//        realm.write([&managed_obj] {
-//            managed_obj.list_mixed_col.push_back(realm::uuid());
-//        });
-//
-//        CHECK(std::holds_alternative<realm::uuid>(managed_obj.list_mixed_col[6]));
-//        CHECK(std::get<realm::uuid>(managed_obj.list_mixed_col[6]) == realm::uuid());
+        auto realm = realm::experimental::db(std::move(config));
+        auto obj = realm::experimental::AllTypesObject();
+        obj.list_mixed_col.push_back((int64_t)42);
+        obj.list_mixed_col.push_back(true);
+        obj.list_mixed_col.push_back(std::string("hello world"));
+        obj.list_mixed_col.push_back(42.42);
+        obj.list_mixed_col.push_back(std::vector<uint8_t>{0,1,2});
+        auto ts = std::chrono::time_point<std::chrono::system_clock>();
+        obj.list_mixed_col.push_back(ts);
+
+        auto managed_obj = realm.write([&]() {
+            return realm.add(std::move(obj));
+        });
+
+        CHECK(std::holds_alternative<int64_t>(managed_obj.list_mixed_col[0]));
+        CHECK(std::get<int64_t>(managed_obj.list_mixed_col[0]) == 42);
+
+        CHECK(std::holds_alternative<bool>(managed_obj.list_mixed_col[1]));
+        CHECK(std::get<bool>(managed_obj.list_mixed_col[1]) == true);
+
+        CHECK(std::holds_alternative<std::string>(managed_obj.list_mixed_col[2]));
+        CHECK(std::get<std::string>(managed_obj.list_mixed_col[2]) == "hello world");
+
+        CHECK(std::holds_alternative<double>(managed_obj.list_mixed_col[3]));
+        CHECK(std::get<double>(managed_obj.list_mixed_col[3]) == 42.42);
+
+        CHECK(std::holds_alternative<std::vector<uint8_t>>(managed_obj.list_mixed_col[4]));
+        CHECK(std::get<std::vector<uint8_t>>(managed_obj.list_mixed_col[4]) == std::vector<uint8_t>{0,1,2});
+
+        CHECK(std::holds_alternative<std::chrono::time_point<std::chrono::system_clock>>(managed_obj.list_mixed_col[5]));
+        CHECK(std::get<std::chrono::time_point<std::chrono::system_clock>>(managed_obj.list_mixed_col[5]) == ts);
+
+        realm.write([&managed_obj] {
+            managed_obj.list_mixed_col.push_back(realm::uuid());
+        });
+
+        CHECK(std::holds_alternative<realm::uuid>(managed_obj.list_mixed_col[6]));
+        CHECK(std::get<realm::uuid>(managed_obj.list_mixed_col[6]) == realm::uuid());
     }
 }

--- a/tests/experimental/db/list_tests.cpp
+++ b/tests/experimental/db/list_tests.cpp
@@ -461,7 +461,7 @@ TEST_CASE("list", "[list]") {
             return realm.add(std::move(obj));
         });
 
-        std::vector<int64_t> as_value = managed_obj.list_int_col.value();
+        std::vector<int64_t> as_value = managed_obj.list_int_col.detach();
         CHECK(as_value == std::vector<int64_t>{1, 2, 3});
     }
 }

--- a/tests/experimental/db/map_tests.cpp
+++ b/tests/experimental/db/map_tests.cpp
@@ -191,4 +191,20 @@ TEST_CASE("map", "[map]") {
         CHECK(managed_obj.map_str_col.find("c") == managed_obj.map_str_col.end());
         CHECK(managed_obj.map_str_col.find("d") != managed_obj.map_str_col.end());
     }
+
+    SECTION("as_value") {
+        auto obj = experimental::AllTypesObject();
+        obj.map_str_col = {
+                {"a", std::string("baz")},
+                {"b", std::string("foo")}
+        };
+
+        auto realm = experimental::db(std::move(config));
+        auto managed_obj = realm.write([&realm, &obj] {
+            return realm.add(std::move(obj));
+        });
+
+        std::map<std::string, std::string> as_values = managed_obj.map_str_col.value();
+        CHECK(as_values == std::map<std::string, std::string>({{"a", std::string("baz")}, {"b", std::string("foo")}}));
+    }
 }

--- a/tests/experimental/db/map_tests.cpp
+++ b/tests/experimental/db/map_tests.cpp
@@ -204,7 +204,7 @@ TEST_CASE("map", "[map]") {
             return realm.add(std::move(obj));
         });
 
-        std::map<std::string, std::string> as_values = managed_obj.map_str_col.value();
+        std::map<std::string, std::string> as_values = managed_obj.map_str_col.detach();
         CHECK(as_values == std::map<std::string, std::string>({{"a", std::string("baz")}, {"b", std::string("foo")}}));
     }
 }

--- a/tests/experimental/db/numeric_tests.cpp
+++ b/tests/experimental/db/numeric_tests.cpp
@@ -135,6 +135,60 @@ TEST_CASE("numerics", "[numerics]") {
 
             managed_obj.double_col--;
             CHECK(managed_obj.double_col == 4.0);
+
+            managed_obj.double_col = 1;
+        });
+
+        CHECK(managed_obj.double_col == 1);
+        CHECK((managed_obj.double_col != 1) == false);
+        CHECK((managed_obj.double_col > 1) == false);
+        CHECK((managed_obj.double_col < 1) == false);
+        CHECK(((managed_obj.double_col <= 1) && (managed_obj.double_col <= 100)));
+        CHECK(((managed_obj.double_col >= 1) && (managed_obj.double_col >= 0)));
+
+        res = realm.objects<experimental::AllTypesObject>().where([](auto&& o) {
+            return o.double_col == 1;
+        });
+        CHECK(res.size() == 1);
+        res = realm.objects<experimental::AllTypesObject>().where([](auto&& o) {
+            return o.double_col != 1;
+        });
+        CHECK(res.size() == 0);
+        res = realm.objects<experimental::AllTypesObject>().where([](auto&& o) {
+            return o.double_col > 1;
+        });
+        CHECK(res.size() == 0);
+        res = realm.objects<experimental::AllTypesObject>().where([](auto&& o) {
+            return o.double_col < 1;
+        });
+        CHECK(res.size() == 0);
+        res = realm.objects<experimental::AllTypesObject>().where([](auto&& o) {
+            return (o.double_col <= 1) && (o.double_col <= 100);
+        });
+        CHECK(res.size() == 1);
+        res = realm.objects<experimental::AllTypesObject>().where([](auto&& o) {
+            return (o.double_col >= 1) && (o.double_col >= 0);
+        });
+        CHECK(res.size() == 1);
+
+        realm.write([&realm, &managed_obj] {
+            managed_obj.double_col = managed_obj.double_col + 1;
+            CHECK(managed_obj.double_col == 2);
+
+            managed_obj.double_col += 1;
+            CHECK(managed_obj.double_col == 3);
+
+            managed_obj.double_col -= 1;
+            CHECK(managed_obj.double_col == 2);
+
+            managed_obj.double_col *= 2;
+            CHECK(managed_obj.double_col == 4);
+
+            managed_obj.double_col++;
+            CHECK(managed_obj.double_col == 5);
+
+            managed_obj.double_col--;
+            CHECK(managed_obj.double_col == 4);
         });
 
         // Opt Int
@@ -201,6 +255,40 @@ TEST_CASE("numerics", "[numerics]") {
 
             managed_obj.opt_double_col--;
             CHECK(managed_obj.opt_double_col == 4.0);
+
+            managed_obj.opt_double_col = 1;
+        });
+
+        CHECK(managed_obj.opt_double_col == 1);
+        CHECK((managed_obj.opt_double_col != 1) == false);
+
+        res = realm.objects<experimental::AllTypesObject>().where([](auto&& o) {
+            return o.opt_double_col == 1;
+        });
+        CHECK(res.size() == 1);
+        res = realm.objects<experimental::AllTypesObject>().where([](auto&& o) {
+            return o.opt_double_col != 1;
+        });
+        CHECK(res.size() == 0);
+
+        realm.write([&realm, &managed_obj] {
+            managed_obj.opt_double_col = *managed_obj.opt_double_col.value() + 1;
+            CHECK(managed_obj.opt_double_col == 2);
+
+            managed_obj.opt_double_col += 1;
+            CHECK(managed_obj.opt_double_col == 3);
+
+            managed_obj.opt_double_col -= 1;
+            CHECK(managed_obj.opt_double_col == 2);
+
+            managed_obj.opt_double_col *= 2;
+            CHECK(managed_obj.opt_double_col == 4);
+
+            managed_obj.opt_double_col++;
+            CHECK(managed_obj.opt_double_col == 5);
+
+            managed_obj.opt_double_col--;
+            CHECK(managed_obj.opt_double_col == 4);
         });
 
         // Enum

--- a/tests/experimental/db/numeric_tests.cpp
+++ b/tests/experimental/db/numeric_tests.cpp
@@ -1,0 +1,309 @@
+#include "../../main.hpp"
+#include "test_objects.hpp"
+
+using namespace realm;
+
+TEST_CASE("numerics", "[numerics]") {
+    realm_path path;
+    db_config config;
+    config.set_path(path);
+    SECTION("unmanaged_managed_mixed_get_set", "[mixed]") {
+        auto obj = experimental::AllTypesObject();
+        obj.int_col = 1;
+        obj.double_col = 1.0;
+        obj.bool_col = true;
+        obj.enum_col = experimental::AllTypesObject::Enum::one;
+
+        obj.opt_int_col = 1;
+        obj.opt_double_col = 1.0;
+        obj.opt_bool_col = true;
+        obj.opt_enum_col = experimental::AllTypesObject::Enum::one;
+
+        obj.list_int_col.push_back(1);
+        obj.map_int_col["foo"] = 1;
+        obj.list_double_col.push_back(1.0);
+        obj.map_double_col["foo"] = 1.0;
+        obj.list_bool_col.push_back(true);
+        obj.map_bool_col["foo"] = true;
+
+        auto realm = experimental::db(std::move(config));
+        auto managed_obj = realm.write([&realm, &obj] {
+            return realm.add(std::move(obj));
+        });
+
+        // Int
+        CHECK(managed_obj.int_col == 1);
+        CHECK((managed_obj.int_col != 1) == false);
+        CHECK((managed_obj.int_col > 1) == false);
+        CHECK((managed_obj.int_col < 1) == false);
+        CHECK(((managed_obj.int_col <= 1) && (managed_obj.int_col <= 100)));
+        CHECK(((managed_obj.int_col >= 1) && (managed_obj.int_col >= 0)));
+
+        auto res = realm.objects<experimental::AllTypesObject>().where([](auto&& o) {
+            return o.int_col == 1;
+        });
+        CHECK(res.size() == 1);
+        res = realm.objects<experimental::AllTypesObject>().where([](auto&& o) {
+            return o.int_col != 1;
+        });
+        CHECK(res.size() == 0);
+        res = realm.objects<experimental::AllTypesObject>().where([](auto&& o) {
+            return o.int_col > 1;
+        });
+        CHECK(res.size() == 0);
+        res = realm.objects<experimental::AllTypesObject>().where([](auto&& o) {
+            return o.int_col < 1;
+        });
+        CHECK(res.size() == 0);
+        res = realm.objects<experimental::AllTypesObject>().where([](auto&& o) {
+            return (o.int_col <= 1) && (o.int_col <= 100);
+        });
+        CHECK(res.size() == 1);
+        res = realm.objects<experimental::AllTypesObject>().where([](auto&& o) {
+            return (o.int_col >= 1) && (o.int_col >= 0);
+        });
+        CHECK(res.size() == 1);
+
+        realm.write([&realm, &managed_obj] {
+            managed_obj.int_col = managed_obj.int_col + 1;
+            CHECK(managed_obj.int_col == 2);
+
+            managed_obj.int_col += 1;
+            CHECK(managed_obj.int_col == 3);
+
+            managed_obj.int_col -= 1;
+            CHECK(managed_obj.int_col == 2);
+
+            managed_obj.int_col *= 2;
+            CHECK(managed_obj.int_col == 4);
+
+            managed_obj.int_col++;
+            CHECK(managed_obj.int_col == 5);
+
+            managed_obj.int_col--;
+            CHECK(managed_obj.int_col == 4);
+        });
+
+        // Double
+        CHECK(managed_obj.double_col == 1.0);
+        CHECK((managed_obj.double_col != 1.0) == false);
+        CHECK((managed_obj.double_col > 1.0) == false);
+        CHECK((managed_obj.double_col < 1.0) == false);
+        CHECK(((managed_obj.double_col <= 1.0) && (managed_obj.double_col <= 100.0)));
+        CHECK(((managed_obj.double_col >= 1.0) && (managed_obj.double_col >= 0.0)));
+
+        res = realm.objects<experimental::AllTypesObject>().where([](auto&& o) {
+            return o.double_col == 1.0;
+        });
+        CHECK(res.size() == 1);
+        res = realm.objects<experimental::AllTypesObject>().where([](auto&& o) {
+            return o.double_col != 1.0;
+        });
+        CHECK(res.size() == 0);
+        res = realm.objects<experimental::AllTypesObject>().where([](auto&& o) {
+            return o.double_col > 1.0;
+        });
+        CHECK(res.size() == 0);
+        res = realm.objects<experimental::AllTypesObject>().where([](auto&& o) {
+            return o.double_col < 1.0;
+        });
+        CHECK(res.size() == 0);
+        res = realm.objects<experimental::AllTypesObject>().where([](auto&& o) {
+            return (o.double_col <= 1.0) && (o.double_col <= 100.0);
+        });
+        CHECK(res.size() == 1);
+        res = realm.objects<experimental::AllTypesObject>().where([](auto&& o) {
+            return (o.double_col >= 1.0) && (o.double_col >= 0.0);
+        });
+        CHECK(res.size() == 1);
+
+        realm.write([&realm, &managed_obj] {
+            managed_obj.double_col = managed_obj.double_col + 1.0;
+            CHECK(managed_obj.double_col == 2.0);
+
+            managed_obj.double_col += 1;
+            CHECK(managed_obj.double_col == 3.0);
+
+            managed_obj.double_col -= 1;
+            CHECK(managed_obj.double_col == 2.0);
+
+            managed_obj.double_col *= 2;
+            CHECK(managed_obj.double_col == 4.0);
+
+            managed_obj.double_col++;
+            CHECK(managed_obj.double_col == 5.0);
+
+            managed_obj.double_col--;
+            CHECK(managed_obj.double_col == 4.0);
+        });
+
+        // Opt Int
+        CHECK(managed_obj.opt_int_col == 1);
+        CHECK((managed_obj.opt_int_col != 1) == false);
+
+        res = realm.objects<experimental::AllTypesObject>().where([](auto&& o) {
+            return o.opt_int_col == 1;
+        });
+        CHECK(res.size() == 1);
+        res = realm.objects<experimental::AllTypesObject>().where([](auto&& o) {
+            return o.opt_int_col != 1;
+        });
+        CHECK(res.size() == 0);
+
+        realm.write([&realm, &managed_obj] {
+            managed_obj.opt_int_col = *managed_obj.opt_int_col.value() + 1;
+            CHECK(managed_obj.opt_int_col == 2);
+
+            managed_obj.opt_int_col += 1;
+            CHECK(managed_obj.opt_int_col == 3);
+
+            managed_obj.opt_int_col -= 1;
+            CHECK(managed_obj.opt_int_col == 2);
+
+            managed_obj.opt_int_col *= 2;
+            CHECK(managed_obj.opt_int_col == 4);
+
+            managed_obj.opt_int_col++;
+            CHECK(managed_obj.opt_int_col == 5);
+
+            managed_obj.opt_int_col--;
+            CHECK(managed_obj.opt_int_col == 4);
+        });
+
+        // Opt Double
+        CHECK(managed_obj.opt_double_col == 1.0);
+        CHECK((managed_obj.opt_double_col != 1.0) == false);
+
+        res = realm.objects<experimental::AllTypesObject>().where([](auto&& o) {
+            return o.opt_double_col == 1.0;
+        });
+        CHECK(res.size() == 1);
+        res = realm.objects<experimental::AllTypesObject>().where([](auto&& o) {
+            return o.opt_double_col != 1.0;
+        });
+        CHECK(res.size() == 0);
+
+        realm.write([&realm, &managed_obj] {
+            managed_obj.opt_double_col = *managed_obj.opt_double_col.value() + 1.0;
+            CHECK(managed_obj.opt_double_col == 2.0);
+
+            managed_obj.opt_double_col += 1.0;
+            CHECK(managed_obj.opt_double_col == 3.0);
+
+            managed_obj.opt_double_col -= 1.0;
+            CHECK(managed_obj.opt_double_col == 2.0);
+
+            managed_obj.opt_double_col *= 2.0;
+            CHECK(managed_obj.opt_double_col == 4.0);
+
+            managed_obj.opt_double_col++;
+            CHECK(managed_obj.opt_double_col == 5.0);
+
+            managed_obj.opt_double_col--;
+            CHECK(managed_obj.opt_double_col == 4.0);
+        });
+
+        // Enum
+
+        CHECK(managed_obj.enum_col == experimental::AllTypesObject::Enum::one);
+        CHECK(managed_obj.enum_col != experimental::AllTypesObject::Enum::two);
+
+        res = realm.objects<experimental::AllTypesObject>().where([](auto&& o) {
+            return o.enum_col == experimental::AllTypesObject::Enum::one;
+        });
+        CHECK(res.size() == 1);
+        res = realm.objects<experimental::AllTypesObject>().where([](auto&& o) {
+            return o.enum_col != experimental::AllTypesObject::Enum::one;
+        });
+        CHECK(res.size() == 0);
+
+        realm.write([&realm, &managed_obj] {
+            managed_obj.enum_col = experimental::AllTypesObject::Enum::two;
+            CHECK(managed_obj.enum_col == experimental::AllTypesObject::Enum::two);
+        });
+
+        // Opt Enum
+        CHECK(managed_obj.opt_enum_col == experimental::AllTypesObject::Enum::one);
+        CHECK(managed_obj.opt_enum_col != experimental::AllTypesObject::Enum::two);
+
+        res = realm.objects<experimental::AllTypesObject>().where([](auto&& o) {
+            return o.opt_enum_col == experimental::AllTypesObject::Enum::one;
+        });
+        CHECK(res.size() == 1);
+        res = realm.objects<experimental::AllTypesObject>().where([](auto&& o) {
+            return o.opt_enum_col != experimental::AllTypesObject::Enum::one;
+        });
+        CHECK(res.size() == 0);
+
+        realm.write([&realm, &managed_obj] {
+            managed_obj.opt_enum_col = experimental::AllTypesObject::Enum::two;
+            CHECK(managed_obj.opt_enum_col == experimental::AllTypesObject::Enum::two);
+        });
+
+        // Bool
+        CHECK(managed_obj.bool_col == true);
+        CHECK(managed_obj.bool_col != false);
+
+        res = realm.objects<experimental::AllTypesObject>().where([](auto&& o) {
+            return o.bool_col == true;
+        });
+        CHECK(res.size() == 1);
+        res = realm.objects<experimental::AllTypesObject>().where([](auto&& o) {
+            return o.bool_col != true;
+        });
+        CHECK(res.size() == 0);
+
+        realm.write([&realm, &managed_obj] {
+            managed_obj.bool_col = false;
+            CHECK(managed_obj.bool_col == false);
+        });
+
+        // Opt Bool
+        CHECK(managed_obj.opt_bool_col == true);
+        CHECK(managed_obj.opt_bool_col != false);
+
+        res = realm.objects<experimental::AllTypesObject>().where([](auto&& o) {
+            return o.opt_bool_col == true;
+        });
+        CHECK(res.size() == 1);
+        res = realm.objects<experimental::AllTypesObject>().where([](auto&& o) {
+            return o.opt_bool_col != true;
+        });
+        CHECK(res.size() == 0);
+
+        realm.write([&realm, &managed_obj] {
+            managed_obj.opt_bool_col = false;
+            CHECK(managed_obj.opt_bool_col == false);
+        });
+
+        // List
+        CHECK(managed_obj.list_int_col[0] == 1);
+        CHECK(managed_obj.list_double_col[0] == 1.0);
+        CHECK(managed_obj.list_bool_col[0] == true);
+
+        realm.write([&realm, &managed_obj] {
+            // TODO: Allow subscript assignment
+            // managed_obj.list_int_col[0] = 2;
+            managed_obj.list_int_col.set(0, 2);
+            CHECK(managed_obj.list_int_col[0] == 2);
+            managed_obj.list_double_col.set(0, 2.0);
+            CHECK(managed_obj.list_double_col[0] == 2.0);
+            managed_obj.list_bool_col.set(0, false);
+            CHECK(managed_obj.list_bool_col[0] == false);
+        });
+
+        // Map
+        CHECK(managed_obj.map_int_col["foo"] == 1);
+        CHECK(managed_obj.map_double_col["foo"] == 1.0);
+        CHECK(managed_obj.map_bool_col["foo"] == true);
+
+        realm.write([&realm, &managed_obj] {
+            managed_obj.map_int_col["foo"] = 2;
+            CHECK(managed_obj.map_int_col["foo"] == 2);
+            managed_obj.map_double_col["foo"] = 2.0;
+            CHECK(managed_obj.map_double_col["foo"] == 2);
+            managed_obj.map_bool_col["foo"] = false;
+            CHECK(managed_obj.map_bool_col["foo"] == false);
+        });
+    }
+}

--- a/tests/experimental/db/numeric_tests.cpp
+++ b/tests/experimental/db/numeric_tests.cpp
@@ -80,6 +80,12 @@ TEST_CASE("numerics", "[numerics]") {
             managed_obj.int_col++;
             CHECK(managed_obj.int_col == 5);
 
+            ++managed_obj.int_col;
+            CHECK(managed_obj.int_col == 6);
+
+            --managed_obj.int_col;
+            CHECK(managed_obj.int_col == 5);
+
             managed_obj.int_col--;
             CHECK(managed_obj.int_col == 4);
         });
@@ -133,7 +139,13 @@ TEST_CASE("numerics", "[numerics]") {
             managed_obj.double_col++;
             CHECK(managed_obj.double_col == 5.0);
 
+            ++managed_obj.double_col;
+            CHECK(managed_obj.double_col == 6.0);
+
             managed_obj.double_col--;
+            CHECK(managed_obj.double_col == 5.0);
+
+            --managed_obj.double_col;
             CHECK(managed_obj.double_col == 4.0);
 
             managed_obj.double_col = 1;

--- a/tests/experimental/db/numeric_tests.cpp
+++ b/tests/experimental/db/numeric_tests.cpp
@@ -217,7 +217,7 @@ TEST_CASE("numerics", "[numerics]") {
         CHECK(res.size() == 0);
 
         realm.write([&realm, &managed_obj] {
-            managed_obj.opt_int_col = *managed_obj.opt_int_col.value() + 1;
+            managed_obj.opt_int_col = *managed_obj.opt_int_col.detach() + 1;
             CHECK(managed_obj.opt_int_col == 2);
 
             managed_obj.opt_int_col += 1;
@@ -250,7 +250,7 @@ TEST_CASE("numerics", "[numerics]") {
         CHECK(res.size() == 0);
 
         realm.write([&realm, &managed_obj] {
-            managed_obj.opt_double_col = *managed_obj.opt_double_col.value() + 1.0;
+            managed_obj.opt_double_col = *managed_obj.opt_double_col.detach() + 1.0;
             CHECK(managed_obj.opt_double_col == 2.0);
 
             managed_obj.opt_double_col += 1.0;
@@ -284,7 +284,7 @@ TEST_CASE("numerics", "[numerics]") {
         CHECK(res.size() == 0);
 
         realm.write([&realm, &managed_obj] {
-            managed_obj.opt_double_col = *managed_obj.opt_double_col.value() + 1;
+            managed_obj.opt_double_col = *managed_obj.opt_double_col.detach() + 1;
             CHECK(managed_obj.opt_double_col == 2);
 
             managed_obj.opt_double_col += 1;

--- a/tests/experimental/db/object_tests.cpp
+++ b/tests/experimental/db/object_tests.cpp
@@ -522,7 +522,7 @@ namespace realm::experimental {
                 if (run_count == 1) {
                     CHECK(change.is_deleted);
                 } else {
-                    CHECK(change.property_changes.size() == 26);
+                    CHECK(change.property_changes.size() == 35);
                     for (auto& prop_change : change.property_changes) {
                         if (prop_change.name == "str_col" && prop_change.new_value) {
                             CHECK(std::get<std::string>(*prop_change.new_value) == "foo");
@@ -558,33 +558,43 @@ namespace realm::experimental {
                             auto obj = std::get<managed<AllTypesObjectEmbedded*>>(*prop_change.new_value);
                             CHECK((obj->str_col) == "embedded obj");
                         } else if (prop_change.name == "list_int_col" && prop_change.new_value) {
-                            auto obj = std::get<std::vector<int64_t>>(*prop_change.new_value);
+                            std::get<std::monostate>(*prop_change.new_value);
                             // Cocoa does not populate collection changes for an object and neither should we for perforamnce reasons.
-                            CHECK(obj.size() == 0);
                         } else if (prop_change.name == "list_bool_col" && prop_change.new_value) {
-                            auto obj = std::get<std::vector<bool>>(*prop_change.new_value);
-                            CHECK(obj.size() == 0);
+                            std::get<std::monostate>(*prop_change.new_value);
                         } else if (prop_change.name == "list_str_col" && prop_change.new_value) {
-                            auto obj = std::get<std::vector<std::string>>(*prop_change.new_value);
-                            CHECK(obj.size() == 0);
+                            std::get<std::monostate>(*prop_change.new_value);
                         } else if (prop_change.name == "list_uuid_col" && prop_change.new_value) {
-                            auto obj = std::get<std::vector<realm::uuid>>(*prop_change.new_value);
-                            CHECK(obj.size() == 0);
+                            std::get<std::monostate>(*prop_change.new_value);
                         } else if (prop_change.name == "list_binary_col" && prop_change.new_value) {
-                            auto obj = std::get<std::vector<std::vector<uint8_t>>>(*prop_change.new_value);
-                            CHECK(obj.size() == 0);
+                            std::get<std::monostate>(*prop_change.new_value);
                         } else if (prop_change.name == "list_date_col" && prop_change.new_value) {
-                            auto obj = std::get<std::vector<std::chrono::time_point<std::chrono::system_clock>>>(*prop_change.new_value);
-                            CHECK(obj.size() == 0);
+                            std::get<std::monostate>(*prop_change.new_value);
                         } else if (prop_change.name == "list_mixed_col" && prop_change.new_value) {
-                            auto obj = std::get<std::vector<realm::mixed>>(*prop_change.new_value);
-                            CHECK(obj.size() == 0);
+                            std::get<std::monostate>(*prop_change.new_value);
                         } else if (prop_change.name == "list_obj_col" && prop_change.new_value) {
-                            auto obj = std::get<std::vector<AllTypesObjectLink*>>(*prop_change.new_value);
-                            CHECK(obj.size() == 0);
+                            std::get<std::monostate>(*prop_change.new_value);
                         } else if (prop_change.name == "list_embedded_obj_col" && prop_change.new_value) {
-                            auto obj = std::get<std::vector<AllTypesObjectEmbedded*>>(*prop_change.new_value);
-                            CHECK(obj.size() == 0);
+                            std::get<std::monostate>(*prop_change.new_value);
+                        } else if (prop_change.name == "map_int_col" && prop_change.new_value) {
+                            std::get<std::monostate>(*prop_change.new_value);
+                            // Cocoa does not populate collection changes for an object and neither should we for perforamnce reasons.
+                        } else if (prop_change.name == "map_bool_col" && prop_change.new_value) {
+                            std::get<std::monostate>(*prop_change.new_value);
+                        } else if (prop_change.name == "map_str_col" && prop_change.new_value) {
+                            std::get<std::monostate>(*prop_change.new_value);
+                        } else if (prop_change.name == "map_uuid_col" && prop_change.new_value) {
+                            std::get<std::monostate>(*prop_change.new_value);
+                        } else if (prop_change.name == "map_binary_col" && prop_change.new_value) {
+                            std::get<std::monostate>(*prop_change.new_value);
+                        } else if (prop_change.name == "map_date_col" && prop_change.new_value) {
+                            std::get<std::monostate>(*prop_change.new_value);
+                        } else if (prop_change.name == "map_mixed_col" && prop_change.new_value) {
+                            std::get<std::monostate>(*prop_change.new_value);
+                        } else if (prop_change.name == "map_link_col" && prop_change.new_value) {
+                            std::get<std::monostate>(*prop_change.new_value);
+                        } else if (prop_change.name == "map_embedded_col" && prop_change.new_value) {
+                            std::get<std::monostate>(*prop_change.new_value);
                         }
                     }
                 }
@@ -627,6 +637,16 @@ namespace realm::experimental {
                 managed_foo.list_obj_col.push_back(&o2);
                 o4.str_col = "embedded obj 2";
                 managed_foo.list_embedded_obj_col.push_back(&o4);
+
+                managed_foo.map_int_col["foo"] = 1;
+                managed_foo.map_bool_col["foo"] = true;
+                managed_foo.map_str_col["foo"] = "bar";
+                managed_foo.map_uuid_col["foo"] = uuid;
+                managed_foo.map_binary_col["foo"] = std::vector<uint8_t>({1});
+                managed_foo.map_date_col["foo"] = date;
+                managed_foo.map_mixed_col["foo"] = "mixed str";
+                managed_foo.map_link_col["foo"] = &o2;
+                managed_foo.map_embedded_col["foo"] = &o4;
             });
             realm.refresh();
             realm.write([&managed_foo, &realm] {
@@ -780,6 +800,28 @@ namespace realm::experimental {
 
             CHECK(managed_obj.map_link_col["foo"] == managed_link2);
             CHECK(managed_obj.map_link_col["bar"] == managed_link2);
+        }
+
+        SECTION("null bool operator") {
+            AllTypesObject obj;
+            obj._id = 1;
+            AllTypesObjectLink link;
+            link._id = 1;
+
+            experimental::db db = experimental::open(path);
+            auto managed_obj = db.write([&]() {
+                return db.add(std::move(obj));
+            });
+
+            bool has_link = managed_obj.opt_obj_col;
+            CHECK(!has_link);
+
+            db.write([&]() {
+                managed_obj.opt_obj_col = &link;
+            });
+
+            has_link = managed_obj.opt_obj_col;
+            CHECK(has_link);
         }
     }
 }

--- a/tests/experimental/db/object_tests.cpp
+++ b/tests/experimental/db/object_tests.cpp
@@ -380,13 +380,13 @@ namespace realm::experimental {
             CHECK(managed_obj.bool_col == true);
             CHECK(managed_obj.enum_col == AllTypesObject::Enum::two);
             CHECK(managed_obj.date_col == date);
-            CHECK(managed_obj.uuid_col.value() == uuid);
+            CHECK(managed_obj.uuid_col.detach() == uuid);
             CHECK(managed_obj.object_id_col == object_id);
             CHECK(managed_obj.decimal_col == decimal);
-            CHECK(managed_obj.binary_col.value() == std::vector<uint8_t>({1}));
-            CHECK(managed_obj.mixed_col.value() == AllTypesObject::my_mixed("mixed"));
+            CHECK(managed_obj.binary_col.detach() == std::vector<uint8_t>({1}));
+            CHECK(managed_obj.mixed_col.detach() == AllTypesObject::my_mixed("mixed"));
 
-            CHECK(managed_obj.object_id_col.value() == object_id);
+            CHECK(managed_obj.object_id_col.detach() == object_id);
 
             CHECK(managed_obj.opt_int_col == 2);
             CHECK(managed_obj.opt_double_col == 2.34);
@@ -395,7 +395,7 @@ namespace realm::experimental {
             CHECK(managed_obj.opt_enum_col == AllTypesObject::Enum::two);
             CHECK(managed_obj.opt_date_col == date);
             CHECK(managed_obj.opt_uuid_col == uuid);
-            CHECK(managed_obj.opt_binary_col.value() == std::vector<uint8_t>({1}));
+            CHECK(managed_obj.opt_binary_col.detach() == std::vector<uint8_t>({1}));
             CHECK(managed_obj.opt_object_id_col == object_id);
             CHECK(managed_obj.opt_decimal_col == decimal);
 

--- a/tests/experimental/db/optional_tests.cpp
+++ b/tests/experimental/db/optional_tests.cpp
@@ -34,7 +34,7 @@ namespace realm::experimental {
             CHECK(managed_obj.opt_enum_col == std::nullopt);
             CHECK(managed_obj.opt_date_col == std::nullopt);
             CHECK(managed_obj.opt_uuid_col == std::nullopt);
-            CHECK(managed_obj.opt_binary_col.value() == std::nullopt);
+            CHECK(managed_obj.opt_binary_col.detach() == std::nullopt);
             CHECK(managed_obj.opt_object_id_col == std::nullopt);
             CHECK(managed_obj.mixed_col == AllTypesObject::my_mixed());
             CHECK(managed_obj.list_mixed_col[0] == realm::mixed());

--- a/tests/experimental/db/results_tests.cpp
+++ b/tests/experimental/db/results_tests.cpp
@@ -193,5 +193,38 @@ namespace realm::experimental {
             CHECK(copy_o.double_col == 123.456);
             CHECK(moved_o.double_col == 123.456);
         }
+
+        SECTION("results_iterator") {
+            auto realm = db(std::move(config));
+
+            AllTypesObject obj;
+            obj.str_col = "foo";
+            obj._id = 1;
+
+            AllTypesObject obj2;
+            obj2.str_col = "bar";
+            obj2._id = 2;
+
+            realm.write([&realm, &obj, &obj2]() {
+                realm.add(std::move(obj));
+                realm.add(std::move(obj2));
+
+            });
+            auto results = realm.objects<AllTypesObject>();
+
+            size_t count = 0;
+            for (auto& o : results) {
+                count++;
+                if (count == 1) {
+                    CHECK(o._id == 1);
+                    CHECK(o.str_col == "foo");
+                } else {
+                    CHECK(o._id == 2);
+                    CHECK(o.str_col == "bar");
+                }
+            }
+            CHECK(count == 2);
+
+        }
     }
 }

--- a/tests/experimental/db/test_objects.hpp
+++ b/tests/experimental/db/test_objects.hpp
@@ -61,11 +61,18 @@ namespace realm::experimental {
     };
     REALM_EMBEDDED_SCHEMA(AllTypesObjectEmbedded, _id, str_col)
 
-    struct AllTypesObjectLink {
+    struct StringObject {
         primary_key<int64_t> _id;
         std::string str_col;
     };
-    REALM_SCHEMA(AllTypesObjectLink, _id, str_col)
+    REALM_SCHEMA(StringObject, _id, str_col)
+
+    struct AllTypesObjectLink {
+        primary_key<int64_t> _id;
+        std::string str_col;
+        StringObject* str_link_col = nullptr;
+    };
+    REALM_SCHEMA(AllTypesObjectLink, _id, str_col, str_link_col)
 
     struct AllTypesObject {
         enum class Enum {
@@ -73,6 +80,7 @@ namespace realm::experimental {
         };
 
         primary_key<int64_t> _id;
+        int64_t int_col;
         double double_col;
         bool bool_col;
         std::string str_col;
@@ -142,7 +150,7 @@ namespace realm::experimental {
     };
 
     REALM_SCHEMA(AllTypesObject,
-                 _id, double_col, bool_col, str_col, enum_col, date_col, uuid_col, object_id_col, decimal_col, binary_col, mixed_col, my_mixed_col,
+                 _id, int_col, double_col, bool_col, str_col, enum_col, date_col, uuid_col, object_id_col, decimal_col, binary_col, mixed_col, my_mixed_col,
                  opt_int_col, opt_double_col, opt_str_col, opt_bool_col, opt_enum_col,
                  opt_date_col, opt_uuid_col, opt_object_id_col, opt_decimal_col, opt_binary_col, opt_obj_col, opt_embedded_obj_col,
                  list_int_col, list_double_col, list_bool_col, list_str_col, list_uuid_col, list_object_id_col, list_decimal_col, list_binary_col,


### PR DESCRIPTION
* Fix iterator on `experimental::Results`
* Add `operator!=()` to collections.
* Add `set_schema_version(uint64_t)`
* Add `managed<std::vector<T*>>::push_back(const managed<T*>&)`
* Add `box<managed<V*>>::box& operator=(const managed<V*>& o)`
* Add `box<managed<V*>>::box& operator=(const managed<V>& o)`
* Add `managed<T*>::operator=(const managed<T>&)`
* Add `managed<T*>::operator=(const managed<T*>&)`
* Fix queries containing link object columns.
* Rename `managed<>::value()` to `managed<>::detach()`