### PR TITLE
Generate aligned storage type mappings

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,16 @@
+add_subdirectory(cpprealm/internal/bridge/generator)
+
+add_custom_command(
+    COMMAND ${CMAKE_COMMAND} -D SOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR}/cpprealm/internal/bridge 
+                             -D BINARY_DIR=${CMAKE_CURRENT_BINARY_DIR}/cpprealm/internal/bridge
+                             -D BRIDGE_TYPE_INFO_BIN=$<TARGET_FILE:BridgeTypeInfoGenerator>
+                             -P ${CMAKE_CURRENT_SOURCE_DIR}/cpprealm/internal/bridge/generator/bridge_type_info_parser.cmake
+    DEPENDS BridgeTypeInfoGenerator
+    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/cpprealm/internal/bridge/generator/bridge_type_info_parser.cmake
+    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/cpprealm/internal/bridge/bridge_types.hpp.in
+    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/cpprealm/internal/bridge/bridge_types.hpp
+)
+
 set(SOURCES
     cpprealm/app.cpp
     cpprealm/sdk.cpp
@@ -104,10 +117,28 @@ set(HEADERS
     cpprealm/experimental/managed_primary_key.hpp
     cpprealm/experimental/sdk.hpp
     cpprealm/internal/bridge/decimal128.hpp
-    cpprealm/experimental/managed_decimal.hpp
-        ) # REALM_INSTALL_HEADERS
+    cpprealm/experimental/managed_decimal.hpp) # REALM_INSTALL_HEADERS
 
-add_library(cpprealm STATIC ${SOURCES} ${HEADERS})
 include(GNUInstallDirs)
-install(TARGETS cpprealm ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
-install(DIRECTORY cpprealm/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/cpprealm)
+
+add_library(cpprealm ${SOURCES} ${HEADERS} ${CMAKE_CURRENT_BINARY_DIR}/cpprealm/internal/bridge/bridge_types.hpp)
+target_include_directories(cpprealm PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+)
+
+install(TARGETS cpprealm RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT runtime)
+install(TARGETS cpprealm LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT runtime)
+install(TARGETS cpprealm ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT devel)
+
+foreach(header ${HEADERS})
+    get_filename_component(dir ${header} DIRECTORY)
+    install(FILES ${header}
+            DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${dir}
+            COMPONENT devel)
+endforeach()
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/cpprealm/internal/bridge/bridge_types.hpp
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/cpprealm/internal/bridge
+        COMPONENT devel)
+install()

--- a/src/cpprealm/app.cpp
+++ b/src/cpprealm/app.cpp
@@ -9,47 +9,47 @@
 
 namespace realm::internal::bridge {
 #ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
-    static_assert(LayoutCheck<storage::AppCredentials, ::realm::app::AppCredentials>{});
-    static_assert(LayoutCheck<storage::AppError, ::realm::app::AppError>{});
+    static_assert(LayoutCheck<storage::AppCredentials, app::AppCredentials>{});
+    static_assert(LayoutCheck<storage::AppError, app::AppError>{});
 #elif __i386__
-    static_assert(SizeCheck<8, sizeof(realm::app::AppCredentials)>{});
-    static_assert(SizeCheck<4, alignof(realm::app::AppCredentials)>{});
-    static_assert(SizeCheck<28, sizeof(realm::app::AppError)>{});
-    static_assert(SizeCheck<4, alignof(realm::app::AppError)>{});
+    static_assert(SizeCheck<8, sizeof(app::AppCredentials)>{});
+    static_assert(SizeCheck<4, alignof(app::AppCredentials)>{});
+    static_assert(SizeCheck<28, sizeof(app::AppError)>{});
+    static_assert(SizeCheck<4, alignof(app::AppError)>{});
 #elif __x86_64__
-    static_assert(SizeCheck<16, sizeof(realm::app::AppCredentials)>{});
-    static_assert(SizeCheck<8, alignof(realm::app::AppCredentials)>{});
+    static_assert(SizeCheck<16, sizeof(app::AppCredentials)>{});
+    static_assert(SizeCheck<8, alignof(app::AppCredentials)>{});
     #if defined(__clang__)
-    static_assert(SizeCheck<48, sizeof(realm::app::AppError)>{});
-    static_assert(SizeCheck<8, alignof(realm::app::AppError)>{});
+    static_assert(SizeCheck<48, sizeof(app::AppError)>{});
+    static_assert(SizeCheck<8, alignof(app::AppError)>{});
     #elif defined(__GNUC__) || defined(__GNUG__)
-    static_assert(SizeCheck<56, sizeof(realm::app::AppError)>{});
-    static_assert(SizeCheck<8, alignof(realm::app::AppError)>{});
+    static_assert(SizeCheck<56, sizeof(app::AppError)>{});
+    static_assert(SizeCheck<8, alignof(app::AppError)>{});
     #endif
 #elif __arm__
-    static_assert(SizeCheck<8, sizeof(realm::app::AppCredentials)>{});
-    static_assert(SizeCheck<4, alignof(realm::app::AppCredentials)>{});
-    static_assert(SizeCheck<28, sizeof(realm::app::AppError)>{});
-    static_assert(SizeCheck<4, alignof(realm::app::AppError)>{});
+    static_assert(SizeCheck<8, sizeof(app::AppCredentials)>{});
+    static_assert(SizeCheck<4, alignof(app::AppCredentials)>{});
+    static_assert(SizeCheck<28, sizeof(app::AppError)>{});
+    static_assert(SizeCheck<4, alignof(app::AppError)>{});
 #elif __aarch64__
-    static_assert(SizeCheck<16, sizeof(realm::app::AppCredentials)>{});
-    static_assert(SizeCheck<8, alignof(realm::app::AppCredentials)>{});
+    static_assert(SizeCheck<16, sizeof(app::AppCredentials)>{});
+    static_assert(SizeCheck<8, alignof(app::AppCredentials)>{});
 #if defined(__clang__)
-    static_assert(SizeCheck<48, sizeof(realm::app::AppError)>{});
+    static_assert(SizeCheck<48, sizeof(app::AppError)>{});
 #elif defined(__GNUC__) || defined(__GNUG__)
-    static_assert(SizeCheck<56, sizeof(realm::app::AppError)>{});
+    static_assert(SizeCheck<56, sizeof(app::AppError)>{});
 #endif
-    static_assert(SizeCheck<8, alignof(realm::app::AppError)>{});
+    static_assert(SizeCheck<8, alignof(app::AppError)>{});
 #elif _WIN32
     #if _DEBUG
-    static_assert(SizeCheck<80, sizeof(realm::app::AppError)>{});
+    static_assert(SizeCheck<80, sizeof(app::AppError)>{});
     #else
-    static_assert(SizeCheck<72, sizeof(realm::app::AppError)>{});
+    static_assert(SizeCheck<72, sizeof(app::AppError)>{});
     #endif
-    static_assert(SizeCheck<16, sizeof(realm::app::AppCredentials)>{});
-    static_assert(SizeCheck<8, alignof(realm::app::AppCredentials)>{});
+    static_assert(SizeCheck<16, sizeof(app::AppCredentials)>{});
+    static_assert(SizeCheck<8, alignof(app::AppCredentials)>{});
     
-    static_assert(SizeCheck<8, alignof(realm::app::AppError)>{});
+    static_assert(SizeCheck<8, alignof(app::AppError)>{});
 #endif
 } // namespace realm::internal::bridge
 

--- a/src/cpprealm/app.cpp
+++ b/src/cpprealm/app.cpp
@@ -7,49 +7,53 @@
 
 #include <utility>
 
