### PR TITLE
fix network_transport.cpp bug

### DIFF
--- a/src/cpprealm/internal/curl/network_transport.cpp
+++ b/src/cpprealm/internal/curl/network_transport.cpp
@@ -147,7 +147,7 @@ namespace realm::internal {
                 fprintf(stderr, "curl_easy_perform() failed when sending request to '%s' with body '%s': %s\n",
                         request.url.c_str(), request.body.c_str(), curl_easy_strerror(response_code));
             }
-            int http_code = 0;
+            long http_code = 0;
             curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code);
             return {
                     http_code,


### PR DESCRIPTION
the response code is using int, which is not right according to https://curl.se/libcurl/c/CURLINFO_RESPONSE_CODE.html