### PR TITLE
Add std::set support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ app_config.metadata_encryption_key = example_key;
 auto encrypted_app = realm::App(app_config);
 ```
 * Add ability to encrypt a Realm. Usage: `realm::config::set_encryption_key(const std::array<char, 64>&)`.
+* Add support for `std::set` in object models.
 
 ### Breaking Changes
 * `realm::App(const std::string &app_id, const std::optional<std::string> &base_url,

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -44,6 +44,7 @@ set(SOURCES
     cpprealm/internal/bridge/realm.cpp
     cpprealm/internal/bridge/results.cpp
     cpprealm/internal/bridge/schema.cpp
+    cpprealm/internal/bridge/set.cpp
     cpprealm/internal/bridge/status.cpp
     cpprealm/internal/bridge/sync_error.cpp
     cpprealm/internal/bridge/sync_manager.cpp
@@ -72,6 +73,7 @@ set(HEADERS
     cpprealm/experimental/managed_numeric.hpp
     cpprealm/experimental/managed_objectid.hpp
     cpprealm/experimental/managed_primary_key.hpp
+    cpprealm/experimental/managed_set.hpp
     cpprealm/experimental/managed_string.hpp
     cpprealm/experimental/managed_timestamp.hpp
     cpprealm/experimental/managed_uuid.hpp
@@ -97,6 +99,7 @@ set(HEADERS
     cpprealm/internal/bridge/realm.hpp
     cpprealm/internal/bridge/results.hpp
     cpprealm/internal/bridge/schema.hpp
+    cpprealm/internal/bridge/set.hpp
     cpprealm/internal/bridge/status.hpp
     cpprealm/internal/bridge/sync_error.hpp
     cpprealm/internal/bridge/sync_manager.hpp
@@ -114,7 +117,8 @@ set(HEADERS
     cpprealm/schema.hpp
     cpprealm/task.hpp
     cpprealm/thread_safe_reference.hpp
-    cpprealm/sdk.hpp cpprealm/alpha_support.hpp) # REALM_INSTALL_HEADERS
+    cpprealm/sdk.hpp
+    cpprealm/alpha_support.hpp) # REALM_INSTALL_HEADERS
 
 if(ENABLE_ALPHA_SDK)
     list(APPEND HEADERS

--- a/src/cpprealm/experimental/accessors.hpp
+++ b/src/cpprealm/experimental/accessors.hpp
@@ -5,6 +5,7 @@
 #include <cpprealm/internal/bridge/lnklst.hpp>
 #include <cpprealm/internal/bridge/obj.hpp>
 #include <cpprealm/internal/bridge/table.hpp>
+#include <cpprealm/internal/bridge/realm.hpp>
 
 namespace realm::experimental {
     template<typename>
@@ -16,6 +17,7 @@ namespace realm::experimental {
     struct accessor {
         static inline void set(internal::bridge::obj& obj,
                                const internal::bridge::col_key& key,
+                               const internal::bridge::realm&,
                                const T& value);
     };
 
@@ -23,6 +25,7 @@ namespace realm::experimental {
     struct accessor<int64_t> {
         static inline void set(internal::bridge::obj& obj,
                                const internal::bridge::col_key& key,
+                               const internal::bridge::realm&,
                                const int64_t& value) {
             obj.set(key, value);
         }
@@ -31,6 +34,7 @@ namespace realm::experimental {
     struct accessor<std::optional<int64_t>> {
         static inline void set(internal::bridge::obj& obj,
                                const internal::bridge::col_key& key,
+                               const internal::bridge::realm&,
                                const std::optional<int64_t>& value) {
             if (value) {
                 obj.set(key, *value);
@@ -43,6 +47,7 @@ namespace realm::experimental {
     struct accessor<double> {
         static inline void set(internal::bridge::obj& obj,
                                const internal::bridge::col_key& key,
+                               const internal::bridge::realm&,
                                const double& value) {
             obj.set(key, value);
         }
@@ -51,6 +56,7 @@ namespace realm::experimental {
     struct accessor<std::optional<double>> {
         static inline void set(internal::bridge::obj& obj,
                                const internal::bridge::col_key& key,
+                               const internal::bridge::realm&,
                                const std::optional<double>& value) {
             if (value) {
                 obj.set(key, *value);
@@ -63,6 +69,7 @@ namespace realm::experimental {
     struct accessor<bool> {
         static inline void set(internal::bridge::obj& obj,
                                const internal::bridge::col_key& key,
+                               const internal::bridge::realm&,
                                const bool& value) {
             obj.set(key, value);
         }
@@ -71,6 +78,7 @@ namespace realm::experimental {
     struct accessor<std::optional<bool>> {
         static inline void set(internal::bridge::obj& obj,
                                const internal::bridge::col_key& key,
+                               const internal::bridge::realm&,
                                const std::optional<bool>& value) {
             if (value) {
                 obj.set(key, *value);
@@ -85,6 +93,7 @@ namespace realm::experimental {
     struct accessor<T, std::enable_if_t<std::is_enum_v<T>>> {
         static inline void set(internal::bridge::obj& obj,
                                const internal::bridge::col_key& key,
+                               const internal::bridge::realm&,
                                const T& value) {
             obj.set(key, static_cast<int64_t>(value));
         }
@@ -93,6 +102,7 @@ namespace realm::experimental {
     struct accessor<T, std::enable_if_t<std::conjunction_v<internal::type_info::is_optional<T>, std::is_enum<typename T::value_type>>>> {
         static inline void set(internal::bridge::obj& obj,
                                const internal::bridge::col_key& key,
+                               const internal::bridge::realm&,
                                const T& value) {
             if (value) {
                 obj.set(key, static_cast<int64_t>(*value));
@@ -106,6 +116,7 @@ namespace realm::experimental {
     struct accessor<T, std::enable_if_t<internal::type_info::MixedPersistableConcept<T>::value>> {
         static inline void set(internal::bridge::obj& obj,
                                const internal::bridge::col_key& key,
+                               const internal::bridge::realm&,
                                const T& value) {
             obj.set(key, serialize(value));
         }
@@ -116,6 +127,7 @@ namespace realm::experimental {
     struct accessor<uuid> {
         static inline void set(internal::bridge::obj& obj,
                                const internal::bridge::col_key& key,
+                               const internal::bridge::realm&,
                                const uuid& value) {
             obj.set(key, value);
         }
@@ -124,6 +136,7 @@ namespace realm::experimental {
     struct accessor<std::optional<uuid>> {
         static inline void set(internal::bridge::obj& obj,
                                const internal::bridge::col_key& key,
+                               const internal::bridge::realm&,
                                const std::optional<uuid>& value) {
             if (value) {
                 obj.set(key, *value);
@@ -136,6 +149,7 @@ namespace realm::experimental {
     struct accessor<object_id> {
         static inline void set(internal::bridge::obj& obj,
                                const internal::bridge::col_key& key,
+                               const internal::bridge::realm&,
                                const object_id& value) {
             obj.set(key, value);
         }
@@ -144,6 +158,7 @@ namespace realm::experimental {
     struct accessor<std::optional<object_id>> {
         static inline void set(internal::bridge::obj& obj,
                                const internal::bridge::col_key& key,
+                               const internal::bridge::realm&,
                                const std::optional<object_id>& value) {
             if (value) {
                 obj.set(key, *value);
@@ -157,6 +172,7 @@ namespace realm::experimental {
     struct accessor<decimal128> {
         static inline void set(internal::bridge::obj& obj,
                                const internal::bridge::col_key& key,
+                               const internal::bridge::realm&,
                                const decimal128& value) {
             obj.set(key, value);
         }
@@ -165,6 +181,7 @@ namespace realm::experimental {
     struct accessor<std::optional<decimal128>> {
         static inline void set(internal::bridge::obj& obj,
                                const internal::bridge::col_key& key,
+                               const internal::bridge::realm&,
                                const std::optional<decimal128>& value) {
             if (value) {
                 obj.set(key, *value);
@@ -178,6 +195,7 @@ namespace realm::experimental {
     struct accessor<std::chrono::time_point<std::chrono::system_clock>> {
         static inline void set(internal::bridge::obj& obj,
                                const internal::bridge::col_key& key,
+                               const internal::bridge::realm&,
                                const std::chrono::time_point<std::chrono::system_clock>& value) {
             obj.set(key, value);
         }
@@ -186,6 +204,7 @@ namespace realm::experimental {
     struct accessor<std::optional<std::chrono::time_point<std::chrono::system_clock>>> {
         static inline void set(internal::bridge::obj& obj,
                                const internal::bridge::col_key& key,
+                               const internal::bridge::realm&,
                                const std::optional<std::chrono::time_point<std::chrono::system_clock>>& value) {
             if (value) {
                 obj.set(key, *value);
@@ -199,6 +218,7 @@ namespace realm::experimental {
     struct accessor<std::string> {
         static inline void set(internal::bridge::obj& obj,
                                const internal::bridge::col_key& key,
+                               const internal::bridge::realm&,
                                const std::string& value) {
             obj.set(key, value);
         }
@@ -207,6 +227,7 @@ namespace realm::experimental {
     struct accessor<std::optional<std::string>> {
         static inline void set(internal::bridge::obj& obj,
                                const internal::bridge::col_key& key,
+                               const internal::bridge::realm&,
                                const std::optional<std::string>& value) {
             if (value) {
                 obj.set(key, *value);
@@ -220,6 +241,7 @@ namespace realm::experimental {
     struct accessor<std::vector<uint8_t>> {
         static inline void set(internal::bridge::obj& obj,
                                const internal::bridge::col_key& key,
+                               const internal::bridge::realm&,
                                const std::vector<uint8_t>& value) {
             obj.set(key, value);
         }
@@ -228,6 +250,7 @@ namespace realm::experimental {
     struct accessor<std::optional<std::vector<uint8_t>>> {
         static inline void set(internal::bridge::obj& obj,
                                const internal::bridge::col_key& key,
+                               const internal::bridge::realm&,
                                const std::optional<std::vector<uint8_t>>& value) {
             if (value) {
                 obj.set(key, *value);
@@ -240,6 +263,7 @@ namespace realm::experimental {
     struct accessor<std::vector<T>> {
         static inline void set(internal::bridge::obj& obj,
                                internal::bridge::col_key&& key,
+                               const internal::bridge::realm&,
                                const std::vector<T>& value) {
             obj.set_list_values(key, value);
         }
@@ -248,6 +272,7 @@ namespace realm::experimental {
     struct accessor<std::vector<T*>> {
         static inline void set(internal::bridge::obj& obj,
                                internal::bridge::col_key&& key,
+                               const internal::bridge::realm& realm,
                                const std::vector<T*>& value) {
             auto list = obj.get_linklist(key);
             for (size_t i = 0; i < value.size(); i++) {
@@ -265,9 +290,9 @@ namespace realm::experimental {
                 } else {
                     m_obj = table.create_object();
                 }
-                std::apply([&m_obj, &lnk](auto && ...p) {
+                std::apply([&m_obj, &lnk, &realm](auto && ...p) {
                     (accessor<typename std::decay_t<decltype(p)>::Result>::set(
-                             m_obj, m_obj.get_table().get_column_key(p.name),
+                             m_obj, m_obj.get_table().get_column_key(p.name), realm,
                              (*lnk).*(std::decay_t<decltype(p)>::ptr)), ...);
                 }, managed<T, void>::schema.ps);
                 if (!managed<T, void>::schema.is_embedded_experimental()) {
@@ -277,9 +302,52 @@ namespace realm::experimental {
         }
     };
     template <typename T>
+    struct accessor<std::set<T>> {
+        static inline void set(internal::bridge::obj& obj,
+                               internal::bridge::col_key&& key,
+                               const internal::bridge::realm& realm,
+                               const std::set<T>& value) {
+            auto set = realm::internal::bridge::set(realm, obj, key);
+            for (const auto& v : value) {
+                set.insert(serialize(v));
+            }
+        }
+    };
+    template <typename T>
+    struct accessor<std::set<T*>> {
+        static inline void set(internal::bridge::obj& obj,
+                               internal::bridge::col_key&& key,
+                               const internal::bridge::realm& realm,
+                               const std::set<T*>& value) {
+            auto set = realm::internal::bridge::set(realm, obj, key);
+            for (const auto& lnk : value) {
+                if (!lnk) {
+                    continue;
+                }
+                auto table = obj.get_target_table(key);
+                internal::bridge::obj m_obj;
+                if constexpr (managed<T>::schema.HasPrimaryKeyProperty) {
+                    auto pk = (*lnk).*(managed<T>::schema.primary_key().ptr);
+                    m_obj = table.create_object_with_primary_key(realm::internal::bridge::mixed(serialize(pk.value)));
+                } else {
+                    m_obj = table.create_object();
+                }
+                std::apply([&m_obj, &lnk, &realm](auto && ...p) {
+                    (accessor<typename std::decay_t<decltype(p)>::Result>::set(
+                             m_obj, m_obj.get_table().get_column_key(p.name), realm,
+                             (*lnk).*(std::decay_t<decltype(p)>::ptr)), ...);
+                }, managed<T, void>::schema.ps);
+                if (!managed<T>::schema.is_embedded_experimental()) {
+                    set.insert(m_obj.get_key());
+                }
+            }
+        }
+    };
+    template <typename T>
     struct accessor<std::map<std::string, T>> {
         static void set(internal::bridge::obj& obj,
                         internal::bridge::col_key&& key,
+                        const internal::bridge::realm&,
                         const std::map<std::string, T>& value) {
             auto d = obj.get_dictionary(key);
             for (auto& [k, v] : value) {
@@ -313,6 +381,7 @@ namespace realm::experimental {
     struct accessor<std::map<std::string, T*>> {
         static void set(internal::bridge::obj& obj,
                         internal::bridge::col_key&& key,
+                        const internal::bridge::realm& realm,
                         const std::map<std::string, T*>& value) {
             auto d = obj.get_dictionary(key);
             for (auto& [k, v] : value) {
@@ -324,9 +393,9 @@ namespace realm::experimental {
                     } else {
                         m_obj = d.create_and_insert_linked_object(k);
                     }
-                    std::apply([&m_obj, o = *v](auto && ...p) {
+                    std::apply([&m_obj, &realm, o = *v](auto && ...p) {
                         (accessor<typename std::decay_t<decltype(p)>::Result>::set(
-                                 m_obj, m_obj.get_table().get_column_key(p.name),
+                                 m_obj, m_obj.get_table().get_column_key(p.name), realm,
                                  o.*(std::decay_t<decltype(p)>::ptr)), ...);
                     }, managed<T, void>::schema.ps);
                     d.insert(k, m_obj.get_key());
@@ -342,6 +411,7 @@ namespace realm::experimental {
     struct accessor<T*> {
         static inline void set(internal::bridge::obj& obj,
                                internal::bridge::col_key&& key,
+                               const internal::bridge::realm& realm,
                                T* value) {
             if (!value) {
                 return;
@@ -358,9 +428,9 @@ namespace realm::experimental {
                 m_obj = table.create_object();
                 obj.set(key, m_obj.get_key());
             }
-            std::apply([&m_obj, &value](auto && ...p) {
+            std::apply([&m_obj, &realm, &value](auto && ...p) {
                 (accessor<typename std::decay_t<decltype(p)>::Result>::set(
-                         m_obj, m_obj.get_table().get_column_key(p.name),
+                         m_obj, m_obj.get_table().get_column_key(p.name), realm,
                          (*value).*(std::decay_t<decltype(p)>::ptr)), ...);
             }, managed<T, void>::schema.ps);
         }
@@ -370,6 +440,7 @@ namespace realm::experimental {
     struct accessor<linking_objects<T>> {
         static inline void set(internal::bridge::obj& obj,
                                internal::bridge::col_key&& key,
+                               const internal::bridge::realm&,
                                linking_objects<T> value) {
         }
     };
@@ -378,6 +449,7 @@ namespace realm::experimental {
     struct accessor<primary_key<T>> {
         static inline void set(internal::bridge::obj& obj,
                                internal::bridge::col_key&& key,
+                               const internal::bridge::realm&,
                                const primary_key<T>& value) {
             if constexpr (std::is_enum_v<T>) {
                 obj.set(key, static_cast<int64_t>(value.value));

--- a/src/cpprealm/experimental/accessors.hpp
+++ b/src/cpprealm/experimental/accessors.hpp
@@ -10,8 +10,6 @@
 namespace realm::experimental {
     template<typename>
     struct primary_key;
-    template<typename, typename>
-    struct managed;
 
     template <typename T, typename = void>
     struct accessor {
@@ -326,8 +324,8 @@ namespace realm::experimental {
                 }
                 auto table = obj.get_target_table(key);
                 internal::bridge::obj m_obj;
-                if constexpr (managed<T>::schema.HasPrimaryKeyProperty) {
-                    auto pk = (*lnk).*(managed<T>::schema.primary_key().ptr);
+                if constexpr (managed<T, void>::schema.HasPrimaryKeyProperty) {
+                    auto pk = (*lnk).*(managed<T, void>::schema.primary_key().ptr);
                     m_obj = table.create_object_with_primary_key(realm::internal::bridge::mixed(serialize(pk.value)));
                 } else {
                     m_obj = table.create_object();
@@ -337,7 +335,7 @@ namespace realm::experimental {
                              m_obj, m_obj.get_table().get_column_key(p.name), realm,
                              (*lnk).*(std::decay_t<decltype(p)>::ptr)), ...);
                 }, managed<T, void>::schema.ps);
-                if (!managed<T>::schema.is_embedded_experimental()) {
+                if (!managed<T, void>::schema.is_embedded_experimental()) {
                     set.insert(m_obj.get_key());
                 }
             }

--- a/src/cpprealm/experimental/db.hpp
+++ b/src/cpprealm/experimental/db.hpp
@@ -80,9 +80,9 @@ namespace realm::experimental {
                 m_obj = table.create_object();
             }
 
-            std::apply([&m_obj, &v](auto && ...p) {
+            std::apply([&m_obj, &v, this](auto && ...p) {
                 (accessor<typename std::decay_t<decltype(p)>::Result>::set(
-                        m_obj, m_obj.get_table().get_column_key(p.name), v.*(std::decay_t<decltype(p)>::ptr)
+                        m_obj, m_obj.get_table().get_column_key(p.name), m_realm, v.*(std::decay_t<decltype(p)>::ptr)
                 ), ...);
             }, managed<T>::schema.ps);
             auto m = managed<T>(std::move(m_obj), m_realm);

--- a/src/cpprealm/experimental/link.hpp
+++ b/src/cpprealm/experimental/link.hpp
@@ -107,9 +107,9 @@ namespace realm {
                     m_obj->set(m_key, obj.get_key());
                 }
 
-                std::apply([&obj, &o](auto && ...p) {
+                std::apply([&obj, &o, realm = *m_realm](auto && ...p) {
                     (accessor<typename std::decay_t<decltype(p)>::Result>::set(
-                             obj, obj.get_table().get_column_key(p.name), (*o).*(std::decay_t<decltype(p)>::ptr)
+                             obj, obj.get_table().get_column_key(p.name), realm, (*o).*(std::decay_t<decltype(p)>::ptr)
                                      ), ...);
                 }, managed<T>::schema.ps);
                 auto m = managed<T>(std::move(obj), *m_realm);

--- a/src/cpprealm/experimental/macros.hpp
+++ b/src/cpprealm/experimental/macros.hpp
@@ -465,7 +465,8 @@ rbool managed<std::optional<type>>::operator op(const std::optional<type>& rhs) 
     \
             return a.get_table() == b->get_table() \
                    && a.get_key() == b->get_key(); \
-        }                       \
+        }                                          \
+       bool operator < (const managed<cls>& rhs) const { return m_obj.get_key() < rhs.m_obj.get_key(); }  \
     };                         \
     struct meta_schema_##cls {   \
         meta_schema_##cls() {                                                    \

--- a/src/cpprealm/experimental/managed_dictionary.hpp
+++ b/src/cpprealm/experimental/managed_dictionary.hpp
@@ -409,9 +409,9 @@ namespace realm::experimental {
                 m_obj = const_cast<box<managed<V*>> *>(this)->m_backing_map.create_and_insert_linked_object(const_cast<box<managed<V*>> *>(this)->m_key);
             }
 
-            std::apply([&m_obj, &o](auto && ...p) {
+            std::apply([&m_obj, &o, realm = this->m_realm](auto && ...p) {
                 (accessor<typename std::decay_t<decltype(p)>::Result>::set(
-                         m_obj, m_obj.get_table().get_column_key(p.name),
+                         m_obj, m_obj.get_table().get_column_key(p.name), realm,
                          (*o).*(std::decay_t<decltype(p)>::ptr)), ...);
             }, managed<V>::schema.ps);
             return *this;

--- a/src/cpprealm/experimental/managed_set.hpp
+++ b/src/cpprealm/experimental/managed_set.hpp
@@ -73,14 +73,8 @@ namespace realm::experimental {
         }
         [[nodiscard]] std::set<T> detach() const {
             auto set = realm::internal::bridge::set(*m_realm, *m_obj, m_key);
-            using U = typename internal::type_info::type_info<T>::internal_type;
-
-            size_t count = set.size();
-            if (count == 0)
-                return std::set<T>();
-
             auto ret = std::set<T>();
-            for(size_t i = 0; i < count; i++) {
+            for(size_t i = 0; i < set.size(); i++) {
                 ret.insert(deserialize<T>(set.get_any(i)));
             }
             return ret;
@@ -126,7 +120,7 @@ namespace realm::experimental {
         {
             auto set = internal::bridge::set(*m_realm, *m_obj, m_key);
             size_t idx = set.find(serialize(v));
-            if (idx == cpprealm::npos)
+            if (idx == realm::npos)
                 return iterator(size(), this);
             return iterator(idx, this);
         }
@@ -323,7 +317,7 @@ namespace realm::experimental {
         {
             auto set = internal::bridge::set(*m_realm, *m_obj, m_key);
             size_t idx = set.find(v.m_obj.get_key());
-            if (idx == cpprealm::npos)
+            if (idx == realm::npos)
                 return iterator(size(), this);
             return iterator(idx, this);
         }
@@ -332,7 +326,7 @@ namespace realm::experimental {
         {
             auto set = internal::bridge::set(*m_realm, *m_obj, m_key);
             size_t idx = set.find(v.m_obj->get_key());
-            if (idx == cpprealm::npos)
+            if (idx == realm::npos)
                 return iterator(size(), this);
             return iterator(idx, this);
         }

--- a/src/cpprealm/experimental/managed_set.hpp
+++ b/src/cpprealm/experimental/managed_set.hpp
@@ -1,0 +1,350 @@
+#ifndef CPPREALM_MANAGED_SET_HPP
+#define CPPREALM_MANAGED_SET_HPP
+
+#include <cpprealm/notifications.hpp>
+#include <cpprealm/experimental/macros.hpp>
+#include <cpprealm/experimental/types.hpp>
+#include <cpprealm/experimental/observation.hpp>
+
+#include <set>
+
+namespace realm::experimental {
+
+    template<typename T>
+    struct managed<std::set<T>, std::enable_if_t<internal::type_info::is_primitive<T>::value>> : managed_base {
+        using managed<std::set<T>>::managed_base::operator=;
+        using value_type = T;
+
+        class iterator {
+        public:
+            using value_type = T;
+
+            using difference_type = std::ptrdiff_t;
+            using pointer = T*;
+            using reference = T&;
+            using iterator_category = std::forward_iterator_tag;
+
+            bool operator!=(const iterator& other) const
+            {
+                return !(*this == other);
+            }
+
+            bool operator==(const iterator& other) const
+            {
+                return (m_parent == other.m_parent) && (m_i == other.m_i);
+            }
+
+            T operator*() const noexcept
+            {
+                auto s = realm::internal::bridge::set(*m_parent->m_realm, *m_parent->m_obj, m_parent->m_key);
+                return deserialize<T>(s.get_any(m_i));
+            }
+
+            iterator& operator++()
+            {
+                this->m_i++;
+                return *this;
+            }
+
+            const iterator& operator++(int i)
+            {
+                this->m_i += i;
+                return *this;
+            }
+        private:
+            template<typename, typename>
+            friend struct managed;
+
+            iterator(size_t i, managed<std::set<T>>* parent)
+                : m_i(i), m_parent(parent)
+            {
+            }
+            size_t m_i;
+            managed<std::set<T>>* m_parent;
+        };
+        iterator begin()
+        {
+            return iterator(0, this);
+        }
+
+        iterator end()
+        {
+            return iterator(size(), this);
+        }
+        [[nodiscard]] std::set<T> detach() const {
+            auto set = realm::internal::bridge::set(*m_realm, *m_obj, m_key);
+            using U = typename internal::type_info::type_info<T>::internal_type;
+
+            size_t count = set.size();
+            if (count == 0)
+                return std::set<T>();
+
+            auto ret = std::set<T>();
+            for(size_t i = 0; i < count; i++) {
+                ret.insert(deserialize<T>(set.get_any(i)));
+            }
+            return ret;
+        }
+
+        realm::notification_token observe(std::function<void(realm::experimental::collection_change)>&& fn) {
+            auto set = std::make_shared<realm::internal::bridge::set>(*m_realm, *m_obj, m_key);
+            realm::notification_token token = set->add_notification_callback(
+                    std::make_shared<realm::experimental::collection_callback_wrapper>(
+                            std::move(fn),
+                            false));
+            token.m_realm = *m_realm;
+            token.m_set = set;
+            return token;
+        }
+
+        void erase(const iterator& it)
+        {
+            auto set = internal::bridge::set(*m_realm, *m_obj, m_key);
+            set.remove(serialize(*it));
+        }
+
+        std::pair<iterator, bool> insert(const T& v)
+        {
+            auto set = internal::bridge::set(*m_realm, *m_obj, m_key);
+            if constexpr (internal::type_info::MixedPersistableConcept<T>::value) {
+                std::pair<size_t, bool> res = set.insert(serialize<T>(v));
+                return std::pair<iterator, bool>(iterator(res.first, this), res.second);
+            } else {
+                std::pair<size_t, bool> res = set.insert(v);
+                return std::pair<iterator, bool>(iterator(res.first, this), res.second);
+            }
+        }
+
+        iterator insert(const iterator& i, const T& v)
+        {
+            auto set = internal::bridge::set(*m_realm, *m_obj, m_key);
+            std::pair<size_t, bool> res = set.insert(v);
+            return iterator(res.first, this);
+        }
+
+        iterator find(const T& v)
+        {
+            auto set = internal::bridge::set(*m_realm, *m_obj, m_key);
+            size_t idx = set.find(serialize(v));
+            if (idx == cpprealm::npos)
+                return iterator(size(), this);
+            return iterator(idx, this);
+        }
+        void clear() {
+            internal::bridge::set(*m_realm, *m_obj, m_key).remove_all();
+        }
+
+        size_t size()
+        {
+            return internal::bridge::set(*m_realm, *m_obj, m_key).size();
+        }
+    };
+
+    template<typename T>
+    struct managed<std::set<T*>> : managed_base {
+        using managed<std::set<T*>>::managed_base::operator=;
+        using value_type = managed<T>;
+
+        class iterator {
+        public:
+            using value_type = managed<T>;
+
+            using difference_type = std::ptrdiff_t;
+            using pointer = T*;
+            using reference = T&;
+            using iterator_category = std::forward_iterator_tag;
+
+            bool operator!=(const iterator& other) const
+            {
+                return !(*this == other);
+            }
+
+            bool operator==(const iterator& other) const
+            {
+                return (m_parent == other.m_parent) && (m_i == other.m_i);
+            }
+
+            managed<T> operator*() const noexcept
+            {
+                auto s = realm::internal::bridge::set(*m_parent->m_realm, *m_parent->m_obj, m_parent->m_key);
+                managed<T> m(s.get_obj(m_i), *m_parent->m_realm);
+                std::apply([&m](auto &&...ptr) {
+                    std::apply([&](auto &&...name) {
+                        ((m.*ptr).assign(&m.m_obj, &m.m_realm, m.m_obj.get_table().get_column_key(name)), ...);
+                    }, managed<T>::managed_pointers_names);
+                }, managed<T>::managed_pointers());
+                return {std::move(m)};
+            }
+
+            iterator& operator++()
+            {
+                this->m_i++;
+                return *this;
+            }
+
+            const iterator& operator++(int i)
+            {
+                this->m_i += i;
+                return *this;
+            }
+        private:
+            template<typename, typename>
+            friend struct managed;
+
+            iterator(size_t i, managed<std::set<T*>>* parent)
+                : m_i(i), m_parent(parent)
+            {
+            }
+            size_t m_i;
+            managed<std::set<T*>>* m_parent;
+        };
+        iterator begin()
+        {
+            return iterator(0, this);
+        }
+
+        iterator end()
+        {
+            return iterator(size(), this);
+        }
+        [[nodiscard]] std::set<T*> detach() const {
+            auto s = realm::internal::bridge::set(*m_realm, *m_obj, m_key);
+            size_t count = s.size();
+            if (count == 0)
+                return std::set<T*>();
+            auto ret = std::set<T*>();
+            for(size_t i = 0; i < count; i++) {
+                managed<T> m(s.get_obj(i), *m_realm);
+                T* v = new T();
+                auto assign = [&m, &v](auto& pair) {
+                    (*v).*(std::decay_t<decltype(pair.first)>::ptr) = (m.*(pair.second)).detach();
+                };
+                auto zipped = zipTuples(managed<T>::schema.ps, managed<T>::managed_pointers());
+                std::apply([&v, &m, &assign](auto && ...pair) {
+                    (assign(pair), ...);
+                }, zipped);
+
+                ret.insert(v);
+            }
+            return ret;
+        }
+
+        realm::notification_token observe(std::function<void(realm::experimental::collection_change)>&& fn) {
+            auto set = std::make_shared<realm::internal::bridge::set>(*m_realm, *m_obj, m_key);
+            realm::notification_token token = set->add_notification_callback(
+                    std::make_shared<realm::experimental::collection_callback_wrapper>(
+                            std::move(fn),
+                            false));
+            token.m_realm = *m_realm;
+            token.m_set = set;
+            return token;
+        }
+
+        void erase(const iterator& it)
+        {
+            auto set = internal::bridge::set(*m_realm, *m_obj, m_key);
+            set.remove(it.operator*().m_obj.get_key());
+        }
+
+        std::pair<iterator, bool> insert(T* value)
+        {
+            auto set = internal::bridge::set(*m_realm, *m_obj, m_key);
+            auto table = m_obj->get_target_table(m_key);
+            internal::bridge::obj m_obj;
+            if constexpr (managed<T>::schema.HasPrimaryKeyProperty) {
+                auto pk = (*value).*(managed<T>::schema.primary_key().ptr);
+                m_obj = table.create_object_with_primary_key(realm::internal::bridge::mixed(serialize(pk.value)));
+            } else {
+                m_obj = table.create_object();
+            }
+            std::apply([&m_obj, &value, realm = *m_realm](auto && ...p) {
+                (accessor<typename std::decay_t<decltype(p)>::Result>::set(
+                         m_obj, m_obj.get_table().get_column_key(p.name), realm,
+                         (*value).*(std::decay_t<decltype(p)>::ptr)), ...);
+            }, managed<T, void>::schema.ps);
+            if (!managed<T>::schema.is_embedded_experimental()) {
+                set.insert(m_obj.get_key());
+            }
+            std::pair<size_t, bool> res = set.insert(m_obj.get_key());
+            return std::pair<iterator, bool>(iterator(res.first, this), res.second);
+        }
+
+        iterator insert(const iterator& i, T* value)
+        {
+            auto set = internal::bridge::set(*m_realm, *m_obj, m_key);
+            auto table = m_obj->get_target_table(m_key);
+            internal::bridge::obj m_obj;
+            if constexpr (managed<T>::schema.HasPrimaryKeyProperty) {
+                auto pk = (*value).*(managed<T>::schema.primary_key().ptr);
+                m_obj = table.create_object_with_primary_key(realm::internal::bridge::mixed(serialize(pk.value)));
+            } else {
+                m_obj = table.create_object();
+            }
+            std::apply([&m_obj, &value, realm = *m_realm](auto && ...p) {
+                (accessor<typename std::decay_t<decltype(p)>::Result>::set(
+                         m_obj, m_obj.get_table().get_column_key(p.name), realm,
+                         (*value).*(std::decay_t<decltype(p)>::ptr)), ...);
+            }, managed<T, void>::schema.ps);
+            std::pair<size_t, bool> res = set.insert(m_obj.get_key());
+            return iterator(res.first, this);
+        }
+
+        std::pair<iterator, bool> insert(const managed<T>& value)
+        {
+            auto set = internal::bridge::set(*m_realm, *m_obj, m_key);
+            std::pair<size_t, bool> res = set.insert(value.m_obj.get_key());
+            return std::pair<iterator, bool>(iterator(res.first, this), res.second);
+
+        }
+
+        iterator insert(const iterator& i, const managed<T>& value)
+        {
+            auto set = internal::bridge::set(*m_realm, *m_obj, m_key);
+            std::pair<size_t, bool> res = set.insert(value.m_obj.get_key());
+            return iterator(res.first, this);
+        }
+
+        std::pair<iterator, bool> insert(const managed<T*>& value)
+        {
+            auto set = internal::bridge::set(*m_realm, *m_obj, m_key);
+            std::pair<size_t, bool> res = set.insert(value.m_obj.get_key());
+            return std::pair<iterator, bool>(iterator(res.first, this), res.second);
+
+        }
+
+        iterator insert(const iterator& i, const managed<T*>& value)
+        {
+            auto set = internal::bridge::set(*m_realm, *m_obj, m_key);
+            std::pair<size_t, bool> res = set.insert(value.m_obj.get_key());
+            return iterator(res.first, this);
+        }
+
+        iterator find(const managed<T>& v)
+        {
+            auto set = internal::bridge::set(*m_realm, *m_obj, m_key);
+            size_t idx = set.find(v.m_obj.get_key());
+            if (idx == cpprealm::npos)
+                return iterator(size(), this);
+            return iterator(idx, this);
+        }
+
+        iterator find(const managed<T*>& v)
+        {
+            auto set = internal::bridge::set(*m_realm, *m_obj, m_key);
+            size_t idx = set.find(v.m_obj->get_key());
+            if (idx == cpprealm::npos)
+                return iterator(size(), this);
+            return iterator(idx, this);
+        }
+        void clear() {
+            internal::bridge::set(*m_realm, *m_obj, m_key).remove_all();
+        }
+
+        size_t size()
+        {
+            return internal::bridge::set(*m_realm, *m_obj, m_key).size();
+        }
+    };
+} // namespace realm::experimental
+
+#endif//CPPREALM_MANAGED_SET_HPP

--- a/src/cpprealm/experimental/sdk.hpp
+++ b/src/cpprealm/experimental/sdk.hpp
@@ -13,6 +13,7 @@
 #include <cpprealm/experimental/managed_timestamp.hpp>
 #include <cpprealm/experimental/managed_uuid.hpp>
 #include <cpprealm/experimental/managed_decimal.hpp>
+#include <cpprealm/experimental/managed_set.hpp>
 #include <cpprealm/experimental/results.hpp>
 #include <cpprealm/experimental/link.hpp>
 #include <cpprealm/experimental/observation.hpp>

--- a/src/cpprealm/experimental/types.hpp
+++ b/src/cpprealm/experimental/types.hpp
@@ -25,6 +25,10 @@ namespace realm {
 
     inline bool operator ==(const uuid& lhs, const uuid& rhs) { return lhs.m_uuid == rhs.m_uuid; }
     inline bool operator !=(const uuid& lhs, const uuid& rhs) { return lhs.m_uuid != rhs.m_uuid; }
+    inline bool operator >(const uuid& lhs, const uuid& rhs) { return lhs.m_uuid > rhs.m_uuid; }
+    inline bool operator >=(const uuid& lhs, const uuid& rhs) { return lhs.m_uuid >= rhs.m_uuid; }
+    inline bool operator <(const uuid& lhs, const uuid& rhs) { return lhs.m_uuid < rhs.m_uuid; }
+    inline bool operator <=(const uuid& lhs, const uuid& rhs) { return lhs.m_uuid <= rhs.m_uuid; }
 
     struct object_id {
         explicit object_id(const std::string &);
@@ -40,6 +44,10 @@ namespace realm {
 
     inline bool operator ==(const object_id& lhs, const object_id& rhs) { return lhs.m_object_id == rhs.m_object_id; }
     inline bool operator !=(const object_id& lhs, const object_id& rhs) { return lhs.m_object_id != rhs.m_object_id; }
+    inline bool operator <(const object_id& lhs, const object_id& rhs) { return lhs.m_object_id < rhs.m_object_id; }
+    inline bool operator >(const object_id& lhs, const object_id& rhs) { return lhs.m_object_id > rhs.m_object_id; }
+    inline bool operator <=(const object_id& lhs, const object_id& rhs) { return lhs.m_object_id <= rhs.m_object_id; }
+    inline bool operator >=(const object_id& lhs, const object_id& rhs) { return lhs.m_object_id >= rhs.m_object_id; }
 
     struct decimal128 {
         explicit decimal128(const std::string &);

--- a/src/cpprealm/experimental/types.hpp
+++ b/src/cpprealm/experimental/types.hpp
@@ -3,6 +3,7 @@
 
 #include <array>
 #include <optional>
+#include <set>
 
 #include <cpprealm/internal/bridge/realm.hpp>
 #include <cpprealm/internal/bridge/schema.hpp>

--- a/src/cpprealm/internal/bridge/generator/CMakeLists.txt
+++ b/src/cpprealm/internal/bridge/generator/CMakeLists.txt
@@ -35,6 +35,7 @@ set(BRIDGE_TYPES
     Query realm::Query
     Results realm::Results
     Schema realm::Schema
+    Set realm::object_store::Set
     SyncError realm::SyncError
     TableRef realm::TableRef
     TableView realm::TableView

--- a/src/cpprealm/internal/bridge/obj.hpp
+++ b/src/cpprealm/internal/bridge/obj.hpp
@@ -222,6 +222,7 @@ namespace realm::internal::bridge {
         void set_null(const col_key&);
         obj create_and_set_linked_object(const col_key&);
         table_view get_backlink_view(table, col_key);
+
     private:
         inline const Obj* get_obj() const;
         inline Obj* get_obj();

--- a/src/cpprealm/internal/bridge/object_schema.cpp
+++ b/src/cpprealm/internal/bridge/object_schema.cpp
@@ -57,10 +57,6 @@ namespace realm::internal::bridge {
 #endif
     }
 
-
-
-
-
     object_schema::object_schema(const realm::ObjectSchema &v) {
 #ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
         new (&m_schema) ObjectSchema(v);

--- a/src/cpprealm/internal/bridge/set.cpp
+++ b/src/cpprealm/internal/bridge/set.cpp
@@ -6,142 +6,171 @@
 #include <cpprealm/internal/bridge/realm.hpp>
 
 #include <cpprealm/internal/bridge/table.hpp>
-#include <cpprealm/internal/type_info.hpp>
-
 #include <realm/object-store/set.hpp>
 
-namespace realm::internal::bridge {
-#ifdef __i386__
-    static_assert(SizeCheck<40, sizeof(object_store::Set)>{});
-    static_assert(SizeCheck<4, alignof(object_store::Set)>{});
-#elif __x86_64__
-    static_assert(SizeCheck<80, sizeof(object_store::Set)>{});
-    static_assert(SizeCheck<8, alignof(object_store::Set)>{});
-#elif __arm__
-    static_assert(SizeCheck<40, sizeof(object_store::Set)>{});
-    static_assert(SizeCheck<4, alignof(object_store::Set)>{});
-#elif __aarch64__
-    static_assert(SizeCheck<80, sizeof(object_store::Set)>{});
-    static_assert(SizeCheck<8, alignof(object_store::Set)>{});
-#elif _WIN32
-    static_assert(SizeCheck<80, sizeof(object_store::Set)>{});
-    static_assert(SizeCheck<8, alignof(object_store::Set)>{});
-#endif
+#include <realm/array_mixed.hpp>
+#include <realm/array_typed_link.hpp>
 
+namespace realm::internal::bridge {
     set::set() {
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
         new (&m_set) object_store::Set();
+#else
+        m_set = std::make_shared<object_store::Set>();
+#endif
     }
 
     set::set(const set& other) {
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
         new (&m_set) object_store::Set(*reinterpret_cast<const object_store::Set*>(&other.m_set));
+#else
+        m_set = other.m_set;
+#endif
     }
 
     set& set::operator=(const set& other) {
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
         if (this != &other) {
             *reinterpret_cast<object_store::Set*>(&m_set) = *reinterpret_cast<const object_store::Set*>(&other.m_set);
         }
+#else
+        m_set = other.m_set;
+#endif
         return *this;
     }
 
     set::set(set&& other) {
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
         new (&m_set) object_store::Set(std::move(*reinterpret_cast<object_store::Set*>(&other.m_set)));
+#else
+        m_set = std::move(other.m_set);
+#endif
     }
 
     set& set::operator=(set&& other) {
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
         if (this != &other) {
             *reinterpret_cast<object_store::Set*>(&m_set) = std::move(*reinterpret_cast<object_store::Set*>(&other.m_set));
         }
+#else
+        m_set = std::move(other.m_set);
+#endif
         return *this;
     }
 
     set::~set() {
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
         reinterpret_cast<object_store::Set*>(&m_set)->~Set();
+#endif
     }
 
     set::set(const object_store::Set &v) {
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
         new (&m_set) object_store::Set(v);
+#else
+        m_set = std::make_shared<object_store::Set>(v);
+#endif
     }
 
     set::set(const realm &realm,
                const obj &obj,
                const col_key& col_key) {
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
         new (&m_set) object_store::Set(realm.operator std::shared_ptr<Realm>(), obj, col_key);
+#else
+        m_set = std::make_shared<object_store::Set>(realm.operator std::shared_ptr<Realm>(), obj, col_key);
+#endif
+    }
+
+    const object_store::Set* set::get_set() const {
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+        return reinterpret_cast<const object_store::Set*>(&m_set);
+#else
+        return m_set.get();
+#endif
+    }
+    object_store::Set* set::get_set() {
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+        return reinterpret_cast<object_store::Set*>(&m_set);
+#else
+        return m_set.get();
+#endif
     }
 
     mixed set::get_any(const size_t& i) const {
-        return reinterpret_cast<const object_store::Set*>(&m_set)->get_any(i);
+        return get_set()->get_any(i);
     }
 
     obj set::get_obj(const size_t& i) const {
-        return reinterpret_cast<const object_store::Set*>(&m_set)->get<Obj>(i);
+        return get_set()->get<Obj>(i);
     }
 
     set::operator object_store::Set() const {
-        return *reinterpret_cast<const object_store::Set*>(&m_set);
+        return *get_set();
     }
 
     table set::get_table() const {
-        return reinterpret_cast<const object_store::Set *>(&m_set)->get_table();
+        return get_set()->get_table();
     }
     size_t set::size() const {
-        return reinterpret_cast<const object_store::Set *>(&m_set)->size();
+        return get_set()->size();
     }
     void set::remove_all() {
-        reinterpret_cast<object_store::Set *>(&m_set)->remove_all();
+        get_set()->remove_all();
     }
 
     std::pair<size_t, bool> set::insert(const std::string &v) {
-        return reinterpret_cast<object_store::Set *>(&m_set)->insert(StringData(v));
+        return get_set()->insert(StringData(v));
     }
     std::pair<size_t, bool> set::insert(const int64_t &v) {
-        return reinterpret_cast<object_store::Set *>(&m_set)->insert(v);
+        return get_set()->insert(v);
     }
     std::pair<size_t, bool> set::insert(const double &v) {
-        return reinterpret_cast<object_store::Set *>(&m_set)->insert(v);
+        return get_set()->insert(v);
     }
     std::pair<size_t, bool> set::insert(const binary &v) {
-        return reinterpret_cast<object_store::Set *>(&m_set)->insert(static_cast<BinaryData>(v));
+        return get_set()->insert(v.operator BinaryData());
     }
     std::pair<size_t, bool> set::insert(const uuid &v) {
-        return reinterpret_cast<object_store::Set *>(&m_set)->insert(static_cast<UUID>(v));
+        return get_set()->insert(v.operator UUID());
     }
     std::pair<size_t, bool> set::insert(const object_id &v) {
-        return reinterpret_cast<object_store::Set *>(&m_set)->insert(static_cast<ObjectId>(v));
+        return get_set()->insert(v.operator ObjectId());
     }
     std::pair<size_t, bool> set::insert(const mixed &v) {
-        return reinterpret_cast<object_store::Set *>(&m_set)->insert(v.operator ::realm::Mixed());
+        return get_set()->insert(v.operator ::realm::Mixed());
     }
     std::pair<size_t, bool> set::insert(const obj_key &v) {
-        return reinterpret_cast<object_store::Set *>(&m_set)->insert(static_cast<ObjKey>(v));
+        return get_set()->insert(v.operator ObjKey());
     }
     std::pair<size_t, bool> set::insert(const timestamp &v) {
-        return reinterpret_cast<object_store::Set *>(&m_set)->insert(static_cast<Timestamp>(v));
+        return get_set()->insert(v.operator Timestamp());
     }
     std::pair<size_t, bool> set::insert(const bool &v) {
-        return reinterpret_cast<object_store::Set *>(&m_set)->insert(v);
+        return get_set()->insert(v);
     }
 
-    void set::remove(const int64_t &v) { reinterpret_cast<object_store::Set *>(&m_set)->remove(v); }
-    void set::remove(const bool &v) { reinterpret_cast<object_store::Set *>(&m_set)->remove(v); }
-    void set::remove(const double &v) { reinterpret_cast<object_store::Set *>(&m_set)->remove(v); }
-    void set::remove(const std::string &v) { reinterpret_cast<object_store::Set *>(&m_set)->remove(StringData(v)); }
-    void set::remove(const uuid &v) { reinterpret_cast<object_store::Set *>(&m_set)->remove(static_cast<UUID>(v)); }
-    void set::remove(const object_id &v) { reinterpret_cast<object_store::Set *>(&m_set)->remove(static_cast<ObjectId>(v)); }
-    void set::remove(const mixed &v) { reinterpret_cast<object_store::Set *>(&m_set)->remove(v.operator ::realm::Mixed()); }
-    void set::remove(const timestamp &v) { reinterpret_cast<object_store::Set *>(&m_set)->remove(static_cast<Timestamp>(v)); }
-    void set::remove(const binary& v) { reinterpret_cast<object_store::Set *>(&m_set)->remove(static_cast<BinaryData>(v)); }
-    void set::remove(const obj_key& v) { reinterpret_cast<object_store::Set *>(&m_set)->remove(static_cast<ObjKey>(v)); }
+    void set::remove(const int64_t &v) { get_set()->remove(v); }
+    void set::remove(const bool &v) { get_set()->remove(v); }
+    void set::remove(const double &v) { get_set()->remove(v); }
+    void set::remove(const std::string &v) { get_set()->remove(StringData(v)); }
+    void set::remove(const uuid &v) { get_set()->remove(v.operator UUID()); }
+    void set::remove(const object_id &v) { get_set()->remove(v.operator ObjectId()); }
+    void set::remove(const mixed &v) { get_set()->remove(v.operator ::realm::Mixed()); }
+    void set::remove(const timestamp &v) { get_set()->remove(v.operator Timestamp()); }
+    void set::remove(const binary& v) { get_set()->remove(v.operator BinaryData()); }
+    void set::remove(const obj_key& v) { get_set()->remove(v.operator ObjKey()); }
 
-    size_t set::find(const int64_t &v) { return reinterpret_cast<object_store::Set *>(&m_set)->find(v); }
-    size_t set::find(const bool &v) { return reinterpret_cast<object_store::Set *>(&m_set)->find(v); }
-    size_t set::find(const double &v) { return reinterpret_cast<object_store::Set *>(&m_set)->find(v); }
-    size_t set::find(const std::string &v) { return reinterpret_cast<object_store::Set *>(&m_set)->find(StringData(v)); }
-    size_t set::find(const uuid &v) { return reinterpret_cast<object_store::Set *>(&m_set)->find(static_cast<UUID>(v)); }
-    size_t set::find(const object_id &v) { return reinterpret_cast<object_store::Set *>(&m_set)->find(static_cast<ObjectId>(v)); }
-    size_t set::find(const mixed &v) { return reinterpret_cast<object_store::Set *>(&m_set)->find(v.operator ::realm::Mixed()); }
-    size_t set::find(const timestamp &v) { return reinterpret_cast<object_store::Set *>(&m_set)->find(static_cast<Timestamp>(v)); }
-    size_t set::find(const binary& v) { return reinterpret_cast<object_store::Set *>(&m_set)->find(static_cast<BinaryData>(v)); }
-    size_t set::find(const obj_key& v) { return reinterpret_cast<object_store::Set *>(&m_set)->find(static_cast<ObjKey>(v)); }
+    size_t set::find(const int64_t &v) { return get_set()->find(v); }
+    size_t set::find(const bool &v) { return get_set()->find(v); }
+    size_t set::find(const double &v) { return get_set()->find(v); }
+    size_t set::find(const std::string &v) { return get_set()->find(StringData(v)); }
+    size_t set::find(const uuid &v) { return get_set()->find(v.operator UUID()); }
+    size_t set::find(const object_id &v) { return get_set()->find(v.operator ObjectId()); }
+    size_t set::find(const mixed &v) { return get_set()->find(v.operator ::realm::Mixed()); }
+    size_t set::find(const timestamp &v) { return get_set()->find(v.operator Timestamp()); }
+    size_t set::find(const binary& v) { return get_set()->find(v.operator BinaryData()); }
+    size_t set::find(const obj_key& v) { return get_set()->find(v.operator ObjKey()); }
 
     notification_token set::add_notification_callback(std::shared_ptr<collection_change_callback> cb) {
         struct wrapper : CollectionChangeCallback {
@@ -155,6 +184,6 @@ namespace realm::internal::bridge {
                 m_cb->after(v);
             }
         } ccb(std::move(cb));
-        return reinterpret_cast<object_store::Set*>(&m_set)->add_notification_callback(ccb);
+        return get_set()->add_notification_callback(ccb);
     }
 }

--- a/src/cpprealm/internal/bridge/set.cpp
+++ b/src/cpprealm/internal/bridge/set.cpp
@@ -1,0 +1,160 @@
+#include <cpprealm/internal/bridge/set.hpp>
+
+#include <cpprealm/internal/bridge/col_key.hpp>
+#include <cpprealm/internal/bridge/obj.hpp>
+#include <cpprealm/internal/bridge/mixed.hpp>
+#include <cpprealm/internal/bridge/realm.hpp>
+
+#include <cpprealm/internal/bridge/table.hpp>
+#include <cpprealm/internal/type_info.hpp>
+
+#include <realm/object-store/set.hpp>
+
+namespace realm::internal::bridge {
+#ifdef __i386__
+    static_assert(SizeCheck<40, sizeof(object_store::Set)>{});
+    static_assert(SizeCheck<4, alignof(object_store::Set)>{});
+#elif __x86_64__
+    static_assert(SizeCheck<80, sizeof(object_store::Set)>{});
+    static_assert(SizeCheck<8, alignof(object_store::Set)>{});
+#elif __arm__
+    static_assert(SizeCheck<40, sizeof(object_store::Set)>{});
+    static_assert(SizeCheck<4, alignof(object_store::Set)>{});
+#elif __aarch64__
+    static_assert(SizeCheck<80, sizeof(object_store::Set)>{});
+    static_assert(SizeCheck<8, alignof(object_store::Set)>{});
+#elif _WIN32
+    static_assert(SizeCheck<80, sizeof(object_store::Set)>{});
+    static_assert(SizeCheck<8, alignof(object_store::Set)>{});
+#endif
+
+    set::set() {
+        new (&m_set) object_store::Set();
+    }
+
+    set::set(const set& other) {
+        new (&m_set) object_store::Set(*reinterpret_cast<const object_store::Set*>(&other.m_set));
+    }
+
+    set& set::operator=(const set& other) {
+        if (this != &other) {
+            *reinterpret_cast<object_store::Set*>(&m_set) = *reinterpret_cast<const object_store::Set*>(&other.m_set);
+        }
+        return *this;
+    }
+
+    set::set(set&& other) {
+        new (&m_set) object_store::Set(std::move(*reinterpret_cast<object_store::Set*>(&other.m_set)));
+    }
+
+    set& set::operator=(set&& other) {
+        if (this != &other) {
+            *reinterpret_cast<object_store::Set*>(&m_set) = std::move(*reinterpret_cast<object_store::Set*>(&other.m_set));
+        }
+        return *this;
+    }
+
+    set::~set() {
+        reinterpret_cast<object_store::Set*>(&m_set)->~Set();
+    }
+
+    set::set(const object_store::Set &v) {
+        new (&m_set) object_store::Set(v);
+    }
+
+    set::set(const realm &realm,
+               const obj &obj,
+               const col_key& col_key) {
+        new (&m_set) object_store::Set(realm.operator std::shared_ptr<Realm>(), obj, col_key);
+    }
+
+    mixed set::get_any(const size_t& i) const {
+        return reinterpret_cast<const object_store::Set*>(&m_set)->get_any(i);
+    }
+
+    obj set::get_obj(const size_t& i) const {
+        return reinterpret_cast<const object_store::Set*>(&m_set)->get<Obj>(i);
+    }
+
+    set::operator object_store::Set() const {
+        return *reinterpret_cast<const object_store::Set*>(&m_set);
+    }
+
+    table set::get_table() const {
+        return reinterpret_cast<const object_store::Set *>(&m_set)->get_table();
+    }
+    size_t set::size() const {
+        return reinterpret_cast<const object_store::Set *>(&m_set)->size();
+    }
+    void set::remove_all() {
+        reinterpret_cast<object_store::Set *>(&m_set)->remove_all();
+    }
+
+    std::pair<size_t, bool> set::insert(const std::string &v) {
+        return reinterpret_cast<object_store::Set *>(&m_set)->insert(StringData(v));
+    }
+    std::pair<size_t, bool> set::insert(const int64_t &v) {
+        return reinterpret_cast<object_store::Set *>(&m_set)->insert(v);
+    }
+    std::pair<size_t, bool> set::insert(const double &v) {
+        return reinterpret_cast<object_store::Set *>(&m_set)->insert(v);
+    }
+    std::pair<size_t, bool> set::insert(const binary &v) {
+        return reinterpret_cast<object_store::Set *>(&m_set)->insert(static_cast<BinaryData>(v));
+    }
+    std::pair<size_t, bool> set::insert(const uuid &v) {
+        return reinterpret_cast<object_store::Set *>(&m_set)->insert(static_cast<UUID>(v));
+    }
+    std::pair<size_t, bool> set::insert(const object_id &v) {
+        return reinterpret_cast<object_store::Set *>(&m_set)->insert(static_cast<ObjectId>(v));
+    }
+    std::pair<size_t, bool> set::insert(const mixed &v) {
+        return reinterpret_cast<object_store::Set *>(&m_set)->insert(v.operator ::realm::Mixed());
+    }
+    std::pair<size_t, bool> set::insert(const obj_key &v) {
+        return reinterpret_cast<object_store::Set *>(&m_set)->insert(static_cast<ObjKey>(v));
+    }
+    std::pair<size_t, bool> set::insert(const timestamp &v) {
+        return reinterpret_cast<object_store::Set *>(&m_set)->insert(static_cast<Timestamp>(v));
+    }
+    std::pair<size_t, bool> set::insert(const bool &v) {
+        return reinterpret_cast<object_store::Set *>(&m_set)->insert(v);
+    }
+
+    void set::remove(const int64_t &v) { reinterpret_cast<object_store::Set *>(&m_set)->remove(v); }
+    void set::remove(const bool &v) { reinterpret_cast<object_store::Set *>(&m_set)->remove(v); }
+    void set::remove(const double &v) { reinterpret_cast<object_store::Set *>(&m_set)->remove(v); }
+    void set::remove(const std::string &v) { reinterpret_cast<object_store::Set *>(&m_set)->remove(StringData(v)); }
+    void set::remove(const uuid &v) { reinterpret_cast<object_store::Set *>(&m_set)->remove(static_cast<UUID>(v)); }
+    void set::remove(const object_id &v) { reinterpret_cast<object_store::Set *>(&m_set)->remove(static_cast<ObjectId>(v)); }
+    void set::remove(const mixed &v) { reinterpret_cast<object_store::Set *>(&m_set)->remove(v.operator ::realm::Mixed()); }
+    void set::remove(const timestamp &v) { reinterpret_cast<object_store::Set *>(&m_set)->remove(static_cast<Timestamp>(v)); }
+    void set::remove(const binary& v) { reinterpret_cast<object_store::Set *>(&m_set)->remove(static_cast<BinaryData>(v)); }
+    void set::remove(const obj_key& v) { reinterpret_cast<object_store::Set *>(&m_set)->remove(static_cast<ObjKey>(v)); }
+
+    size_t set::find(const int64_t &v) { return reinterpret_cast<object_store::Set *>(&m_set)->find(v); }
+    size_t set::find(const bool &v) { return reinterpret_cast<object_store::Set *>(&m_set)->find(v); }
+    size_t set::find(const double &v) { return reinterpret_cast<object_store::Set *>(&m_set)->find(v); }
+    size_t set::find(const std::string &v) { return reinterpret_cast<object_store::Set *>(&m_set)->find(StringData(v)); }
+    size_t set::find(const uuid &v) { return reinterpret_cast<object_store::Set *>(&m_set)->find(static_cast<UUID>(v)); }
+    size_t set::find(const object_id &v) { return reinterpret_cast<object_store::Set *>(&m_set)->find(static_cast<ObjectId>(v)); }
+    size_t set::find(const mixed &v) { return reinterpret_cast<object_store::Set *>(&m_set)->find(v.operator ::realm::Mixed()); }
+    size_t set::find(const timestamp &v) { return reinterpret_cast<object_store::Set *>(&m_set)->find(static_cast<Timestamp>(v)); }
+    size_t set::find(const binary& v) { return reinterpret_cast<object_store::Set *>(&m_set)->find(static_cast<BinaryData>(v)); }
+    size_t set::find(const obj_key& v) { return reinterpret_cast<object_store::Set *>(&m_set)->find(static_cast<ObjKey>(v)); }
+
+    notification_token set::add_notification_callback(std::shared_ptr<collection_change_callback> cb) {
+        struct wrapper : CollectionChangeCallback {
+            std::shared_ptr<collection_change_callback> m_cb;
+            explicit wrapper(std::shared_ptr<collection_change_callback>&& cb)
+                : m_cb(std::move(cb)) {}
+            void before(const CollectionChangeSet& v) const {
+                m_cb->before(v);
+            }
+            void after(const CollectionChangeSet& v) const {
+                m_cb->after(v);
+            }
+        } ccb(std::move(cb));
+        return reinterpret_cast<object_store::Set*>(&m_set)->add_notification_callback(ccb);
+    }
+}

--- a/src/cpprealm/internal/bridge/set.hpp
+++ b/src/cpprealm/internal/bridge/set.hpp
@@ -5,6 +5,7 @@
 #include <memory>
 #include <set>
 #include <string>
+#include <cpprealm/internal/bridge/utils.hpp>
 
 namespace realm {
     namespace object_store {
@@ -83,16 +84,12 @@ namespace realm::internal::bridge {
         size_t find(const obj_key&);
         notification_token add_notification_callback(std::shared_ptr<collection_change_callback>);
     private:
-#ifdef __i386__
-        std::aligned_storage<40, 4>::type m_set[1];
-#elif __x86_64__
-        std::aligned_storage<80, 8>::type m_set[1];
-#elif __arm__
-        std::aligned_storage<40, 4>::type m_set[1];
-#elif __aarch64__
-        std::aligned_storage<80, 8>::type m_set[1];
-#elif _WIN32
-        std::aligned_storage<80, 8>::type m_set[1];
+        const object_store::Set* get_set() const;
+        object_store::Set* get_set();
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+        storage::Set m_set[1];
+#else
+        std::shared_ptr<object_store::Set> m_set;
 #endif
     };
 }

--- a/src/cpprealm/internal/bridge/set.hpp
+++ b/src/cpprealm/internal/bridge/set.hpp
@@ -1,0 +1,100 @@
+#ifndef CPP_REALM_BRIDGE_SET_HPP
+#define CPP_REALM_BRIDGE_SET_HPP
+
+#include <cstdlib>
+#include <memory>
+#include <set>
+#include <string>
+
+namespace realm {
+    namespace object_store {
+        class Set;
+    }
+    template <typename>
+    struct object;
+    template <typename, typename>
+    struct persisted;
+}
+
+namespace realm::internal::bridge {
+    struct realm;
+    struct obj;
+    struct obj_key;
+    struct mixed;
+    struct binary;
+    struct uuid;
+    struct object_id;
+    struct col_key;
+    struct timestamp;
+    struct table;
+    struct notification_token;
+    struct collection_change_callback;
+
+    struct set {
+        set();
+        set(const set& other) ;
+        set& operator=(const set& other) ;
+        set(set&& other);
+        set& operator=(set&& other);
+        ~set();
+        set(const object_store::Set&); //NOLINT(google-explicit-constructor)
+        operator object_store::Set() const; //NOLINT(google-explicit-constructor)
+        set(const realm& realm, const obj& obj, const col_key&);
+
+        mixed get_any(const size_t& i) const;
+        obj get_obj(const size_t& i) const;
+
+        [[nodiscard]] size_t size() const;
+        void remove_all();
+
+        table get_table() const;
+
+        std::pair<size_t, bool> insert(const std::string&);
+        std::pair<size_t, bool> insert(const int64_t &);
+        std::pair<size_t, bool> insert(const double &);
+        std::pair<size_t, bool> insert(const bool &);
+        std::pair<size_t, bool> insert(const binary &);
+        std::pair<size_t, bool> insert(const uuid &);
+        std::pair<size_t, bool> insert(const object_id &);
+        std::pair<size_t, bool> insert(const mixed &);
+        std::pair<size_t, bool> insert(const obj_key &);
+        std::pair<size_t, bool> insert(const timestamp &);
+
+        void remove(const int64_t &);
+        void remove(const bool &);
+        void remove(const double &);
+        void remove(const std::string &);
+        void remove(const uuid &);
+        void remove(const object_id &);
+        void remove(const mixed &);
+        void remove(const timestamp &);
+        void remove(const binary&);
+        void remove(const obj_key&);
+
+        size_t find(const int64_t &);
+        size_t find(const bool &);
+        size_t find(const double &);
+        size_t find(const std::string &);
+        size_t find(const uuid &);
+        size_t find(const object_id &);
+        size_t find(const mixed &);
+        size_t find(const timestamp &);
+        size_t find(const binary&);
+        size_t find(const obj_key&);
+        notification_token add_notification_callback(std::shared_ptr<collection_change_callback>);
+    private:
+#ifdef __i386__
+        std::aligned_storage<40, 4>::type m_set[1];
+#elif __x86_64__
+        std::aligned_storage<80, 8>::type m_set[1];
+#elif __arm__
+        std::aligned_storage<40, 4>::type m_set[1];
+#elif __aarch64__
+        std::aligned_storage<80, 8>::type m_set[1];
+#elif _WIN32
+        std::aligned_storage<80, 8>::type m_set[1];
+#endif
+    };
+}
+
+#endif //CPP_REALM_BRIDGE_SET_HPP

--- a/src/cpprealm/internal/type_info.hpp
+++ b/src/cpprealm/internal/type_info.hpp
@@ -12,6 +12,7 @@
 #include <cpprealm/internal/bridge/dictionary.hpp>
 #include <cpprealm/internal/bridge/object_id.hpp>
 #include <cpprealm/internal/bridge/decimal128.hpp>
+#include <cpprealm/internal/bridge/set.hpp>
 
 #include <map>
 #include <vector>
@@ -38,6 +39,14 @@ namespace realm::internal::type_info {
     };
     template <typename T>
     struct is_vector<std::vector<T>> : std::true_type {
+        static constexpr auto value = true;
+    };
+    template <typename T, typename = void>
+    struct is_set : std::false_type {
+        static constexpr auto value = false;
+    };
+    template <typename T>
+    struct is_set<std::set<T>> : std::true_type {
         static constexpr auto value = true;
     };
     template <typename T, typename = void>
@@ -243,6 +252,13 @@ namespace realm::internal::type_info {
         using internal_type = internal::bridge::dictionary;
         static constexpr bridge::property::type type() {
             return bridge::property::type::Dictionary | type_info<ValueType>::type();
+        }
+    };
+    template <typename ValueType>
+    struct type_info<std::set<ValueType>> {
+        using internal_type = bridge::set;
+        static constexpr bridge::property::type type() {
+            return bridge::property::type::Set | type_info<ValueType>::type();
         }
     };
     template <typename T>

--- a/src/cpprealm/notifications.hpp
+++ b/src/cpprealm/notifications.hpp
@@ -27,6 +27,7 @@
 #include <cpprealm/thread_safe_reference.hpp>
 #include <cpprealm/internal/bridge/dictionary.hpp>
 #include <cpprealm/internal/bridge/list.hpp>
+#include <cpprealm/internal/bridge/set.hpp>
 
 #include <any>
 #include <future>
@@ -69,6 +70,7 @@ struct notification_token {
     internal::bridge::notification_token m_token;
     std::shared_ptr<internal::bridge::dictionary> m_dictionary;
     std::shared_ptr<internal::bridge::list> m_list;
+    std::shared_ptr<internal::bridge::set> m_set;
     internal::bridge::realm m_realm;
 };
 

--- a/src/cpprealm/persisted_object_id.hpp
+++ b/src/cpprealm/persisted_object_id.hpp
@@ -11,16 +11,6 @@ namespace realm {
         return stream << value.to_string();
     }
 
-<<<<<<< HEAD
-=======
-    inline bool operator ==(const object_id& lhs, const object_id& rhs) { return lhs.m_object_id == rhs.m_object_id; }
-    inline bool operator !=(const object_id& lhs, const object_id& rhs) { return lhs.m_object_id != rhs.m_object_id; }
-    inline bool operator <(const object_id& lhs, const object_id& rhs) { return lhs.m_object_id < rhs.m_object_id; }
-    inline bool operator >(const object_id& lhs, const object_id& rhs) { return lhs.m_object_id > rhs.m_object_id; }
-    inline bool operator <=(const object_id& lhs, const object_id& rhs) { return lhs.m_object_id <= rhs.m_object_id; }
-    inline bool operator >=(const object_id& lhs, const object_id& rhs) { return lhs.m_object_id >= rhs.m_object_id; }
-
->>>>>>> e4939c5 (Begin adding std::set support for primitives)
     template <>
     struct persisted<object_id> : persisted_primitive_base<object_id> {
         using persisted_primitive_base<object_id>::persisted_primitive_base;
@@ -33,10 +23,6 @@ namespace realm {
         __cpp_realm_friends
     };
 
-    __cpp_realm_generate_operator(object_id, >, greater)
-    __cpp_realm_generate_operator(object_id, <, less)
-    __cpp_realm_generate_operator(object_id, >=, greater_equal)
-    __cpp_realm_generate_operator(object_id, <=, less_equal)
     __cpp_realm_generate_operator(object_id, ==, equal)
     __cpp_realm_generate_operator(object_id, !=, not_equal)
 }

--- a/src/cpprealm/persisted_object_id.hpp
+++ b/src/cpprealm/persisted_object_id.hpp
@@ -6,12 +6,21 @@
 #include <cpprealm/experimental/types.hpp>
 namespace realm {
 
-
     inline std::ostream& operator<< (std::ostream& stream, const object_id& value)
     {
         return stream << value.to_string();
     }
 
+<<<<<<< HEAD
+=======
+    inline bool operator ==(const object_id& lhs, const object_id& rhs) { return lhs.m_object_id == rhs.m_object_id; }
+    inline bool operator !=(const object_id& lhs, const object_id& rhs) { return lhs.m_object_id != rhs.m_object_id; }
+    inline bool operator <(const object_id& lhs, const object_id& rhs) { return lhs.m_object_id < rhs.m_object_id; }
+    inline bool operator >(const object_id& lhs, const object_id& rhs) { return lhs.m_object_id > rhs.m_object_id; }
+    inline bool operator <=(const object_id& lhs, const object_id& rhs) { return lhs.m_object_id <= rhs.m_object_id; }
+    inline bool operator >=(const object_id& lhs, const object_id& rhs) { return lhs.m_object_id >= rhs.m_object_id; }
+
+>>>>>>> e4939c5 (Begin adding std::set support for primitives)
     template <>
     struct persisted<object_id> : persisted_primitive_base<object_id> {
         using persisted_primitive_base<object_id>::persisted_primitive_base;

--- a/src/cpprealm/persisted_uuid.hpp
+++ b/src/cpprealm/persisted_uuid.hpp
@@ -13,11 +13,6 @@ namespace realm {
         return stream << value.to_string();
     }
 
-    inline bool operator >(const uuid& lhs, const uuid& rhs) { return lhs.m_uuid > rhs.m_uuid; }
-    inline bool operator <(const uuid& lhs, const uuid& rhs) { return lhs.m_uuid < rhs.m_uuid; }
-    inline bool operator >=(const uuid& lhs, const uuid& rhs) { return lhs.m_uuid >= rhs.m_uuid; }
-    inline bool operator <=(const uuid& lhs, const uuid& rhs) { return lhs.m_uuid <= rhs.m_uuid; }
-
     template <>
     struct persisted<uuid> : persisted_primitive_base<uuid> {
         using persisted_primitive_base<uuid>::persisted_primitive_base;

--- a/src/cpprealm/schema.hpp
+++ b/src/cpprealm/schema.hpp
@@ -112,6 +112,14 @@ namespace realm {
                         property.set_object_link(
                                 experimental::managed<std::remove_pointer_t<typename Result::value_type>, void>::schema.name);
                     }
+                } else if constexpr (realm::internal::type_info::is_set<Result>::value) {
+                    if constexpr (std::is_base_of_v<object_base<typename Result::value_type>,
+                                                    typename Result::value_type>) {
+                        property.set_object_link(Result::value_type::schema.name);
+                    } else if constexpr (std::is_pointer_v<typename Result::value_type>) {
+                        property.set_object_link(
+                                experimental::managed<std::remove_pointer_t<typename Result::value_type>, void>::schema.name);
+                    }
                 } else if constexpr (realm::internal::type_info::is_map<Result>::value) {
                     if constexpr (internal::type_info::is_optional<typename Result::mapped_type>::value) {
                         if constexpr (std::is_base_of_v<object_base<typename Result::mapped_type::value_type>, typename Result::mapped_type::value_type>) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -79,7 +79,8 @@ else()
             experimental/db/run_loop_tests.cpp
             experimental/db/string_tests.cpp
             experimental/db/performance_tests.cpp
-            experimental/db/numeric_tests.cpp)
+            experimental/db/numeric_tests.cpp
+            experimental/db/set_tests.cpp)
     target_compile_definitions(cpprealm_sync_tests PUBLIC CPPREALM_ENABLE_SYNC_TESTS)
 
     if(ENABLE_ALPHA_SDK)

--- a/tests/experimental/db/object_tests.cpp
+++ b/tests/experimental/db/object_tests.cpp
@@ -982,5 +982,31 @@ namespace realm::experimental {
             CHECK(detached_obj.map_mixed_col["foo"] == realm::mixed("bar"));
             CHECK(detached_obj.map_link_col["foo"]->str_col == "link object 3");
         }
+        SECTION("optional objects") {
+            auto realm = db(std::move(config));
+
+            auto obj1 = AllTypesObject();
+            obj1._id = 1;
+
+
+            auto o = AllTypesObjectLink();
+            o.str_col = "bar";
+            obj1.opt_obj_col = &o;
+
+            auto obj2 = AllTypesObject();
+
+
+            obj2._id = 2;
+            obj2.opt_obj_col = &o;
+
+            realm.write([&] {
+                realm.add(std::move(obj1));
+                realm.add(std::move(obj2));
+            });
+
+            CHECK(realm.objects<AllTypesObject>().size() == 2);
+//            CHECK(realm.objects<AllTypesObjectLink>().size() == 2);
+
+        }
     }
 }

--- a/tests/experimental/db/set_tests.cpp
+++ b/tests/experimental/db/set_tests.cpp
@@ -55,7 +55,7 @@ TEST_CASE("set", "[set]") {
         auto time = std::chrono::system_clock::now();
         auto time2 = time + time.time_since_epoch();
         test(&managed_obj.set_date_col, scenario, {time, time, time2, std::chrono::time_point<std::chrono::system_clock>()});
-        test(&managed_obj.set_mixed_col, scenario, { realm::mixed(42), realm::mixed(42), realm::mixed("24"), realm::mixed(realm::uuid("18de7916-7f84-11ec-a8a3-0242ac120002"))});
+        test(&managed_obj.set_mixed_col, scenario, { realm::mixed((int64_t)42), realm::mixed((int64_t)42), realm::mixed("24"), realm::mixed(realm::uuid("18de7916-7f84-11ec-a8a3-0242ac120002"))});
     }
 
     SECTION("find") {
@@ -94,7 +94,7 @@ TEST_CASE("set", "[set]") {
         auto time = std::chrono::system_clock::now();
         auto time2 = time + time.time_since_epoch();
         test(&managed_obj.set_date_col, scenario, {time, time, time2, std::chrono::time_point<std::chrono::system_clock>()});
-        test(&managed_obj.set_mixed_col, scenario, { realm::mixed(42), realm::mixed(42), realm::mixed("24"), realm::mixed(realm::uuid("18de7916-7f84-11ec-a8a3-0242ac120002"))});
+        test(&managed_obj.set_mixed_col, scenario, { realm::mixed((int64_t)42), realm::mixed((int64_t)42), realm::mixed("24"), realm::mixed(realm::uuid("18de7916-7f84-11ec-a8a3-0242ac120002"))});
 
         realm.write([&]() {
             managed_obj.set_bool_col.insert(true);
@@ -151,7 +151,7 @@ TEST_CASE("set", "[set]") {
         auto time = std::chrono::system_clock::now();
         auto time2 = time + time.time_since_epoch();
         test(&managed_obj.set_date_col, scenario, {time, time, time2, std::chrono::time_point<std::chrono::system_clock>()});
-        test(&managed_obj.set_mixed_col, scenario, { realm::mixed(42), realm::mixed(42), realm::mixed("24"), realm::mixed(realm::uuid("18de7916-7f84-11ec-a8a3-0242ac120002"))});
+        test(&managed_obj.set_mixed_col, scenario, { realm::mixed((int64_t)42), realm::mixed((int64_t)42), realm::mixed("24"), realm::mixed(realm::uuid("18de7916-7f84-11ec-a8a3-0242ac120002"))});
 
         realm.write([&]() {
             managed_obj.set_bool_col.insert(true);
@@ -218,7 +218,7 @@ TEST_CASE("set", "[set]") {
         auto time = std::chrono::system_clock::now();
         auto time2 = time + time.time_since_epoch();
         test(&managed_obj.set_date_col, scenario, {time, time, time2, std::chrono::time_point<std::chrono::system_clock>()});
-        test(&managed_obj.set_mixed_col, scenario, { realm::mixed(42), realm::mixed(42), realm::mixed("24"), realm::mixed(realm::uuid("18de7916-7f84-11ec-a8a3-0242ac120002"))});
+        test(&managed_obj.set_mixed_col, scenario, { realm::mixed((int64_t)42), realm::mixed((int64_t)42), realm::mixed("24"), realm::mixed(realm::uuid("18de7916-7f84-11ec-a8a3-0242ac120002"))});
 
         size_t callback_count = 0;
         auto token = managed_obj.set_bool_col.observe([&](auto&& c) {
@@ -304,8 +304,8 @@ TEST_CASE("set", "[set]") {
         test<&experimental::AllTypesObject::set_mixed_col,
              &experimental::managed<experimental::AllTypesObject>::set_mixed_col>(scenario,
                                                                                   std::vector<realm::mixed>({
-                 realm::mixed(42),
-                 realm::mixed(42),
+                 realm::mixed((int64_t)42),
+                 realm::mixed((int64_t)42),
                  realm::mixed("24"),
                  realm::mixed(realm::uuid("18de7916-7f84-11ec-a8a3-0242ac120002"))}));
     }

--- a/tests/experimental/db/set_tests.cpp
+++ b/tests/experimental/db/set_tests.cpp
@@ -1,0 +1,647 @@
+#include "../../main.hpp"
+#include "test_objects.hpp"
+
+using namespace realm;
+
+template<typename T, typename Func>
+void test(realm::experimental::managed<T>* property, Func f, 
+          std::vector<typename T::value_type>&& values, size_t&& expected_count = 3) {
+    f(property, values, expected_count);
+}
+
+template<auto UnmanagedPtr, auto ManagedPtr, typename Func, typename T>
+void test(Func f, std::vector<T>&& values, size_t&& expected_count = 3) {
+    constexpr auto unmanaged_ptr = UnmanagedPtr;
+    constexpr auto managed_ptr = ManagedPtr;
+    f(unmanaged_ptr, managed_ptr, values, expected_count);
+}
+
+TEST_CASE("set", "[set]") {
+    realm_path path;
+    db_config config;
+    config.set_path(path);
+
+    SECTION("insert") {
+        auto realm = realm::experimental::db(std::move(config));
+        auto obj = realm::experimental::AllTypesObject();
+
+        auto managed_obj = realm.write([&]() {
+            return realm.add(std::move(obj));
+        });
+
+        auto scenario = [&](auto& p, auto& values, size_t expected_count) {
+            realm.write([&]() {
+                for (auto v: values) {
+                    p->insert(v);
+                }
+            });
+            CHECK(p->size() == expected_count);
+        };
+
+        test(&managed_obj.set_int_col, scenario, {42, 42, 24, -1});
+        test(&managed_obj.set_double_col, scenario, {42.001, 42.001, 24.001, -1.001});
+        test(&managed_obj.set_bool_col, scenario, {true, false, true}, 2);
+        test(&managed_obj.set_str_col, scenario, {"42", "42", "24", "-1"});
+        test(&managed_obj.set_uuid_col, scenario, {realm::uuid("18de7916-7f84-11ec-a8a3-0242ac120000"), 
+                                                   realm::uuid("18de7916-7f84-11ec-a8a3-0242ac120000"),
+                                                   realm::uuid("18de7916-7f84-11ec-a8a3-0242ac120001"),
+                                                   realm::uuid("18de7916-7f84-11ec-a8a3-0242ac120002")});
+        auto obj_id = realm::object_id::generate();
+        test(&managed_obj.set_object_id_col, scenario, {obj_id, obj_id, realm::object_id::generate(), realm::object_id::generate()});
+
+        auto bin_data = std::vector<uint8_t>({1, 2, 3, 4});
+        test(&managed_obj.set_binary_col, scenario, {bin_data, bin_data, std::vector<uint8_t>({1, 3, 4}), std::vector<uint8_t>({1})});
+
+        auto time = std::chrono::system_clock::now();
+        auto time2 = time + time.time_since_epoch();
+        test(&managed_obj.set_date_col, scenario, {time, time, time2, std::chrono::time_point<std::chrono::system_clock>()});
+        test(&managed_obj.set_mixed_col, scenario, { realm::mixed(42), realm::mixed(42), realm::mixed("24"), realm::mixed(realm::uuid("18de7916-7f84-11ec-a8a3-0242ac120002"))});
+    }
+
+    SECTION("find") {
+        auto realm = realm::experimental::db(std::move(config));
+        auto obj = realm::experimental::AllTypesObject();
+        auto managed_obj = realm.write([&]() {
+            return realm.add(std::move(obj));
+        });
+
+        auto scenario = [&](auto& p, auto& values, size_t expected_count) {
+            realm.write([&]() {
+                p->insert(values[0]);
+            });
+            CHECK(p->size() == 1);
+
+            auto it = p->find(values[0]);
+            CHECK(it != p->end());
+            CHECK(*it == values[0]);
+            auto it2 = p->find(values[values.size() - 1]);
+            CHECK(it2 == p->end());
+        };
+
+        test(&managed_obj.set_int_col, scenario, {42, 42, 24, -1});
+        test(&managed_obj.set_double_col, scenario, {42.001, 42.001, 24.001, -1.001});
+        test(&managed_obj.set_str_col, scenario, {"42", "42", "24", "-1"});
+        test(&managed_obj.set_uuid_col, scenario, {realm::uuid("18de7916-7f84-11ec-a8a3-0242ac120000"),
+                                                   realm::uuid("18de7916-7f84-11ec-a8a3-0242ac120000"),
+                                                   realm::uuid("18de7916-7f84-11ec-a8a3-0242ac120001"),
+                                                   realm::uuid("18de7916-7f84-11ec-a8a3-0242ac120002")});
+        auto obj_id = realm::object_id::generate();
+        test(&managed_obj.set_object_id_col, scenario, {obj_id, obj_id, realm::object_id::generate(), realm::object_id::generate()});
+
+        auto bin_data = std::vector<uint8_t>({1, 2, 3, 4});
+        test(&managed_obj.set_binary_col, scenario, {bin_data, bin_data, std::vector<uint8_t>({1, 3, 4}), std::vector<uint8_t>({1})});
+
+        auto time = std::chrono::system_clock::now();
+        auto time2 = time + time.time_since_epoch();
+        test(&managed_obj.set_date_col, scenario, {time, time, time2, std::chrono::time_point<std::chrono::system_clock>()});
+        test(&managed_obj.set_mixed_col, scenario, { realm::mixed(42), realm::mixed(42), realm::mixed("24"), realm::mixed(realm::uuid("18de7916-7f84-11ec-a8a3-0242ac120002"))});
+
+        realm.write([&]() {
+            managed_obj.set_bool_col.insert(true);
+        });
+        CHECK(managed_obj.set_bool_col.size() == 1);
+
+        auto it = managed_obj.set_bool_col.find(true);
+        CHECK(it != managed_obj.set_bool_col.end());
+        CHECK(*it == true);
+        auto it2 = managed_obj.set_bool_col.find(false);
+        CHECK(it2 == managed_obj.set_bool_col.end());
+    }
+
+    SECTION("erase") {
+        auto realm = realm::experimental::db(std::move(config));
+        auto obj = realm::experimental::AllTypesObject();
+        auto managed_obj = realm.write([&]() {
+            return realm.add(std::move(obj));
+        });
+
+        auto scenario = [&](auto& p, auto& values, size_t expected_count) {
+            realm.write([&]() {
+                for (auto& v : values) {
+                    p->insert(v);
+                }
+            });
+
+            auto it = p->find(values[0]);
+            realm.write([&]() {
+                p->erase(it);
+            });
+            it =  p->find(values[0]);
+            CHECK(it ==  p->end());
+            CHECK(p->size() == 2);
+            realm.write([&]() {
+                p->clear();
+            });
+            CHECK(p->size() == 0);
+        };
+
+        test(&managed_obj.set_int_col, scenario, {42, 42, 24, -1});
+        test(&managed_obj.set_double_col, scenario, {42.001, 42.001, 24.001, -1.001});
+        test(&managed_obj.set_str_col, scenario, {"42", "42", "24", "-1"});
+        test(&managed_obj.set_uuid_col, scenario, {realm::uuid("18de7916-7f84-11ec-a8a3-0242ac120000"),
+                                                   realm::uuid("18de7916-7f84-11ec-a8a3-0242ac120000"),
+                                                   realm::uuid("18de7916-7f84-11ec-a8a3-0242ac120001"),
+                                                   realm::uuid("18de7916-7f84-11ec-a8a3-0242ac120002")});
+        auto obj_id = realm::object_id::generate();
+        test(&managed_obj.set_object_id_col, scenario, {obj_id, obj_id, realm::object_id::generate(), realm::object_id::generate()});
+
+        auto bin_data = std::vector<uint8_t>({1, 2, 3, 4});
+        test(&managed_obj.set_binary_col, scenario, {bin_data, bin_data, std::vector<uint8_t>({1, 3, 4}), std::vector<uint8_t>({1})});
+
+        auto time = std::chrono::system_clock::now();
+        auto time2 = time + time.time_since_epoch();
+        test(&managed_obj.set_date_col, scenario, {time, time, time2, std::chrono::time_point<std::chrono::system_clock>()});
+        test(&managed_obj.set_mixed_col, scenario, { realm::mixed(42), realm::mixed(42), realm::mixed("24"), realm::mixed(realm::uuid("18de7916-7f84-11ec-a8a3-0242ac120002"))});
+
+        realm.write([&]() {
+            managed_obj.set_bool_col.insert(true);
+            managed_obj.set_bool_col.insert(false);
+        });
+
+        auto it = managed_obj.set_bool_col.find(true);
+        realm.write([&]() {
+            managed_obj.set_bool_col.erase(it);
+        });
+        it =  managed_obj.set_bool_col.find(true);
+        CHECK(it ==  managed_obj.set_bool_col.end());
+        CHECK(managed_obj.set_bool_col.size() == 1);
+        realm.write([&]() {
+            managed_obj.set_bool_col.clear();
+        });
+        CHECK(managed_obj.set_bool_col.size() == 0);
+    }
+
+    SECTION("notifications") {
+        auto realm = realm::experimental::db(std::move(config));
+        auto obj = realm::experimental::AllTypesObject();
+        auto managed_obj = realm.write([&]() {
+            return realm.add(std::move(obj));
+        });
+
+        auto scenario = [&](auto& p, auto& values, size_t expected_count) {
+            size_t callback_count = 0;
+            auto token = p->observe([&](auto&& c) {
+                callback_count++;
+                if (callback_count == 2)
+                    CHECK(c.insertions.size() == 3);
+                else if (callback_count == 3)
+                    CHECK(c.deletions.size() == 3);
+            });
+            realm.write([&]() {
+                for (auto& v : values) {
+                    p->insert(v);
+                }
+            });
+            realm.refresh();
+            CHECK(callback_count == 2);
+
+            realm.write([&]() {
+                p->clear();
+            });
+            realm.refresh();
+            CHECK(callback_count == 3);
+        };
+
+        test(&managed_obj.set_int_col, scenario, {42, 42, 24, -1});
+        test(&managed_obj.set_double_col, scenario, {42.001, 42.001, 24.001, -1.001});
+        test(&managed_obj.set_str_col, scenario, {"42", "42", "24", "-1"});
+        test(&managed_obj.set_uuid_col, scenario, {realm::uuid("18de7916-7f84-11ec-a8a3-0242ac120000"),
+                                                   realm::uuid("18de7916-7f84-11ec-a8a3-0242ac120000"),
+                                                   realm::uuid("18de7916-7f84-11ec-a8a3-0242ac120001"),
+                                                   realm::uuid("18de7916-7f84-11ec-a8a3-0242ac120002")});
+        auto obj_id = realm::object_id::generate();
+        test(&managed_obj.set_object_id_col, scenario, {obj_id, obj_id, realm::object_id::generate(), realm::object_id::generate()});
+
+        auto bin_data = std::vector<uint8_t>({1, 2, 3, 4});
+        test(&managed_obj.set_binary_col, scenario, {bin_data, bin_data, std::vector<uint8_t>({1, 3, 4}), std::vector<uint8_t>({1})});
+
+        auto time = std::chrono::system_clock::now();
+        auto time2 = time + time.time_since_epoch();
+        test(&managed_obj.set_date_col, scenario, {time, time, time2, std::chrono::time_point<std::chrono::system_clock>()});
+        test(&managed_obj.set_mixed_col, scenario, { realm::mixed(42), realm::mixed(42), realm::mixed("24"), realm::mixed(realm::uuid("18de7916-7f84-11ec-a8a3-0242ac120002"))});
+
+        size_t callback_count = 0;
+        auto token = managed_obj.set_bool_col.observe([&](auto&& c) {
+            callback_count++;
+            if (callback_count == 2)
+                CHECK(c.insertions.size() == 2);
+            else if (callback_count == 3)
+                CHECK(c.deletions.size() == 2);
+        });
+        realm.write([&]() {
+            managed_obj.set_bool_col.insert(true);
+            managed_obj.set_bool_col.insert(false);
+        });
+        realm.refresh();
+        CHECK(callback_count == 2);
+
+        realm.write([&]() {
+            managed_obj.set_bool_col.clear();
+        });
+        realm.refresh();
+        CHECK(callback_count == 3);
+    }
+
+    SECTION("detach()") {
+
+        auto scenario = [&](auto unmanaged_ptr, auto managed_ptr, auto& values, size_t expected_count) {
+            auto realm = realm::experimental::db(std::move(config));
+            auto obj = realm::experimental::AllTypesObject();
+
+            for (auto& v : values) {
+                (obj.*unmanaged_ptr).insert(v);
+            }
+
+            auto managed_obj = realm.write([&]() {
+                return realm.add(std::move(obj));
+            });
+
+            auto other = (managed_obj.*managed_ptr).detach();
+            using ElementType = typename std::remove_reference<decltype(*values.begin())>::type;
+            CHECK(other == std::set<ElementType>(values.begin(), values.end()));
+        };
+
+        test<&experimental::AllTypesObject::set_int_col,
+             &experimental::managed<experimental::AllTypesObject>::set_int_col>(scenario,
+                                                                                std::vector<int64_t>({1, 2, 3, 3}));
+        test<&experimental::AllTypesObject::set_double_col,
+             &experimental::managed<experimental::AllTypesObject>::set_double_col>(scenario,
+                                                                                   std::vector<double>({42.001, 42.001, 24.001, -1.001}));
+        test<&experimental::AllTypesObject::set_str_col,
+             &experimental::managed<experimental::AllTypesObject>::set_str_col>(scenario,
+                                                                                std::vector<std::string>({"42", "42", "24", "-1"}));
+        test<&experimental::AllTypesObject::set_uuid_col,
+             &experimental::managed<experimental::AllTypesObject>::set_uuid_col>(scenario,
+                                                                                std::vector<realm::uuid>({realm::uuid("18de7916-7f84-11ec-a8a3-0242ac120000"),
+                                                                                                          realm::uuid("18de7916-7f84-11ec-a8a3-0242ac120000"),
+                                                                                                          realm::uuid("18de7916-7f84-11ec-a8a3-0242ac120001"),
+                                                                                                          realm::uuid("18de7916-7f84-11ec-a8a3-0242ac120002")}));
+        auto obj_id = realm::object_id::generate();
+        test<&experimental::AllTypesObject::set_object_id_col,
+             &experimental::managed<experimental::AllTypesObject>::set_object_id_col>(scenario,
+                                                                                      std::vector<realm::object_id>({obj_id,
+                                                                                                                     obj_id,
+                                                                                                                     realm::object_id::generate(),
+                                                                                                                     realm::object_id::generate()}));
+        auto bin_data = std::vector<uint8_t>({1, 2, 3, 4});
+        test<&experimental::AllTypesObject::set_binary_col,
+             &experimental::managed<experimental::AllTypesObject>::set_binary_col>(scenario,
+                                                                                   std::vector<std::vector<uint8_t>>({bin_data,
+                                                                                   bin_data,
+                                                                                   std::vector<uint8_t>({1, 3, 4}),
+                                                                                   std::vector<uint8_t>({1})}));
+
+        auto time = std::chrono::system_clock::now();
+        auto time2 = time + time.time_since_epoch();
+        test<&experimental::AllTypesObject::set_date_col,
+             &experimental::managed<experimental::AllTypesObject>::set_date_col>(scenario,
+                                                                                 std::vector<std::chrono::time_point<std::chrono::system_clock>>({time,
+                                                                                                                    time,
+                                                                                                                    time2,
+                                                                                                                    std::chrono::time_point<std::chrono::system_clock>()}));
+
+
+        test<&experimental::AllTypesObject::set_mixed_col,
+             &experimental::managed<experimental::AllTypesObject>::set_mixed_col>(scenario,
+                                                                                  std::vector<realm::mixed>({
+                 realm::mixed(42),
+                 realm::mixed(42),
+                 realm::mixed("24"),
+                 realm::mixed(realm::uuid("18de7916-7f84-11ec-a8a3-0242ac120002"))}));
+    }
+
+    SECTION("set_algorithms") {
+        auto realm = realm::experimental::db(std::move(config));
+        auto obj = realm::experimental::AllTypesObject();
+        obj.set_int_col.insert(3);
+
+        auto managed_obj = realm.write([&]() {
+            return realm.add(std::move(obj));
+        });
+
+        std::set<int64_t> other = {1,2,3};
+        std::set<int64_t> res;
+        std::set_intersection(managed_obj.set_int_col.begin(), managed_obj.set_int_col.end(), other.begin(), other.end(), std::inserter(res, res.begin()));
+        CHECK(res == std::set<int64_t>({3}));
+
+        realm.write([&]() {
+            managed_obj.set_int_col.clear();
+        });
+        std::set<int64_t> a = {1, 2, 3};
+        std::set<int64_t> b = {2, 3};
+
+        realm.write([&]() {
+            std::set_intersection(a.begin(), a.end(), b.begin(), b.end(), std::inserter(managed_obj.set_int_col, managed_obj.set_int_col.begin()));
+        });
+        CHECK(managed_obj.set_int_col.detach() == std::set<int64_t>({2, 3}));
+
+        realm.write([&]() {
+            managed_obj.set_int_col.clear();
+            std::set_union(a.begin(), a.end(), b.begin(), b.end(), std::inserter(managed_obj.set_int_col, managed_obj.set_int_col.begin()));
+        });
+        CHECK(managed_obj.set_int_col.detach() == std::set<int64_t>({1, 2, 3}));
+
+
+        realm.write([&]() {
+            managed_obj.set_int_col.clear();
+            std::set_difference(a.begin(), a.end(), b.begin(), b.end(), std::inserter(managed_obj.set_int_col, managed_obj.set_int_col.begin()));
+        });
+        CHECK(managed_obj.set_int_col.detach() == std::set<int64_t>({1}));
+
+        realm.write([&]() {
+            managed_obj.set_int_col.clear();
+            std::set_symmetric_difference(a.begin(), a.end(), b.begin(), b.end(), std::inserter(managed_obj.set_int_col, managed_obj.set_int_col.begin()));
+        });
+        CHECK(managed_obj.set_int_col.detach() == std::set<int64_t>({1}));
+    }
+
+    SECTION("iterator") {
+        auto realm = realm::experimental::db(std::move(config));
+        auto obj = realm::experimental::AllTypesObject();
+        auto managed_obj = realm.write([&]() {
+            return realm.add(std::move(obj));
+        });
+        realm.write([&]() {
+            managed_obj.set_int_col.insert(1);
+            managed_obj.set_int_col.insert(2);
+            managed_obj.set_int_col.insert(3);
+            managed_obj.set_int_col.insert(3);
+        });
+
+        std::set<int64_t> res;
+        for (const auto& x : managed_obj.set_int_col) {
+            res.insert(x);
+        }
+        CHECK(res == std::set<int64_t>({1, 2, 3}));
+        res.clear();
+
+        for (auto it = managed_obj.set_int_col.begin(); it != managed_obj.set_int_col.end(); ++it) {
+            res.insert(*it);
+        }
+        CHECK(res == std::set<int64_t>({1, 2, 3}));
+    }
+
+    // All of the above but for managed objects
+
+    SECTION("insert object") {
+        auto realm = realm::experimental::db(std::move(config));
+
+        experimental::AllTypesObjectLink link;
+        link._id = 1;
+        link.str_col = "foo";
+
+        experimental::AllTypesObjectLink link2;
+        link2._id = 2;
+        link2.str_col = "bar";
+
+        experimental::AllTypesObjectLink link3;
+        link3._id = 3;
+        link3.str_col = "bar";
+
+        auto obj = realm::experimental::AllTypesObject();
+        obj.set_obj_col.insert(&link);
+
+        auto managed_obj = realm.write([&]() {
+            return realm.add(std::move(obj));
+        });
+
+        auto managed_link = realm.write([&]() {
+            return realm.add(std::move(link3));
+        });
+
+        realm.write([&]() {
+            managed_obj.set_obj_col.insert(&link2);
+            managed_obj.set_obj_col.insert(managed_link);
+        });
+        CHECK(managed_obj.set_obj_col.size() == 3);
+        realm.write([&]() {
+            managed_obj.set_obj_col.insert(&link2);
+            managed_obj.set_obj_col.insert(managed_link);
+        });
+        CHECK(managed_obj.set_obj_col.size() == 3);
+    }
+
+    SECTION("find") {
+        auto realm = realm::experimental::db(std::move(config));
+        auto obj = realm::experimental::AllTypesObject();
+        auto managed_obj = realm.write([&]() {
+            return realm.add(std::move(obj));
+        });
+
+        experimental::AllTypesObjectLink link;
+        link._id = 1;
+        link.str_col = "foo";
+
+        experimental::AllTypesObjectLink link2;
+        link2._id = 2;
+        link2.str_col = "bar";
+
+        experimental::AllTypesObjectLink link3;
+        link3._id = 3;
+        link3.str_col = "bar";
+
+        auto managed_link_not_in_set = realm.write([&]() {
+            return realm.add(std::move(link2));
+        });
+
+        auto managed_link = realm.write([&]() {
+            realm.add(std::move(link2));
+            return realm.add(std::move(link3));
+        });
+
+        realm.write([&]() {
+            managed_obj.set_obj_col.insert(&link);
+            managed_obj.set_obj_col.insert(&link);
+            managed_obj.set_obj_col.insert(managed_link);
+            managed_obj.set_obj_col.insert(managed_link);
+        });
+        CHECK(managed_obj.set_obj_col.size() == 2);
+
+        auto it = managed_obj.set_obj_col.find(managed_link);
+        CHECK(it != managed_obj.set_obj_col.end());
+        auto x = (*it)._id.operator int64_t();
+        CHECK(*it == realm.objects<experimental::AllTypesObjectLink>().where([](auto& o) { return o._id == 3; })[0]);
+        auto it2 = managed_obj.set_obj_col.find(managed_link_not_in_set);
+        CHECK(it2 == managed_obj.set_obj_col.end());
+    }
+
+    SECTION("erase") {
+        auto realm = realm::experimental::db(std::move(config));
+        auto obj = realm::experimental::AllTypesObject();
+        auto managed_obj = realm.write([&]() {
+            return realm.add(std::move(obj));
+        });
+
+        experimental::AllTypesObjectLink link;
+        link._id = 1;
+        link.str_col = "foo";
+
+        experimental::AllTypesObjectLink link2;
+        link2._id = 2;
+        link2.str_col = "bar";
+
+        auto managed_link = realm.write([&]() {
+            return realm.add(std::move(link2));
+        });
+
+        realm.write([&]() {
+            managed_obj.set_obj_col.insert(&link);
+            managed_obj.set_obj_col.insert(managed_link);
+        });
+
+        auto it = managed_obj.set_obj_col.find(managed_link);
+        realm.write([&]() {
+            managed_obj.set_obj_col.erase(it);
+        });
+        it =  managed_obj.set_obj_col.find(managed_link);
+        CHECK(it ==  managed_obj.set_obj_col.end());
+        CHECK(managed_obj.set_obj_col.size() == 1);
+        realm.write([&]() {
+            managed_obj.set_obj_col.clear();
+        });
+        CHECK(managed_obj.set_obj_col.size() == 0);
+    }
+
+    SECTION("notifications") {
+        auto realm = realm::experimental::db(std::move(config));
+        auto obj = realm::experimental::AllTypesObject();
+        auto managed_obj = realm.write([&]() {
+            return realm.add(std::move(obj));
+        });
+
+        experimental::AllTypesObjectLink link;
+        link._id = 1;
+        link.str_col = "foo";
+
+        experimental::AllTypesObjectLink link2;
+        link2._id = 2;
+        link2.str_col = "bar";
+
+        auto managed_link = realm.write([&]() {
+            return realm.add(std::move(link2));
+        });
+
+        size_t callback_count = 0;
+        auto token = managed_obj.set_obj_col.observe([&](auto&& c) {
+            callback_count++;
+            if (callback_count == 2)
+                CHECK(c.insertions.size() == 2);
+            else if (callback_count == 3)
+                CHECK(c.deletions.size() == 2);
+        });
+        realm.write([&]() {
+            managed_obj.set_obj_col.insert(&link);
+            managed_obj.set_obj_col.insert(managed_link);
+        });
+        realm.refresh();
+        CHECK(callback_count == 2);
+
+        realm.write([&]() {
+            managed_obj.set_obj_col.clear();
+        });
+        realm.refresh();
+        CHECK(callback_count == 3);
+    }
+
+    SECTION("detach()") {
+        auto realm = realm::experimental::db(std::move(config));
+        auto obj = realm::experimental::AllTypesObject();
+
+        experimental::AllTypesObjectLink link;
+        link._id = 1;
+        link.str_col = "foo";
+
+        auto managed_obj = realm.write([&]() {
+            return realm.add(std::move(obj));
+        });
+
+        realm.write([&]() {
+            managed_obj.set_obj_col.insert(&link);
+        });
+
+        auto other = managed_obj.set_obj_col.detach();
+        CHECK(other.begin().operator*()->_id == link._id);
+        CHECK(other.begin().operator*()->str_col == link.str_col);
+
+    }
+
+    SECTION("set_algorithms") {
+        auto realm = realm::experimental::db(std::move(config));
+        auto obj = realm::experimental::SetParentObject();
+
+        experimental::AllTypesObjectLink link;
+        link._id = 1;
+        link.str_col = "foo";
+
+        experimental::AllTypesObjectLink link2;
+        link2._id = 2;
+        link2.str_col = "bar";
+
+        obj.set1.insert(&link);
+        obj.set1.insert(&link2);
+
+        obj.set2.insert(&link);
+
+        auto managed_obj = realm.write([&]() {
+            return realm.add(std::move(obj));
+        });
+
+        realm.write([&]() {
+            std::set_intersection(managed_obj.set1.begin(), managed_obj.set1.end(), managed_obj.set2.begin(), managed_obj.set2.end(), std::inserter(managed_obj.set3, managed_obj.set3.begin()));
+        });
+        CHECK(managed_obj.set3.size() == 1);
+        CHECK(managed_obj.set3.begin().operator*()._id == 1);
+
+        realm.write([&]() {
+            managed_obj.set3.clear();
+            std::set_union(managed_obj.set1.begin(), managed_obj.set1.end(), managed_obj.set2.begin(), managed_obj.set2.end(), std::inserter(managed_obj.set3, managed_obj.set3.begin()));
+        });
+        CHECK(managed_obj.set3.size() == 2);
+
+        realm.write([&]() {
+            managed_obj.set3.clear();
+            std::set_difference(managed_obj.set1.begin(), managed_obj.set1.end(), managed_obj.set2.begin(), managed_obj.set2.end(), std::inserter(managed_obj.set3, managed_obj.set3.begin()));
+        });
+        CHECK(managed_obj.set3.size() == 1);
+
+        realm.write([&]() {
+            managed_obj.set3.clear();
+            std::set_symmetric_difference(managed_obj.set1.begin(), managed_obj.set1.end(), managed_obj.set2.begin(), managed_obj.set2.end(), std::inserter(managed_obj.set3, managed_obj.set3.begin()));
+        });
+        CHECK(managed_obj.set3.size() == 1);
+    }
+
+    SECTION("iterator") {
+        auto realm = realm::experimental::db(std::move(config));
+        auto obj = realm::experimental::AllTypesObject();
+        auto managed_obj = realm.write([&]() {
+            return realm.add(std::move(obj));
+        });
+
+        experimental::AllTypesObjectLink link;
+        link._id = 1;
+        link.str_col = "foo";
+
+        experimental::AllTypesObjectLink link2;
+        link2._id = 2;
+        link2.str_col = "bar";
+
+        realm.write([&]() {
+            managed_obj.set_obj_col.insert(&link);
+            managed_obj.set_obj_col.insert(&link2);
+        });
+
+        std::set<int64_t> res;
+        for (const auto& x : managed_obj.set_obj_col) {
+            res.insert(x._id);
+        }
+        CHECK(res == std::set<int64_t>({1, 2}));
+        res.clear();
+
+        for (auto it = managed_obj.set_obj_col.begin(); it != managed_obj.set_obj_col.end(); ++it) {
+            res.insert(it.operator*()._id);
+        }
+        CHECK(res == std::set<int64_t>({1, 2}));
+    }
+}
+

--- a/tests/experimental/db/test_objects.hpp
+++ b/tests/experimental/db/test_objects.hpp
@@ -74,6 +74,14 @@ namespace realm::experimental {
     };
     REALM_SCHEMA(AllTypesObjectLink, _id, str_col, str_link_col)
 
+    struct SetParentObject {
+        primary_key<int64_t> _id;
+        std::set<AllTypesObjectLink *> set1;
+        std::set<AllTypesObjectLink *> set2;
+        std::set<AllTypesObjectLink *> set3;
+    };
+    REALM_SCHEMA(SetParentObject, _id, set1, set2, set3)
+
     struct AllTypesObject {
         enum class Enum {
             one, two
@@ -122,6 +130,17 @@ namespace realm::experimental {
         std::vector<AllTypesObjectLink*> list_obj_col;
         std::vector<AllTypesObjectEmbedded*> list_embedded_obj_col;
 
+        std::set<int64_t> set_int_col;
+        std::set<double> set_double_col;
+        std::set<bool> set_bool_col;
+        std::set<std::string> set_str_col;
+        std::set<realm::uuid> set_uuid_col;
+        std::set<realm::object_id> set_object_id_col;
+        std::set<std::vector<std::uint8_t>> set_binary_col;
+        std::set<std::chrono::time_point<std::chrono::system_clock>> set_date_col;
+        std::set<realm::mixed> set_mixed_col;
+        std::set<AllTypesObjectLink*> set_obj_col;
+
         std::map<std::string, int64_t> map_int_col;
         std::map<std::string, double> map_double_col;
         std::map<std::string, bool> map_bool_col;
@@ -143,6 +162,8 @@ namespace realm::experimental {
                  opt_date_col, opt_uuid_col, opt_object_id_col, opt_decimal_col, opt_binary_col, opt_obj_col, opt_embedded_obj_col,
                  list_int_col, list_double_col, list_bool_col, list_str_col, list_uuid_col, list_object_id_col, list_decimal_col, list_binary_col,
                  list_date_col, list_mixed_col, list_enum_col, list_obj_col, list_embedded_obj_col,
+                 set_int_col, set_double_col, set_bool_col, set_str_col, set_uuid_col, set_object_id_col, set_binary_col,
+                 set_date_col, set_mixed_col, set_obj_col,
                  map_int_col, map_double_col, map_bool_col, map_str_col, map_uuid_col, map_object_id_col, map_decimal_col, map_binary_col,
                  map_date_col, map_enum_col, map_mixed_col, map_link_col, map_embedded_col)
 }

--- a/tests/experimental/sync/flexible_sync_tests.cpp
+++ b/tests/experimental/sync/flexible_sync_tests.cpp
@@ -15,7 +15,8 @@ TEST_CASE("flexible_sync_beta", "[sync]") {
 
         auto update_success = synced_realm.subscriptions().update([](realm::mutable_sync_subscription_set &subs) {
                                                               subs.clear();
-                                                          }).get();
+                                                          })
+                                      .get();
         CHECK(update_success == true);
         CHECK(synced_realm.subscriptions().size() == 0);
 
@@ -24,7 +25,8 @@ TEST_CASE("flexible_sync_beta", "[sync]") {
                                                              return obj.str_col == "foo";
                                                          });
                                                          subs.add<experimental::AllTypesObjectLink>("foo-link");
-                                                     }).get();
+                                                     })
+                                 .get();
         CHECK(update_success == true);
         CHECK(synced_realm.subscriptions().size() == 2);
 
@@ -52,9 +54,10 @@ TEST_CASE("flexible_sync_beta", "[sync]") {
 
         synced_realm.subscriptions().update([](realm::mutable_sync_subscription_set &subs) {
                                         subs.update_subscription<experimental::AllTypesObject>("foo-strings", [](auto &obj) {
-                                            return obj.str_col == "bar" && obj._id == (int64_t)1230;
+                                            return obj.str_col == "bar" && obj._id == (int64_t) 1230;
                                         });
-                                    }).get();
+                                    })
+                .get();
 
         auto sub2 = *synced_realm.subscriptions().find("foo-strings");
         CHECK(sub2.name == "foo-strings");
@@ -77,7 +80,7 @@ TEST_CASE("flexible_sync_beta", "[sync]") {
     }
 
     SECTION("encrypted sync realm") {
-        std::array<char, 64> example_key = {0,0,0,0,0,0,0,0, 1,1,0,0,0,0,0,0, 2,2,0,0,0,0,0,0, 3,3,0,0,0,0,0,0, 4,4,0,0,0,0,0,0, 5,5,0,0,0,0,0,0, 6,6,0,0,0,0,0,0, 7,7,0,0,0,0,0,0};
+        std::array<char, 64> example_key = {0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 2, 2, 0, 0, 0, 0, 0, 0, 3, 3, 0, 0, 0, 0, 0, 0, 4, 4, 0, 0, 0, 0, 0, 0, 5, 5, 0, 0, 0, 0, 0, 0, 6, 6, 0, 0, 0, 0, 0, 0, 7, 7, 0, 0, 0, 0, 0, 0};
         realm::App::configuration app_config;
         app_config.app_id = Admin::shared().create_app({"str_col", "_id"});
         app_config.base_url = Admin::shared().base_url();
@@ -90,11 +93,93 @@ TEST_CASE("flexible_sync_beta", "[sync]") {
 
         auto update_success = synced_realm.subscriptions().update([](realm::mutable_sync_subscription_set &subs) {
                                                               subs.clear();
-                                                          }).get();
+                                                          })
+                                      .get();
         CHECK(update_success == true);
         CHECK(synced_realm.subscriptions().size() == 0);
         // Missing encryption key
         auto flx_sync_config2 = user.flexible_sync_configuration();
         REQUIRE_THROWS(experimental::db(flx_sync_config2));
+    }
+}
+
+template<typename T, typename Func>
+void test_set(realm::experimental::managed<T>* property, Func f,
+          std::vector<typename T::value_type>&& values, size_t&& expected_count = 3) {
+    f(property, values, expected_count);
+}
+
+TEST_CASE("set collection sync", "[set]") {
+    auto app = realm::App(realm::App::configuration({Admin::shared().cached_app_id(), Admin::shared().base_url()}));
+
+    SECTION("insert") {
+        auto user = app.login(realm::App::credentials::anonymous()).get();
+        auto flx_sync_config = user.flexible_sync_configuration();
+        auto realm = realm::experimental::db(std::move(flx_sync_config));
+        auto update_success = realm.subscriptions().update([](realm::mutable_sync_subscription_set &subs) {
+                                                              subs.clear();
+                                                          }).get();
+        CHECK(update_success == true);
+        CHECK(realm.subscriptions().size() == 0);
+
+        update_success = realm.subscriptions().update([](realm::mutable_sync_subscription_set &subs) {
+                                                         subs.add<experimental::AllTypesObject>("foo-strings", [](auto &obj) {
+                                                             return obj.str_col == "foo";
+                                                         });
+                                                         subs.add<experimental::AllTypesObjectLink>("foo-link");
+                                                     }).get();
+        CHECK(update_success == true);
+        CHECK(realm.subscriptions().size() == 2);
+
+        auto obj = realm::experimental::AllTypesObject();
+
+        auto managed_obj = realm.write([&]() {
+            return realm.add(std::move(obj));
+        });
+
+        auto scenario = [&](auto &p, auto &values, size_t expected_count) {
+            realm.write([&]() {
+                for (auto v: values) {
+                    p->insert(v);
+                }
+            });
+            CHECK(p->size() == expected_count);
+        };
+
+        test_set(&managed_obj.set_int_col, scenario, {42, 42, 24, -1});
+        test_set(&managed_obj.set_double_col, scenario, {42.001, 42.001, 24.001, -1.001});
+        test_set(&managed_obj.set_bool_col, scenario, {true, false, true}, 2);
+        test_set(&managed_obj.set_str_col, scenario, {"42", "42", "24", "-1"});
+        test_set(&managed_obj.set_uuid_col, scenario, {realm::uuid("18de7916-7f84-11ec-a8a3-0242ac120000"), realm::uuid("18de7916-7f84-11ec-a8a3-0242ac120000"), realm::uuid("18de7916-7f84-11ec-a8a3-0242ac120001"), realm::uuid("18de7916-7f84-11ec-a8a3-0242ac120002")});
+        auto obj_id = realm::object_id::generate();
+        test_set(&managed_obj.set_object_id_col, scenario, {obj_id, obj_id, realm::object_id::generate(), realm::object_id::generate()});
+
+        auto bin_data = std::vector<uint8_t>({1, 2, 3, 4});
+        test_set(&managed_obj.set_binary_col, scenario, {bin_data, bin_data, std::vector<uint8_t>({1, 3, 4}), std::vector<uint8_t>({1})});
+
+        auto time = std::chrono::system_clock::now();
+        auto time2 = time + time.time_since_epoch();
+        test_set(&managed_obj.set_date_col, scenario, {time, time, time2, std::chrono::time_point<std::chrono::system_clock>()});
+        test_set(&managed_obj.set_mixed_col, scenario, {realm::mixed((int64_t)42), realm::mixed((int64_t)42), realm::mixed("24"), realm::mixed(realm::uuid("18de7916-7f84-11ec-a8a3-0242ac120002"))});
+
+        test::wait_for_sync_uploads(user).get();
+        test::wait_for_sync_downloads(user).get();
+
+        app.register_user("set_collection_sync@mongodb.com", "foobar").get();
+        auto user2 = app.login(realm::App::credentials::username_password("set_collection_sync@mongodb.com", "foobar")).get();
+
+        auto realm2 = realm::experimental::db(user2.flexible_sync_configuration());
+        auto update_success2 = realm2.subscriptions().update([](realm::mutable_sync_subscription_set &subs) {
+                                                  subs.add<experimental::AllTypesObject>("foo-strings", [](auto &obj) {
+                                                      return obj.str_col == "foo";
+                                                  });
+                                                  subs.add<experimental::AllTypesObjectLink>("foo-link");
+                                              }).get();
+        CHECK(update_success2 == true);
+        CHECK(realm2.subscriptions().size() == 2);
+        test::wait_for_sync_downloads(user2).get();
+        realm2.refresh();
+        auto objs = realm2.objects<experimental::AllTypesObject>();
+        CHECK(objs.size() == 1);
     }
 }

--- a/tests/experimental/sync/test_objects.hpp
+++ b/tests/experimental/sync/test_objects.hpp
@@ -76,6 +76,17 @@ namespace realm::experimental {
         std::vector<AllTypesObjectLink*> list_obj_col;
         std::vector<AllTypesObjectEmbedded*> list_embedded_obj_col;
 
+        std::set<int64_t> set_int_col;
+        std::set<double> set_double_col;
+        std::set<bool> set_bool_col;
+        std::set<std::string> set_str_col;
+        std::set<realm::uuid> set_uuid_col;
+        std::set<realm::object_id> set_object_id_col;
+        std::set<std::vector<std::uint8_t>> set_binary_col;
+        std::set<std::chrono::time_point<std::chrono::system_clock>> set_date_col;
+        std::set<realm::mixed> set_mixed_col;
+        std::set<AllTypesObjectLink*> set_obj_col;
+
         std::map<std::string, int64_t> map_int_col;
         std::map<std::string, double> map_double_col;
         std::map<std::string, bool> map_bool_col;
@@ -98,9 +109,10 @@ namespace realm::experimental {
                  opt_date_col, opt_uuid_col, opt_object_id_col, opt_decimal_col, opt_binary_col, opt_obj_col, opt_embedded_obj_col,
                  list_int_col, list_double_col, list_bool_col, list_str_col, list_uuid_col, list_object_id_col, list_decimal_col, list_binary_col,
                  list_date_col, list_mixed_col, list_enum_col, list_obj_col, list_embedded_obj_col,
+                 set_int_col, set_double_col, set_bool_col, set_str_col, set_uuid_col, set_object_id_col, set_binary_col,
+                 set_date_col, set_mixed_col, set_obj_col,
                  map_int_col, map_double_col, map_bool_col, map_str_col, map_uuid_col, map_object_id_col, map_decimal_col, map_binary_col,
                  map_date_col, map_enum_col, map_mixed_col, map_link_col, map_embedded_col)
-
 
     struct EmbeddedFoo {
         int64_t bar;


### PR DESCRIPTION
Adds support for `std::set` in object models.

```cpp
    struct SetTypesObject {
        primary_key<int64_t> _id;
        std::set<int64_t> set_int_col;
        std::set<double> set_double_col;
        std::set<bool> set_bool_col;
        std::set<std::string> set_str_col;
        std::set<realm::uuid> set_uuid_col;
        std::set<realm::object_id> set_object_id_col;
        std::set<std::vector<std::uint8_t>> set_binary_col;
        std::set<std::chrono::time_point<std::chrono::system_clock>> set_date_col;
        std::set<realm::mixed> set_mixed_col;
        std::set<AllTypesObjectLink*> set_obj_col;
    };

    REALM_SCHEMA(AllTypesObject,
                 _id, set_int_col, set_double_col, set_bool_col, set_str_col, set_uuid_col, set_object_id_col, set_binary_col,
                 set_date_col, set_mixed_col, set_obj_coll)
```