-namespace realm {
-
-#ifdef __i386__
-    static_assert(internal::bridge::SizeCheck<8, sizeof(realm::app::AppCredentials)>{});
-    static_assert(internal::bridge::SizeCheck<4, alignof(realm::app::AppCredentials)>{});
-    static_assert(internal::bridge::SizeCheck<28, sizeof(realm::app::AppError)>{});
-    static_assert(internal::bridge::SizeCheck<4, alignof(realm::app::AppError)>{});
+namespace realm::internal::bridge {
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+    static_assert(LayoutCheck<storage::AppCredentials, ::realm::app::AppCredentials>{});
+    static_assert(LayoutCheck<storage::AppError, ::realm::app::AppError>{});
+#elif __i386__
+    static_assert(SizeCheck<8, sizeof(realm::app::AppCredentials)>{});
+    static_assert(SizeCheck<4, alignof(realm::app::AppCredentials)>{});
+    static_assert(SizeCheck<28, sizeof(realm::app::AppError)>{});
+    static_assert(SizeCheck<4, alignof(realm::app::AppError)>{});
 #elif __x86_64__
-    static_assert(internal::bridge::SizeCheck<16, sizeof(realm::app::AppCredentials)>{});
-    static_assert(internal::bridge::SizeCheck<8, alignof(realm::app::AppCredentials)>{});
+    static_assert(SizeCheck<16, sizeof(realm::app::AppCredentials)>{});
+    static_assert(SizeCheck<8, alignof(realm::app::AppCredentials)>{});
     #if defined(__clang__)
-    static_assert(internal::bridge::SizeCheck<48, sizeof(realm::app::AppError)>{});
-    static_assert(internal::bridge::SizeCheck<8, alignof(realm::app::AppError)>{});
+    static_assert(SizeCheck<48, sizeof(realm::app::AppError)>{});
+    static_assert(SizeCheck<8, alignof(realm::app::AppError)>{});
     #elif defined(__GNUC__) || defined(__GNUG__)
-    static_assert(internal::bridge::SizeCheck<56, sizeof(realm::app::AppError)>{});
-    static_assert(internal::bridge::SizeCheck<8, alignof(realm::app::AppError)>{});
+    static_assert(SizeCheck<56, sizeof(realm::app::AppError)>{});
+    static_assert(SizeCheck<8, alignof(realm::app::AppError)>{});
     #endif
 #elif __arm__
-    static_assert(internal::bridge::SizeCheck<8, sizeof(realm::app::AppCredentials)>{});
-    static_assert(internal::bridge::SizeCheck<4, alignof(realm::app::AppCredentials)>{});
-    static_assert(internal::bridge::SizeCheck<28, sizeof(realm::app::AppError)>{});
-    static_assert(internal::bridge::SizeCheck<4, alignof(realm::app::AppError)>{});
+    static_assert(SizeCheck<8, sizeof(realm::app::AppCredentials)>{});
+    static_assert(SizeCheck<4, alignof(realm::app::AppCredentials)>{});
+    static_assert(SizeCheck<28, sizeof(realm::app::AppError)>{});
+    static_assert(SizeCheck<4, alignof(realm::app::AppError)>{});
 #elif __aarch64__
-    static_assert(internal::bridge::SizeCheck<16, sizeof(realm::app::AppCredentials)>{});
-    static_assert(internal::bridge::SizeCheck<8, alignof(realm::app::AppCredentials)>{});
+    static_assert(SizeCheck<16, sizeof(realm::app::AppCredentials)>{});
+    static_assert(SizeCheck<8, alignof(realm::app::AppCredentials)>{});
 #if defined(__clang__)
-    static_assert(internal::bridge::SizeCheck<48, sizeof(realm::app::AppError)>{});
+    static_assert(SizeCheck<48, sizeof(realm::app::AppError)>{});
 #elif defined(__GNUC__) || defined(__GNUG__)
-    static_assert(internal::bridge::SizeCheck<56, sizeof(realm::app::AppError)>{});
+    static_assert(SizeCheck<56, sizeof(realm::app::AppError)>{});
 #endif
-    static_assert(internal::bridge::SizeCheck<8, alignof(realm::app::AppError)>{});
+    static_assert(SizeCheck<8, alignof(realm::app::AppError)>{});
 #elif _WIN32
     #if _DEBUG
-    static_assert(internal::bridge::SizeCheck<80, sizeof(realm::app::AppError)>{});
+    static_assert(SizeCheck<80, sizeof(realm::app::AppError)>{});
     #else
-    static_assert(internal::bridge::SizeCheck<72, sizeof(realm::app::AppError)>{});
+    static_assert(SizeCheck<72, sizeof(realm::app::AppError)>{});
     #endif
-    static_assert(internal::bridge::SizeCheck<16, sizeof(realm::app::AppCredentials)>{});
-    static_assert(internal::bridge::SizeCheck<8, alignof(realm::app::AppCredentials)>{});
+    static_assert(SizeCheck<16, sizeof(realm::app::AppCredentials)>{});
+    static_assert(SizeCheck<8, alignof(realm::app::AppCredentials)>{});
     
-    static_assert(internal::bridge::SizeCheck<8, alignof(realm::app::AppError)>{});
+    static_assert(SizeCheck<8, alignof(realm::app::AppError)>{});
 #endif
+} // namespace realm::internal::bridge
 
+namespace realm {
     static_assert((int)user::state::logged_in == (int)SyncUser::State::LoggedIn);
     static_assert((int)user::state::logged_out == (int)SyncUser::State::LoggedOut);
     static_assert((int)user::state::removed == (int)SyncUser::State::Removed);

--- a/src/cpprealm/app.hpp
+++ b/src/cpprealm/app.hpp
@@ -70,7 +70,9 @@ struct app_error {
 
     [[nodiscard]] bool is_client_error() const;
 private:
-#ifdef __i386__
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+    internal::bridge::storage::AppError m_error[1];
+#elif __i386__
     std::aligned_storage<28, 4>::type m_error[1];
 #elif _WIN32
     #if _DEBUG
@@ -251,7 +253,9 @@ public:
         operator app::AppCredentials() const;
         friend class App;
 
-#ifdef __i386__
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+    internal::bridge::storage::AppCredentials m_credentials[1];
+#elif __i386__
     std::aligned_storage<8, 4>::type m_credentials[1];
 #elif _WIN32
     std::aligned_storage<16, 8>::type m_credentials[1];

--- a/src/cpprealm/flex_sync.cpp
+++ b/src/cpprealm/flex_sync.cpp
@@ -2,49 +2,55 @@
 #include <realm/object-store/shared_realm.hpp>
 #include <realm/sync/subscriptions.hpp>
 
-namespace realm {
-#ifdef __i386__
-    static_assert(internal::bridge::SizeCheck<60, sizeof(sync::SubscriptionSet)>{});
-    static_assert(internal::bridge::SizeCheck<4, alignof(sync::SubscriptionSet)>{});
-    static_assert(internal::bridge::SizeCheck<116, sizeof(sync::MutableSubscriptionSet)>{});
-    static_assert(internal::bridge::SizeCheck<4, alignof(sync::MutableSubscriptionSet)>{});
+namespace realm::internal::bridge {
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+    static_assert(LayoutCheck<storage::SyncSubscriptionSet, sync::SubscriptionSet>{});
+    static_assert(LayoutCheck<storage::MutableSyncSubscriptionSet, sync::MutableSubscriptionSet>{});
+#elif __i386__
+    static_assert(SizeCheck<60, sizeof(sync::SubscriptionSet)>{});
+    static_assert(SizeCheck<4, alignof(sync::SubscriptionSet)>{});
+    static_assert(SizeCheck<116, sizeof(sync::MutableSubscriptionSet)>{});
+    static_assert(SizeCheck<4, alignof(sync::MutableSubscriptionSet)>{});
 #elif __x86_64__
     #if defined(__clang__)
-    static_assert(internal::bridge::SizeCheck<96, sizeof(sync::SubscriptionSet)>{});
-    static_assert(internal::bridge::SizeCheck<184, sizeof(sync::MutableSubscriptionSet)>{});
+    static_assert(SizeCheck<96, sizeof(sync::SubscriptionSet)>{});
+    static_assert(SizeCheck<184, sizeof(sync::MutableSubscriptionSet)>{});
     #elif defined(__GNUC__) || defined(__GNUG__)
-    static_assert(internal::bridge::SizeCheck<104, sizeof(sync::SubscriptionSet)>{});
-    static_assert(internal::bridge::SizeCheck<192, sizeof(sync::MutableSubscriptionSet)>{});
+    static_assert(SizeCheck<104, sizeof(sync::SubscriptionSet)>{});
+    static_assert(SizeCheck<192, sizeof(sync::MutableSubscriptionSet)>{});
     #endif
-    static_assert(internal::bridge::SizeCheck<8, alignof(sync::SubscriptionSet)>{});
-    static_assert(internal::bridge::SizeCheck<8, alignof(sync::MutableSubscriptionSet)>{});
+    static_assert(SizeCheck<8, alignof(sync::SubscriptionSet)>{});
+    static_assert(SizeCheck<8, alignof(sync::MutableSubscriptionSet)>{});
 #elif __arm__
-    static_assert(internal::bridge::SizeCheck<64, sizeof(sync::SubscriptionSet)>{});
-    static_assert(internal::bridge::SizeCheck<8, alignof(sync::SubscriptionSet)>{});
-    static_assert(internal::bridge::SizeCheck<136, sizeof(sync::MutableSubscriptionSet)>{});
-    static_assert(internal::bridge::SizeCheck<8, alignof(sync::MutableSubscriptionSet)>{});
+    static_assert(SizeCheck<64, sizeof(sync::SubscriptionSet)>{});
+    static_assert(SizeCheck<8, alignof(sync::SubscriptionSet)>{});
+    static_assert(SizeCheck<136, sizeof(sync::MutableSubscriptionSet)>{});
+    static_assert(SizeCheck<8, alignof(sync::MutableSubscriptionSet)>{});
 #elif __aarch64__
 #if defined(__clang__)
-    static_assert(internal::bridge::SizeCheck<96, sizeof(sync::SubscriptionSet)>{});
-    static_assert(internal::bridge::SizeCheck<184, sizeof(sync::MutableSubscriptionSet)>{});
+    static_assert(SizeCheck<96, sizeof(sync::SubscriptionSet)>{});
+    static_assert(SizeCheck<184, sizeof(sync::MutableSubscriptionSet)>{});
 #elif defined(__GNUC__) || defined(__GNUG__)
-    static_assert(internal::bridge::SizeCheck<104, sizeof(sync::SubscriptionSet)>{});
-    static_assert(internal::bridge::SizeCheck<192, sizeof(sync::MutableSubscriptionSet)>{});
+    static_assert(SizeCheck<104, sizeof(sync::SubscriptionSet)>{});
+    static_assert(SizeCheck<192, sizeof(sync::MutableSubscriptionSet)>{});
 #endif
-    static_assert(internal::bridge::SizeCheck<8, alignof(sync::SubscriptionSet)>{});
-    static_assert(internal::bridge::SizeCheck<8, alignof(sync::MutableSubscriptionSet)>{});
+    static_assert(SizeCheck<8, alignof(sync::SubscriptionSet)>{});
+    static_assert(SizeCheck<8, alignof(sync::MutableSubscriptionSet)>{});
 #elif _WIN32
-    static_assert(internal::bridge::SizeCheck<8, alignof(sync::SubscriptionSet)>{});
-    static_assert(internal::bridge::SizeCheck<8, alignof(sync::MutableSubscriptionSet)>{});
+    static_assert(SizeCheck<8, alignof(sync::SubscriptionSet)>{});
+    static_assert(SizeCheck<8, alignof(sync::MutableSubscriptionSet)>{});
 
     #if _DEBUG
-    static_assert(internal::bridge::SizeCheck<120, sizeof(sync::SubscriptionSet)>{});
-    static_assert(internal::bridge::SizeCheck<208, sizeof(sync::MutableSubscriptionSet)>{});
+    static_assert(SizeCheck<120, sizeof(sync::SubscriptionSet)>{});
+    static_assert(SizeCheck<208, sizeof(sync::MutableSubscriptionSet)>{});
     #else
-    static_assert(internal::bridge::SizeCheck<104, sizeof(sync::SubscriptionSet)>{});
-    static_assert(internal::bridge::SizeCheck<192, sizeof(sync::MutableSubscriptionSet)>{});
+    static_assert(SizeCheck<104, sizeof(sync::SubscriptionSet)>{});
+    static_assert(SizeCheck<192, sizeof(sync::MutableSubscriptionSet)>{});
     #endif
 #endif
+} // namespace realm::internal::bridge
+
+namespace realm {
     sync_subscription::sync_subscription(const sync::Subscription &v)
     {
        identifier = v.id.to_string();

--- a/src/cpprealm/flex_sync.hpp
+++ b/src/cpprealm/flex_sync.hpp
@@ -157,7 +157,9 @@ namespace realm {
 
     private:
         mutable_sync_subscription_set(internal::bridge::realm&, const sync::MutableSubscriptionSet& subscription_set);
-#ifdef __i386__
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+        internal::bridge::storage::MutableSyncSubscriptionSet m_subscription_set[1];
+#elif __i386__
         std::aligned_storage<116, 4>::type m_subscription_set[1];
 #elif __x86_64__
     #if defined(__clang__)
@@ -207,7 +209,9 @@ namespace realm {
     private:
         template <typename ...Ts>
         friend struct db;
-#ifdef __i386__
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+        internal::bridge::storage::SyncSubscriptionSet m_subscription_set[1];
+#elif __i386__
         std::aligned_storage<60, 4>::type m_subscription_set[1];
 #elif __x86_64__
     #if defined(__clang__)

--- a/src/cpprealm/internal/bridge/binary.cpp
+++ b/src/cpprealm/internal/bridge/binary.cpp
@@ -4,7 +4,9 @@
 #include <realm/binary_data.hpp>
 
 namespace realm::internal::bridge {
-#ifdef __i386__
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+        static_assert(LayoutCheck<storage::OwnedBinaryData, OwnedBinaryData>{});
+#elif __i386__
         static_assert(SizeCheck<8, sizeof(OwnedBinaryData)>{});
         static_assert(SizeCheck<4, alignof(OwnedBinaryData)>{});
 #elif __x86_64__

--- a/src/cpprealm/internal/bridge/binary.hpp
+++ b/src/cpprealm/internal/bridge/binary.hpp
@@ -25,7 +25,9 @@ namespace realm::internal::bridge {
         operator BinaryData() const; //NOLINT(google-explicit-constructor)
         char operator[](size_t i) const noexcept;
     private:
-#ifdef __i386__
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+            storage::OwnedBinaryData m_data[1];
+#elif __i386__
             std::aligned_storage<8, 4>::type m_data[1];
 #elif __x86_64__
             std::aligned_storage<16, 8>::type m_data[1];

--- a/src/cpprealm/internal/bridge/bridge_types.hpp.in
+++ b/src/cpprealm/internal/bridge/bridge_types.hpp.in
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <type_traits>
+
+#define CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+
+namespace realm::internal::bridge::storage {
+@BRIDGE_TYPE_DECLS@
+}

--- a/src/cpprealm/internal/bridge/col_key.cpp
+++ b/src/cpprealm/internal/bridge/col_key.cpp
@@ -3,7 +3,9 @@
 #include <realm/keys.hpp>
 
 namespace realm::internal::bridge {
-#ifdef __i386__
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+    static_assert(LayoutCheck<storage::ColKey, ColKey>{});
+#elif __i386__
     static_assert(SizeCheck<8, sizeof(ColKey)>{});
     static_assert(SizeCheck<4, alignof(ColKey)>{});
 #elif __x86_64__

--- a/src/cpprealm/internal/bridge/col_key.hpp
+++ b/src/cpprealm/internal/bridge/col_key.hpp
@@ -21,7 +21,9 @@ namespace realm::internal::bridge {
         operator bool() const;
         [[nodiscard]] int64_t value() const;
     private:
-#ifdef __i386__
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+        storage::ColKey m_col_key[1];
+#elif __i386__
         std::aligned_storage<8, 4>::type m_col_key[1];
 #elif __x86_64__
         std::aligned_storage<8, 8>::type m_col_key[1];

--- a/src/cpprealm/internal/bridge/decimal128.cpp
+++ b/src/cpprealm/internal/bridge/decimal128.cpp
@@ -5,7 +5,9 @@
 #include <realm/decimal128.hpp>
 
 namespace realm::internal::bridge {
-#ifdef __i386__
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+        static_assert(LayoutCheck<storage::Decimal128, Decimal128>{});
+#elif __i386__
     static_assert(SizeCheck<16, sizeof(::realm::Decimal128)>{});
     static_assert(SizeCheck<4, alignof(::realm::Decimal128)>{});
 #elif __x86_64__

--- a/src/cpprealm/internal/bridge/decimal128.hpp
+++ b/src/cpprealm/internal/bridge/decimal128.hpp
@@ -35,7 +35,9 @@ namespace realm::internal::bridge {
         decimal128& operator/=(const decimal128& o);
         decimal128& operator-=(const decimal128& o);
     private:
-#ifdef __i386__
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+        storage::Decimal128 m_decimal[1];
+#elif __i386__
         std::aligned_storage<12, 1>::type m_decimal[1];
 #elif __x86_64__
         std::aligned_storage<12, 1>::type m_decimal[1];

--- a/src/cpprealm/internal/bridge/dictionary.cpp
+++ b/src/cpprealm/internal/bridge/dictionary.cpp
@@ -8,7 +8,9 @@
 #include <realm/object-store/results.hpp>
 
 namespace realm::internal::bridge {
-#ifdef __i386__
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+    static_assert(LayoutCheck<storage::Dictionary, object_store::Dictionary>{});
+#elif __i386__
     static_assert(SizeCheck<40, sizeof(Dictionary)>{});
     static_assert(SizeCheck<4, alignof(Dictionary)>{});
 #elif __x86_64__
@@ -25,7 +27,9 @@ namespace realm::internal::bridge {
     static_assert(SizeCheck<8, alignof(Dictionary)>{});
 #endif
 
-#ifdef __i386__
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+        static_assert(LayoutCheck<storage::CoreDictionary, CoreDictionary>{});
+#elif __i386__
     static_assert(SizeCheck<96, sizeof(CoreDictionary)>{});
     static_assert(SizeCheck<4, alignof(CoreDictionary)>{});
 #elif __x86_64__

--- a/src/cpprealm/internal/bridge/dictionary.hpp
+++ b/src/cpprealm/internal/bridge/dictionary.hpp
@@ -106,7 +106,9 @@ namespace realm::internal::bridge {
 
         size_t size() const;
     private:
-#ifdef __i386__
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+        storage::CoreDictionary m_dictionary[1];
+#elif __i386__
         std::aligned_storage<96, 4>::type m_dictionary[1];
 #elif __x86_64__
         std::aligned_storage<144, 8>::type m_dictionary[1];
@@ -144,7 +146,9 @@ namespace realm::internal::bridge {
     private:
         template <typename T>
         friend T get(dictionary&, const std::string&);
-#ifdef __i386__
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+        storage::Dictionary m_dictionary[1];
+#elif __i386__
         std::aligned_storage<40, 4>::type m_dictionary[1];
 #elif __x86_64__
         std::aligned_storage<80, 8>::type m_dictionary[1];

--- a/src/cpprealm/internal/bridge/generator/CMakeLists.txt
+++ b/src/cpprealm/internal/bridge/generator/CMakeLists.txt
@@ -5,7 +5,9 @@ set(BRIDGE_TYPE_REQUIRED_HEADERS
     realm/object-store/list.hpp
     realm/object-store/results.hpp
     realm/object-store/thread_safe_reference.hpp
+    realm/object-store/sync/app.hpp
     realm/sync/config.hpp
+    realm/sync/subscriptions.hpp
 )
 
 set(BRIDGE_TYPES
@@ -39,6 +41,10 @@ set(BRIDGE_TYPES
     ThreadSafeReference realm::ThreadSafeReference
     Timestamp realm::Timestamp
     UUID realm::UUID
+    AppCredentials realm::app::AppCredentials
+    AppError realm::app::AppError
+    SyncSubscriptionSet realm::sync::SubscriptionSet
+    MutableSyncSubscriptionSet realm::sync::MutableSubscriptionSet
 )
 
 while(BRIDGE_TYPES)
@@ -56,4 +62,11 @@ endforeach()
 
 configure_file(bridge_type_info_generator.cpp.in bridge_type_info_generator.cpp)
 add_library(BridgeTypeInfoGenerator STATIC ${CMAKE_CURRENT_BINARY_DIR}/bridge_type_info_generator.cpp)
+
+if(MSVC)
+    target_compile_options(BridgeTypeInfoGenerator PRIVATE /O0)
+else()
+    target_compile_options(BridgeTypeInfoGenerator PRIVATE -O0)
+endif()
+
 target_link_libraries(BridgeTypeInfoGenerator Realm::Storage)

--- a/src/cpprealm/internal/bridge/generator/CMakeLists.txt
+++ b/src/cpprealm/internal/bridge/generator/CMakeLists.txt
@@ -1,0 +1,59 @@
+set(BRIDGE_TYPE_REQUIRED_HEADERS
+    realm.hpp
+    realm/object-store/shared_realm.hpp
+    realm/object-store/dictionary.hpp
+    realm/object-store/list.hpp
+    realm/object-store/results.hpp
+    realm/object-store/thread_safe_reference.hpp
+    realm/sync/config.hpp
+)
+
+set(BRIDGE_TYPES
+    OwnedBinaryData realm::OwnedBinaryData
+    Realm_Config realm::Realm::Config
+    ColKey realm::ColKey
+    Decimal128 realm::Decimal128
+    Dictionary realm::object_store::Dictionary
+    CoreDictionary realm::Dictionary
+    List realm::List
+    LnkLst realm::LnkLst
+    Mixed realm::Mixed
+    ObjKey realm::ObjKey
+    ObjLink realm::ObjLink
+    Obj realm::Obj
+    ObjectId realm::ObjectId
+    ObjectSchema realm::ObjectSchema
+    Object realm::Object
+    IndexSet realm::IndexSet
+    CollectionChangeSet realm::CollectionChangeSet
+    IndexSet_IndexIterator realm::IndexSet::IndexIterator
+    IndexSet_IndexIteratableAdaptor realm::IndexSet::IndexIteratableAdaptor
+    NotificationToken realm::NotificationToken
+    Property realm::Property
+    Query realm::Query
+    Results realm::Results
+    Schema realm::Schema
+    SyncError realm::SyncError
+    TableRef realm::TableRef
+    TableView realm::TableView
+    ThreadSafeReference realm::ThreadSafeReference
+    Timestamp realm::Timestamp
+    UUID realm::UUID
+)
+
+while(BRIDGE_TYPES)
+    list(POP_FRONT BRIDGE_TYPES _name _expression)
+    string(REGEX MATCHALL "." _name_char_matches "${_name}")
+    list(TRANSFORM _name_char_matches PREPEND ')
+    list(TRANSFORM _name_char_matches APPEND ')
+    list(JOIN _name_char_matches ", " _name_chars)
+    list(APPEND TYPE_INFO_QUERY_DECLS "REALM_TYPE_INFO(${_name}, ${_expression}, ${_name_chars});\n")
+endwhile()
+
+foreach(h ${BRIDGE_TYPE_REQUIRED_HEADERS})
+string(APPEND BRIDGE_TYPE_HEADER_DECLS "#include \"${h}\"\n")
+endforeach()
+
+configure_file(bridge_type_info_generator.cpp.in bridge_type_info_generator.cpp)
+add_library(BridgeTypeInfoGenerator STATIC ${CMAKE_CURRENT_BINARY_DIR}/bridge_type_info_generator.cpp)
+target_link_libraries(BridgeTypeInfoGenerator Realm::Storage)

--- a/src/cpprealm/internal/bridge/generator/bridge_type_info_generator.cpp.in
+++ b/src/cpprealm/internal/bridge/generator/bridge_type_info_generator.cpp.in
@@ -1,0 +1,44 @@
+@BRIDGE_TYPE_HEADER_DECLS@
+
+#undef KEY
+#if defined(__i386)
+# define KEY '_','_','i','3','8','6'
+#elif defined(__x86_64)
+# define KEY '_','_','x','8','6','_','6','4'
+#elif defined(__ppc__)
+# define KEY '_','_','p','p','c','_','_'
+#elif defined(__ppc64__)
+# define KEY '_','_','p','p','c','6','4','_','_'
+#elif defined(__aarch64__)
+# define KEY '_','_','a','a','r','c','h','6','4','_','_'
+#elif defined(__ARM_ARCH_7A__)
+# define KEY '_','_','A','R','M','_','A','R','C','H','_','7','A','_','_'
+#elif defined(__ARM_ARCH_7S__)
+# define KEY '_','_','A','R','M','_','A','R','C','H','_','7','S','_','_'
+#endif
+
+int main()
+{
+    int required = 0;
+
+    #define REALM_TYPE_INFO(NAME, EXPRESSION, ...) \
+        static char info_##NAME[] =  {'R', 'E', 'A', 'L', 'M', '_', 'T', 'Y', 'P', 'E', '_', 'I', 'N', 'F', 'O', ':', __VA_ARGS__,'[', \
+        ('0' + ((sizeof(EXPRESSION) / 10000)%10)), \
+        ('0' + ((sizeof(EXPRESSION) / 1000)%10)), \
+        ('0' + ((sizeof(EXPRESSION) / 100)%10)), \
+        ('0' + ((sizeof(EXPRESSION) / 10)%10)), \
+        ('0' +  (sizeof(EXPRESSION)    % 10)), \
+        ',', \
+        ('0' + ((alignof(EXPRESSION) / 10000)%10)), \
+        ('0' + ((alignof(EXPRESSION) / 1000)%10)), \
+        ('0' + ((alignof(EXPRESSION) / 100)%10)), \
+        ('0' + ((alignof(EXPRESSION) / 10)%10)), \
+        ('0' +  (alignof(EXPRESSION)    % 10)), \
+        ']', \
+        '\0'}; \
+        required += info_##NAME[0]
+
+    @TYPE_INFO_QUERY_DECLS@
+
+    return required;
+}

--- a/src/cpprealm/internal/bridge/generator/bridge_type_info_parser.cmake
+++ b/src/cpprealm/internal/bridge/generator/bridge_type_info_parser.cmake
@@ -1,0 +1,13 @@
+file(STRINGS ${BRIDGE_TYPE_INFO_BIN} compiled_string_literals REGEX "^REALM_TYPE_INFO")
+
+set(regex "REALM_TYPE_INFO:(.+)\\[0*(.*),0*(.*)\\]")
+
+foreach(i ${compiled_string_literals})
+    if("${i}" MATCHES "${regex}")
+        list(APPEND BRIDGE_TYPE_DECLS "using ${CMAKE_MATCH_1} = std::aligned_storage<${CMAKE_MATCH_2}, ${CMAKE_MATCH_3}>::type;\n")
+    else()
+        message(FATAL_ERROR "Unrecognized type info string: " ${h})
+    endif()
+endforeach()
+
+configure_file(${SOURCE_DIR}/bridge_types.hpp.in ${BINARY_DIR}/bridge_types.hpp)

--- a/src/cpprealm/internal/bridge/list.cpp
+++ b/src/cpprealm/internal/bridge/list.cpp
@@ -10,7 +10,9 @@
 #include <realm/object-store/list.hpp>
 
 namespace realm::internal::bridge {
-#ifdef __i386__
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+    static_assert(LayoutCheck<storage::List, List>{});
+#elif __i386__
     static_assert(SizeCheck<40, sizeof(List)>{});
     static_assert(SizeCheck<4, alignof(List)>{});
 #elif __x86_64__

--- a/src/cpprealm/internal/bridge/list.hpp
+++ b/src/cpprealm/internal/bridge/list.hpp
@@ -87,7 +87,9 @@ namespace realm::internal::bridge {
     private:
         template <typename ValueType>
         friend ValueType get(const list&, size_t idx);
-#ifdef __i386__
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+        storage::List m_list[1];
+#elif __i386__
         std::aligned_storage<40, 4>::type m_list[1];
 #elif __x86_64__
         std::aligned_storage<80, 8>::type m_list[1];

--- a/src/cpprealm/internal/bridge/lnklst.cpp
+++ b/src/cpprealm/internal/bridge/lnklst.cpp
@@ -6,7 +6,9 @@
 #include <realm/list.hpp>
 
 namespace realm::internal::bridge {
-#ifdef __i386__
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+    static_assert(LayoutCheck<storage::LnkLst, LnkLst>{});
+#elif __i386__
     static_assert(SizeCheck<104, sizeof(LnkLst)>{});
     static_assert(SizeCheck<4, alignof(LnkLst)>{});
 #elif __x86_64__

--- a/src/cpprealm/internal/bridge/lnklst.hpp
+++ b/src/cpprealm/internal/bridge/lnklst.hpp
@@ -23,7 +23,9 @@ namespace realm::internal::bridge {
         obj create_and_insert_linked_object(size_t idx);
         void add(const obj_key&);
     private:
-#ifdef __i386__
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+        storage::LnkLst m_lnk_lst[1];
+#elif __i386__
         std::aligned_storage<160, 8>::type m_lnk_lst[1];
 #elif __x86_64__
         std::aligned_storage<160, 8>::type m_lnk_lst[1];

--- a/src/cpprealm/internal/bridge/mixed.cpp
+++ b/src/cpprealm/internal/bridge/mixed.cpp
@@ -4,7 +4,9 @@
 #include <realm/mixed.hpp>
 
 namespace realm::internal::bridge {
-#ifdef __i386__
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+    static_assert(LayoutCheck<storage::Mixed, Mixed>{});
+#elif __i386__
     static_assert(SizeCheck<20, sizeof(Mixed)>{});
     static_assert(SizeCheck<4, alignof(Mixed)>{});
 #elif __x86_64__

--- a/src/cpprealm/internal/bridge/mixed.hpp
+++ b/src/cpprealm/internal/bridge/mixed.hpp
@@ -94,7 +94,9 @@ namespace realm::internal::bridge {
     private:
         std::string m_owned_string;
         binary m_owned_data;
-#ifdef __i386__
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+        storage::Mixed m_mixed[1];
+#elif __i386__
         std::aligned_storage<20, 4>::type m_mixed[1];
 #elif __x86_64__
         std::aligned_storage<24, 8>::type m_mixed[1];

--- a/src/cpprealm/internal/bridge/obj.cpp
+++ b/src/cpprealm/internal/bridge/obj.cpp
@@ -20,7 +20,9 @@
 #include <cpprealm/internal/bridge/realm.hpp>
 
 namespace realm::internal::bridge {
-#ifdef __i386__
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+    static_assert(LayoutCheck<storage::Obj, Obj>{});
+#elif __i386__
     static_assert(SizeCheck<44, sizeof(Obj)>{});
     static_assert(SizeCheck<4, alignof(Obj)>{});
 #elif __x86_64__

--- a/src/cpprealm/internal/bridge/obj.hpp
+++ b/src/cpprealm/internal/bridge/obj.hpp
@@ -225,7 +225,9 @@ namespace realm::internal::bridge {
     private:
         template <typename T>
         friend T get(const obj&, const col_key& col_key);
-#ifdef __i386__
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+        storage::Obj m_obj[1];
+#elif __i386__
         std::aligned_storage<44, 4>::type m_obj[1];
 #elif __x86_64__
         std::aligned_storage<64, 8>::type m_obj[1];

--- a/src/cpprealm/internal/bridge/obj_key.cpp
+++ b/src/cpprealm/internal/bridge/obj_key.cpp
@@ -4,7 +4,9 @@
 #include <realm/keys.hpp>
 
 namespace realm::internal::bridge {
-#ifdef __i386__
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+    static_assert(LayoutCheck<storage::ObjKey, ObjKey>{});
+#elif __i386__
     static_assert(SizeCheck<8, sizeof(ObjKey)>{});
     static_assert(SizeCheck<4, alignof(ObjKey)>{});
 #elif __x86_64__
@@ -71,7 +73,9 @@ namespace realm::internal::bridge {
         return static_cast<ObjKey>(lhs) != static_cast<ObjKey>(rhs);
     }
 
-#ifdef __i386__
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+    static_assert(LayoutCheck<storage::ObjLink, ObjLink>{});
+#elif __i386__
     static_assert(SizeCheck<12, sizeof(ObjLink)>{});
     static_assert(SizeCheck<4, alignof(ObjLink)>{});
 #elif __x86_64__

--- a/src/cpprealm/internal/bridge/obj_key.hpp
+++ b/src/cpprealm/internal/bridge/obj_key.hpp
@@ -20,7 +20,9 @@ namespace realm::internal::bridge {
         ~obj_key();
         operator ObjKey() const;
     private:
-#ifdef __i386__
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+        storage::ObjKey m_obj_key[1];
+#elif __i386__
         std::aligned_storage<8, 4>::type m_obj_key[1];
 #elif __x86_64__
         std::aligned_storage<8, 8>::type m_obj_key[1];
@@ -50,7 +52,9 @@ namespace realm::internal::bridge {
         operator ObjLink() const;
         obj_key get_obj_key();
     private:
-#ifdef __i386__
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+        storage::ObjLink m_obj_link[1];
+#elif __i386__
         std::aligned_storage<12, 4>::type m_obj_link[1];
 #elif __x86_64__
         std::aligned_storage<16, 8>::type m_obj_link[1];

--- a/src/cpprealm/internal/bridge/object.cpp
+++ b/src/cpprealm/internal/bridge/object.cpp
@@ -14,7 +14,14 @@
 #include <memory>
 
 namespace realm::internal::bridge {
-#ifdef __i386__
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+    static_assert(LayoutCheck<storage::Object, Object>{});
+    static_assert(LayoutCheck<storage::IndexSet, IndexSet>{});
+    static_assert(LayoutCheck<storage::CollectionChangeSet, CollectionChangeSet>{});
+    static_assert(LayoutCheck<storage::IndexSet_IndexIterator, IndexSet::IndexIterator>{});
+    static_assert(LayoutCheck<storage::IndexSet_IndexIteratableAdaptor, IndexSet::IndexIteratableAdaptor>{});
+    static_assert(LayoutCheck<storage::NotificationToken, NotificationToken>{});
+#elif __i386__
     static_assert(SizeCheck<64, sizeof(Object)>{});
     static_assert(SizeCheck<4, alignof(Object)>{});
     static_assert(SizeCheck<12, sizeof(IndexSet)>{});

--- a/src/cpprealm/internal/bridge/object.hpp
+++ b/src/cpprealm/internal/bridge/object.hpp
@@ -33,7 +33,9 @@ namespace realm::internal::bridge {
         operator NotificationToken() const;
         void unregister();
     private:
-#ifdef __i386__
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+        storage::NotificationToken m_token[1];
+#elif __i386__
         std::aligned_storage<16, 4>::type m_token[1];
 #elif __x86_64__
         std::aligned_storage<24, 8>::type m_token[1];
@@ -75,7 +77,9 @@ namespace realm::internal::bridge {
 
         private:
             friend struct index_iterable_adaptor;
-#ifdef __i386__
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+            storage::IndexSet_IndexIterator m_iterator[1];
+#elif __i386__
             std::aligned_storage<16, 4>::type m_iterator[1];
 #elif __x86_64__
             std::aligned_storage<32, 8>::type m_iterator[1];
@@ -105,7 +109,9 @@ namespace realm::internal::bridge {
             const_iterator end() const noexcept;
         private:
             friend struct index_set;
-#ifdef __i386__
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+            storage::IndexSet_IndexIteratableAdaptor m_index_iterable_adaptor[1];
+#elif __i386__
             std::aligned_storage<4, 4>::type m_index_iterable_adaptor[1];
 #elif __x86_64__
             std::aligned_storage<8, 8>::type m_index_iterable_adaptor[1];
@@ -119,7 +125,9 @@ namespace realm::internal::bridge {
         };
         index_iterable_adaptor as_indexes() const;
     private:
-#ifdef __i386__
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+        storage::IndexSet m_idx_set[1];
+#elif __i386__
         std::aligned_storage<24, 4>::type m_idx_set[1];
 #elif __x86_64__
         std::aligned_storage<24, 8>::type m_idx_set[1];
@@ -151,7 +159,9 @@ namespace realm::internal::bridge {
         [[nodiscard]] bool empty() const;
         [[nodiscard]] bool collection_root_was_deleted() const;
     private:
-#ifdef __i386__
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+        storage::CollectionChangeSet m_change_set[1];
+#elif __i386__
         std::aligned_storage<84, 4>::type m_change_set[1];
 #elif __x86_64__
     #if defined(__clang__)
@@ -206,7 +216,9 @@ namespace realm::internal::bridge {
         [[nodiscard]] list get_list(const col_key&) const;
         [[nodiscard]] dictionary get_dictionary(const col_key&) const;
     private:
-#ifdef __i386__
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+        storage::Object m_object[1];
+#elif __i386__
         std::aligned_storage<64, 4>::type m_object[1];
 #elif __x86_64__
         std::aligned_storage<104, 8>::type m_object[1];

--- a/src/cpprealm/internal/bridge/object_id.cpp
+++ b/src/cpprealm/internal/bridge/object_id.cpp
@@ -7,7 +7,9 @@
 #include <cpprealm/internal/bridge/object_id.hpp>
 
 namespace realm::internal::bridge {
-#ifdef __i386__
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+    static_assert(LayoutCheck<storage::ObjectId, ObjectId>{});
+#elif __i386__
     static_assert(SizeCheck<12, sizeof(::realm::ObjectId)>{});
     static_assert(SizeCheck<1, alignof(::realm::ObjectId)>{});
 #elif __x86_64__

--- a/src/cpprealm/internal/bridge/object_id.hpp
+++ b/src/cpprealm/internal/bridge/object_id.hpp
@@ -24,7 +24,9 @@ namespace realm::internal::bridge {
         [[nodiscard]] std::string to_string() const;
         [[nodiscard]] static object_id generate();
     private:
-#ifdef __i386__
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+        storage::ObjectId m_object_id[1];
+#elif __i386__
         std::aligned_storage<12, 1>::type m_object_id[1];
 #elif __x86_64__
         std::aligned_storage<12, 1>::type m_object_id[1];

--- a/src/cpprealm/internal/bridge/object_schema.cpp
+++ b/src/cpprealm/internal/bridge/object_schema.cpp
@@ -6,7 +6,9 @@
 #include <realm/object-store/property.hpp>
 
 namespace realm::internal::bridge {
-#ifdef __i386__
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+    static_assert(LayoutCheck<storage::ObjectSchema, ObjectSchema>{});
+#elif __i386__
     static_assert(SizeCheck<68, sizeof(ObjectSchema)>{});
     static_assert(SizeCheck<4, alignof(ObjectSchema)>{});
 #elif __x86_64__

--- a/src/cpprealm/internal/bridge/object_schema.hpp
+++ b/src/cpprealm/internal/bridge/object_schema.hpp
@@ -38,7 +38,9 @@ namespace realm::internal::bridge {
         property property_for_name(const std::string&);
         bool operator==(const object_schema& rhs);
     private:
-#ifdef __i386__
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+        storage::ObjectSchema m_schema[1];
+#elif __i386__
         std::aligned_storage<68, 4>::type m_schema[1];
 #elif __x86_64__
     #if defined(__clang__)

--- a/src/cpprealm/internal/bridge/property.cpp
+++ b/src/cpprealm/internal/bridge/property.cpp
@@ -5,7 +5,9 @@
 #include <realm/object-store/property.hpp>
 
 namespace realm::internal::bridge {
-#ifdef __i386__
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+    static_assert(LayoutCheck<storage::Property, Property>{});
+#elif __i386__
     static_assert(SizeCheck<64, sizeof(Property)>{});
     static_assert(SizeCheck<4, alignof(Property)>{});
 #elif __x86_64__

--- a/src/cpprealm/internal/bridge/property.hpp
+++ b/src/cpprealm/internal/bridge/property.hpp
@@ -62,7 +62,9 @@ namespace realm::internal::bridge {
         std::string name() const;
         [[nodiscard]] col_key column_key() const;
     private:
-#ifdef __i386__
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+        storage::Property m_property[1];
+#elif __i386__
         std::aligned_storage<64, 4>::type m_property[1];
 #elif __x86_64__
     #if defined(__clang__)

--- a/src/cpprealm/internal/bridge/query.cpp
+++ b/src/cpprealm/internal/bridge/query.cpp
@@ -28,7 +28,9 @@
         return *this; \
     }
 namespace realm::internal::bridge {
-#ifdef __i386__
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+    static_assert(LayoutCheck<storage::Query, Query>{});
+#elif __i386__
     static_assert(SizeCheck<68, sizeof(Query)>{});
     static_assert(SizeCheck<4, alignof(Query)>{});
 #elif __x86_64__

--- a/src/cpprealm/internal/bridge/query.hpp
+++ b/src/cpprealm/internal/bridge/query.hpp
@@ -124,7 +124,9 @@ namespace realm::internal::bridge {
         query& not_equal(col_key column_key, bool value);
         using underlying = Query;
     private:
-#ifdef __i386__
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+        storage::Query m_query[1];
+#elif __i386__
         std::aligned_storage<68, 4>::type m_query[1];
 #elif __x86_64__
     #if defined(__clang__)

--- a/src/cpprealm/internal/bridge/realm.cpp
+++ b/src/cpprealm/internal/bridge/realm.cpp
@@ -30,7 +30,9 @@
 #include <filesystem>
 
 namespace realm::internal::bridge {
-#ifdef __i386__
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+    static_assert(LayoutCheck<storage::Realm_Config, Realm::Config>{});
+#elif __i386__
     static_assert(SizeCheck<192, sizeof(Realm::Config)>{});
     static_assert(SizeCheck<8, alignof(Realm::Config)>{});
 #elif __x86_64__

--- a/src/cpprealm/internal/bridge/realm.hpp
+++ b/src/cpprealm/internal/bridge/realm.hpp
@@ -151,7 +151,9 @@ namespace realm::internal::bridge {
             void set_custom_http_headers(const std::map<std::string, std::string>& headers);
             void set_schema_version(uint64_t version);
         private:
-#ifdef __i386__
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+            storage::Realm_Config m_config[1];
+#elif __i386__
             std::aligned_storage<192, 8>::type m_config[1];
 #elif __x86_64__
     #if defined(__clang__)

--- a/src/cpprealm/internal/bridge/results.cpp
+++ b/src/cpprealm/internal/bridge/results.cpp
@@ -7,7 +7,9 @@
 #include <cpprealm/internal/bridge/utils.hpp>
 
 namespace realm::internal::bridge {
-#ifdef __i386__
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+    static_assert(LayoutCheck<storage::Results, Results>{});
+#elif __i386__
     static_assert(SizeCheck<496, sizeof(Results)>{});
     static_assert(SizeCheck<4, alignof(Results)>{});
 #elif __x86_64__

--- a/src/cpprealm/internal/bridge/results.hpp
+++ b/src/cpprealm/internal/bridge/results.hpp
@@ -33,7 +33,9 @@ namespace realm::internal::bridge {
     private:
         template <typename T>
         friend T get(results&, size_t);
-#ifdef __i386__
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+        storage::Results m_results[1];
+#elif __i386__
         std::aligned_storage<496, 4>::type m_results[1];
 #elif __x86_64__
     #if defined(__clang__)

--- a/src/cpprealm/internal/bridge/schema.cpp
+++ b/src/cpprealm/internal/bridge/schema.cpp
@@ -6,7 +6,9 @@
 #include <realm/object-store/property.hpp>
 
 namespace realm::internal::bridge {
-#ifdef __i386__
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+    static_assert(LayoutCheck<storage::Schema, Schema>{});
+#elif __i386__
     static_assert(SizeCheck<12, sizeof(Schema)>{});
     static_assert(SizeCheck<4, alignof(Schema)>{});
 #elif __x86_64__

--- a/src/cpprealm/internal/bridge/schema.hpp
+++ b/src/cpprealm/internal/bridge/schema.hpp
@@ -22,7 +22,9 @@ namespace realm::internal::bridge {
         operator Schema() const; //NOLINT(google-explicit-constructor)
         object_schema find(const std::string &name);
     private:
-#ifdef __i386__
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+        storage::Schema m_schema[1];
+#elif __i386__
         std::aligned_storage<12, 4>::type m_schema[1];
 #elif __x86_64__
         std::aligned_storage<24, 8>::type m_schema[1];

--- a/src/cpprealm/internal/bridge/sync_error.cpp
+++ b/src/cpprealm/internal/bridge/sync_error.cpp
@@ -4,7 +4,9 @@
 #include <realm/sync/config.hpp>
 
 namespace realm::internal::bridge {
-#ifdef __i386__
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+    static_assert(LayoutCheck<storage::SyncError, SyncError>{});
+#elif __i386__
     static_assert(SizeCheck<68, sizeof(SyncError)>{});
     static_assert(SizeCheck<4, alignof(SyncError)>{});
 #elif __x86_64__

--- a/src/cpprealm/internal/bridge/sync_error.hpp
+++ b/src/cpprealm/internal/bridge/sync_error.hpp
@@ -33,7 +33,9 @@ namespace realm::internal::bridge {
         /// The error indicates a client reset situation.
         [[nodiscard]] bool is_client_reset_requested() const;
     private:
-#ifdef __i386__
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+        storage::SyncError m_error[1];
+#elif __i386__
         std::aligned_storage<68, 4>::type m_error[1];
 #elif __x86_64__
     #if defined(__clang__)

--- a/src/cpprealm/internal/bridge/table.cpp
+++ b/src/cpprealm/internal/bridge/table.cpp
@@ -12,7 +12,7 @@
 namespace realm::internal::bridge {
 #ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
     static_assert(LayoutCheck<storage::TableRef, TableRef>{});
-    static_assert(LayoutCheck<storage::TableView, TableView>{});
+    static_assert(LayoutCheck<storage::TableRef, ConstTableRef>{});
 #elif __i386__
     static_assert(SizeCheck<12, sizeof(TableRef)>{});
     static_assert(SizeCheck<4, alignof(TableRef)>{});
@@ -131,7 +131,9 @@ namespace realm::internal::bridge {
         return static_cast<TableRef>(lhs) != static_cast<TableRef>(rhs);
     }
 
-#ifdef __i386__
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+    static_assert(LayoutCheck<storage::TableView, TableView>{});
+#elif __i386__
     static_assert(SizeCheck<316, sizeof(TableView)>{});
     static_assert(SizeCheck<4, alignof(TableView)>{});
 #elif __x86_64__

--- a/src/cpprealm/internal/bridge/table.cpp
+++ b/src/cpprealm/internal/bridge/table.cpp
@@ -10,7 +10,10 @@
 #include <realm/mixed.hpp>
 
 namespace realm::internal::bridge {
-#ifdef __i386__
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+    static_assert(LayoutCheck<storage::TableRef, TableRef>{});
+    static_assert(LayoutCheck<storage::TableView, TableView>{});
+#elif __i386__
     static_assert(SizeCheck<12, sizeof(TableRef)>{});
     static_assert(SizeCheck<4, alignof(TableRef)>{});
     static_assert(SizeCheck<12, sizeof(ConstTableRef)>{});

--- a/src/cpprealm/internal/bridge/table.hpp
+++ b/src/cpprealm/internal/bridge/table.hpp
@@ -45,7 +45,9 @@ namespace realm {
             obj get_object(const obj_key&) const;
             bool is_valid(const obj_key&) const;
             using underlying = TableRef;
-#ifdef __i386__
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+        storage::TableRef m_table[1];
+#elif __i386__
          std::aligned_storage<12, 4>::type m_table[1];
 #elif __x86_64__
         std::aligned_storage<16, 8>::type m_table[1];
@@ -68,7 +70,9 @@ namespace realm {
             table_view(const TableView &);
             operator TableView() const;
             using underlying = TableView;
-#ifdef __i386__
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+            storage::TableView m_table_view[1];
+#elif __i386__
             std::aligned_storage<316, 4>::type m_table_view[1];
 #elif __x86_64__
 #if defined(__clang__)

--- a/src/cpprealm/internal/bridge/thread_safe_reference.cpp
+++ b/src/cpprealm/internal/bridge/thread_safe_reference.cpp
@@ -9,7 +9,9 @@
 #include <memory>
 
 namespace realm::internal::bridge {
-#ifdef __i386__
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+    static_assert(LayoutCheck<storage::ThreadSafeReference, ThreadSafeReference>{});
+#elif __i386__
     static_assert(SizeCheck<4, sizeof(ThreadSafeReference)>{});
     static_assert(SizeCheck<4, alignof(ThreadSafeReference)>{});
 #elif __x86_64__

--- a/src/cpprealm/internal/bridge/thread_safe_reference.hpp
+++ b/src/cpprealm/internal/bridge/thread_safe_reference.hpp
@@ -27,7 +27,9 @@ namespace realm::internal::bridge {
         friend struct realm;
         template <typename T>
         friend T resolve(const realm&, thread_safe_reference&& tsr);
-#ifdef __i386__
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+        storage::ThreadSafeReference m_thread_safe_reference[1];
+#elif __i386__
         std::aligned_storage<4, 4>::type m_thread_safe_reference[1];
 #elif __x86_64__
         std::aligned_storage<8, 8>::type m_thread_safe_reference[1];

--- a/src/cpprealm/internal/bridge/timestamp.cpp
+++ b/src/cpprealm/internal/bridge/timestamp.cpp
@@ -3,7 +3,9 @@
 #include <realm/timestamp.hpp>
 
 namespace realm::internal::bridge {
-#ifdef __i386__
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+    static_assert(LayoutCheck<storage::Timestamp, Timestamp>{});
+#elif __i386__
     static_assert(SizeCheck<16, sizeof(Timestamp)>{});
     static_assert(SizeCheck<4, alignof(Timestamp)>{});
 #elif __x86_64__

--- a/src/cpprealm/internal/bridge/timestamp.hpp
+++ b/src/cpprealm/internal/bridge/timestamp.hpp
@@ -31,7 +31,9 @@ namespace realm::internal::bridge {
         }
     private:
         static constexpr int32_t nanoseconds_per_second = 1000000000;
-#ifdef __i386__
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+        storage::Timestamp m_timestamp[1];
+#elif __i386__
         std::aligned_storage<16, 4>::type m_timestamp[1];
 #elif __x86_64__
         std::aligned_storage<16, 8>::type m_timestamp[1];

--- a/src/cpprealm/internal/bridge/utils.hpp
+++ b/src/cpprealm/internal/bridge/utils.hpp
@@ -7,11 +7,21 @@
 #include <type_traits>
 #include <realm/utilities.hpp>
 
+#if __has_include(<cpprealm/internal/bridge/bridge_types.hpp>)
+#include <cpprealm/internal/bridge/bridge_types.hpp>
+#endif
+
 namespace realm::internal::bridge {
     template <size_t lhs, size_t rhs, typename = void>
     struct SizeCheck;
     template <size_t lhs, size_t rhs>
     struct SizeCheck<lhs, rhs, std::enable_if_t<(lhs == rhs)>> : std::true_type {
+    };
+
+    template <typename Left, typename Right, typename = void>
+    struct LayoutCheck;
+    template <typename Left, typename Right>
+    struct LayoutCheck<Left, Right, std::enable_if_t<(sizeof(Left) == sizeof(Right) && alignof(Left) == alignof(Right))>> : std::true_type {
     };
 
     template <typename T>

--- a/src/cpprealm/internal/bridge/uuid.cpp
+++ b/src/cpprealm/internal/bridge/uuid.cpp
@@ -4,7 +4,9 @@
 #include <cpprealm/experimental/types.hpp>
 
 namespace realm::internal::bridge {
-#ifdef __i386__
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+    static_assert(LayoutCheck<storage::UUID, UUID>{});
+#elif __i386__
     static_assert(SizeCheck<16, sizeof(::realm::UUID)>{});
     static_assert(SizeCheck<1, alignof(::realm::UUID)>{});
 #elif __x86_64__

--- a/src/cpprealm/internal/bridge/uuid.hpp
+++ b/src/cpprealm/internal/bridge/uuid.hpp
@@ -26,7 +26,9 @@ namespace realm::internal::bridge {
         [[nodiscard]] std::string to_base64() const;
         [[nodiscard]] std::array<uint8_t, 16> to_bytes() const;
     private:
-#ifdef __i386__
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+        storage::UUID m_uuid[1];
+#elif __i386__
         std::aligned_storage<16, 1>::type m_uuid[1];
 #elif __x86_64__
         std::aligned_storage<16, 1>::type m_uuid[1];

--- a/src/cpprealm/internal/curl/network_transport.cpp
+++ b/src/cpprealm/internal/curl/network_transport.cpp
@@ -149,7 +149,7 @@ namespace realm::internal {
             long http_code = 0;
             curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code);
             return {
-                    http_code,
+                    static_cast<int>(http_code),
                     0, // binding_response_code
                     std::move(response_headers),
                     std::move(response),


### PR DESCRIPTION
Add a CMake target that calculates the size and alignment of the types we need to bridge between realm-core and realm-cpp so that we don't have to hardcode `std::aligned_storage` declarations. This enables building for compiler/architecture combos that our hardcoded declarations don't account for.

Add your type to the `BRIDGE_TYPES` list in [src/cpprealm/internal/bridge/generator/CMakeLists.txt](https://github.com/realm/realm-cpp/compare/lm/gcc10...yg/generated-bridge-types?expand=1#diff-1e8842a36e2185a2723f471a901a9de4a1b0f3de238133bf7e91b8915c6cb546) and CMake will generate a static library target that calculates the size and alignment for every declared bridge type and compile it with the current compiler. A second target will parse the binary and generate a header file with declarations similar to
```cpp
#define CPPREALM_HAVE_GENERATED_BRIDGE_TYPES

namespace realm::internal::bridge::storage {
    using OwnedBinaryData = std::aligned_storage<16, 8>::type;
    using Realm_Config = std::aligned_storage<312, 8>::type;
    using ColKey = std::aligned_storage<8, 8>::type;
    using Decimal128 = std::aligned_storage<16, 8>::type;
    using Dictionary = std::aligned_storage<80, 8>::type;
    using CoreDictionary = std::aligned_storage<144, 8>::type;
    using List = std::aligned_storage<80, 8>::type;
    using LnkLst = std::aligned_storage<160, 8>::type;
    using Mixed = std::aligned_storage<24, 8>::type;
    using ObjKey = std::aligned_storage<8, 8>::type;
    using ObjLink = std::aligned_storage<16, 8>::type;
    using Obj = std::aligned_storage<64, 8>::type;
    using ObjectId = std::aligned_storage<12, 1>::type;
    using ObjectSchema = std::aligned_storage<128, 8>::type;
    using Object = std::aligned_storage<104, 8>::type;
    using IndexSet = std::aligned_storage<24, 8>::type;
    using CollectionChangeSet = std::aligned_storage<168, 8>::type;
    using IndexSet_IndexIterator = std::aligned_storage<32, 8>::type;
    using IndexSet_IndexIteratableAdaptor = std::aligned_storage<8, 8>::type;
    using NotificationToken = std::aligned_storage<24, 8>::type;
    using Property = std::aligned_storage<120, 8>::type;
    using Query = std::aligned_storage<128, 8>::type;
    using Results = std::aligned_storage<896, 8>::type;
    using Schema = std::aligned_storage<24, 8>::type;
    using SyncError = std::aligned_storage<128, 8>::type;
    using TableRef = std::aligned_storage<16, 8>::type;
    using TableView = std::aligned_storage<568, 8>::type;
    using ThreadSafeReference = std::aligned_storage<8, 8>::type;
    using Timestamp = std::aligned_storage<16, 8>::type;
    using UUID = std::aligned_storage<16, 1>::type;
}
```

We can then declare our type storage as
```cpp
#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
        storage::Timestamp m_timestamp[1];
#elif __i386__
        std::aligned_storage<16, 4>::type m_timestamp[1];
#elif __x86_64__
        std::aligned_storage<16, 8>::type m_timestamp[1];
#elif __arm__
        std::aligned_storage<16, 8>::type m_timestamp[1];
#elif __aarch64__
        std::aligned_storage<16, 8>::type m_timestamp[1];
#elif _WIN32
        std::aligned_storage<16, 8>::type m_timestamp[1];
#endif
```
where we use the generated `std::aligned_storage` declaration, but if we don't find it we fall back to the hardcoded declarations. This is useful for builds outside of CMake where we can't plug in the same generation.