### PR TITLE
Add encryption support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,21 @@ X.Y.Z Release notes (YYYY-MM-DD)
 * Using a property type of vector of enums would cause a compilation error (since 0.1.0).
 
 ### Enhancements
-* The Sync metadata Realm is now encrypted by default unless the `REALM_DISABLE_METADATA_ENCRYPTION` environment variable is set.
+* The Sync metadata Realm is now encrypted by default on Apple platforms unless the `REALM_DISABLE_METADATA_ENCRYPTION` environment variable is set.
+  To enable encryption on the metadata Realm on other platforms you must set an encryption key on `realm::App::configuration`.
+```cpp
+std::array<char, 64> example_key = {...};
+realm::App::configuration app_config;
+app_config.app_id = ...
+app_config.metadata_encryption_key = example_key;
+auto encrypted_app = realm::App(app_config);
+```
 * Add ability to encrypt a Realm. Usage: `realm::config::set_encryption_key(const std::array<char, 64>&)`.
 
 ### Breaking Changes
-* None
+* `realm::App(const std::string &app_id, const std::optional<std::string> &base_url,
+              const std::optional<std::string> &path, const std::optional<std::map<std::string, std::string>> &custom_http_headers)` has been deprecated.
+   use `realm::App(const realm::App::configuration&);` instead.
 
 ### Compatibility
 * Fileformat: Generates files with format v22.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ X.Y.Z Release notes (YYYY-MM-DD)
 * Using a property type of vector of enums would cause a compilation error (since 0.1.0).
 
 ### Enhancements
-* None
+* The Sync metadata Realm is now encrypted by default unless the `REALM_DISABLE_METADATA_ENCRYPTION` environment variable is set.
+* Add ability to encrypt a Realm. Usage: `realm::config::set_encryption_key(const std::array<char, 64>&)`.
 
 ### Breaking Changes
 * None

--- a/src/cpprealm/app.cpp
+++ b/src/cpprealm/app.cpp
@@ -352,11 +352,8 @@ namespace realm {
 #endif
         SyncClientConfig config;
         bool should_encrypt = !getenv("REALM_DISABLE_METADATA_ENCRYPTION");
-#if REALM_DISABLE_METADATA_ENCRYPTION
-        config.metadata_mode = SyncManager::MetadataMode::NoEncryption;
-#else
-        config.metadata_mode = SyncManager::MetadataMode::NoEncryption;
-#endif
+        config.metadata_mode = should_encrypt ? SyncManager::MetadataMode::Encryption : SyncManager::MetadataMode::NoEncryption;
+
 #ifdef QT_CORE_LIB
         auto qt_path = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation).toStdString();
         if (!std::filesystem::exists(qt_path)) {

--- a/src/cpprealm/app.cpp
+++ b/src/cpprealm/app.cpp
@@ -381,7 +381,7 @@ namespace realm {
         auto app_config = app::App::Config();
         app_config.app_id = config.app_id;
         app_config.transport = std::make_shared<internal::DefaultTransport>(config.custom_http_headers);
-        app_config.base_url = config.base_url ? config.base_url : util::Optional<std::string>();
+        app_config.base_url = config.base_url;
         auto device_info = app::App::Config::DeviceInfo();
 
         device_info.framework_name = "Realm Cpp",

--- a/src/cpprealm/app.hpp
+++ b/src/cpprealm/app.hpp
@@ -222,10 +222,21 @@ bool operator!=(const user& lhs, const user& rhs);
 
 class App {
 public:
+    struct configuration {
+        std::string app_id;
+        std::optional<std::string> base_url;
+        std::optional<std::string> path;
+        std::optional<std::map<std::string, std::string>> custom_http_headers;
+        std::optional<std::array<char, 64>> metadata_encryption_key;
+    };
+
+    [[deprecated("Use App(const configuration&) instead.")]]
     explicit App(const std::string& app_id,
                  const std::optional<std::string>& base_url = {},
                  const std::optional<std::string>& path = {},
                  const std::optional<std::map<std::string, std::string>>& custom_http_headers = {});
+
+    App(const configuration&);
 
     struct credentials {
         using auth_code = util::TaggedString<class auth_code_tag>;

--- a/src/cpprealm/internal/bridge/realm.cpp
+++ b/src/cpprealm/internal/bridge/realm.cpp
@@ -269,6 +269,13 @@ namespace realm::internal::bridge {
         reinterpret_cast<RealmConfig*>(&m_config)->schema_version = version;
     }
 
+    void realm::config::set_encryption_key(const std::array<char, 64>& encryption_key) {
+        auto key = std::vector<char>();
+        key.resize(64);
+        key.assign(encryption_key.begin(), encryption_key.end());
+        reinterpret_cast<RealmConfig*>(&m_config)->encryption_key = std::move(key);
+    }
+
     realm::sync_config realm::config::sync_config() const {
         return reinterpret_cast<const RealmConfig*>(&m_config)->sync_config;
     }

--- a/src/cpprealm/internal/bridge/realm.hpp
+++ b/src/cpprealm/internal/bridge/realm.hpp
@@ -150,6 +150,7 @@ namespace realm::internal::bridge {
             void set_sync_config(const std::optional<struct sync_config>&);
             void set_custom_http_headers(const std::map<std::string, std::string>& headers);
             void set_schema_version(uint64_t version);
+            void set_encryption_key(const std::array<char, 64>&);
             std::optional<schema> get_schema();
         private:
 #ifdef __i386__

--- a/tests/alpha/app_tests.cpp
+++ b/tests/alpha/app_tests.cpp
@@ -68,7 +68,7 @@ static std::string create_jwt(const std::string& appId)
 }
 
 TEST_CASE("app", "[app]") {
-    auto app = realm::App(Admin::shared().cached_app_id(), Admin::shared().base_url());
+    auto app = realm::App(realm::App::configuration({Admin::shared().cached_app_id(), Admin::shared().base_url()}));
 
     SECTION("auth_providers_promise") {
         auto run_login = [&app](realm::App::credentials&& credentials) {

--- a/tests/alpha/asymmetric_object_tests.cpp
+++ b/tests/alpha/asymmetric_object_tests.cpp
@@ -8,7 +8,7 @@ using namespace realm;
 TEST_CASE("asymmetric object", "[sync]") {
     SECTION("basic", "[sync]") {
         auto asymmetric_app_id = Admin::shared().create_app({}, "test", true);
-        auto app = realm::App(asymmetric_app_id, Admin::shared().base_url());
+        auto app = realm::App(realm::App::configuration({asymmetric_app_id, Admin::shared().base_url()}));
         auto user = app.login(realm::App::credentials::anonymous()).get();
         auto p = realm::async_open<AllTypesAsymmetricObject, EmbeddedFoo>(user.flexible_sync_configuration());
         auto tsr = p.get_future().get();

--- a/tests/alpha/flx_sync_tests.cpp
+++ b/tests/alpha/flx_sync_tests.cpp
@@ -6,7 +6,7 @@
 using namespace realm;
 
 TEST_CASE("flx_sync", "[sync]") {
-    auto app = realm::App(Admin::shared().cached_app_id(), Admin::shared().base_url());
+    auto app = realm::App(realm::App::configuration({Admin::shared().cached_app_id(), Admin::shared().base_url()}));
     SECTION("all") {
         app.get_sync_manager().set_log_level(logger::level::off);
         auto user = app.login(realm::App::credentials::anonymous()).get();
@@ -92,7 +92,7 @@ TEST_CASE("flx_sync", "[sync]") {
 }
 
 TEST_CASE("realm_is_populated_on_async_open", "[sync]") {
-    auto app = realm::App(Admin::shared().cached_app_id(), Admin::shared().base_url());
+    auto app = realm::App(realm::App::configuration({Admin::shared().cached_app_id(), Admin::shared().base_url()}));
     SECTION("all") {
         {
             auto user = app.login(realm::App::credentials::anonymous()).get();

--- a/tests/experimental/db/realm_tests.cpp
+++ b/tests/experimental/db/realm_tests.cpp
@@ -61,4 +61,19 @@ namespace realm::experimental {
         t.join();
         p.get_future().get();
     }
+
+    TEST_CASE("encrypted realm") {
+        std::array<char, 64> example_key = {0,0,0,0,0,0,0,0, 1,1,0,0,0,0,0,0, 2,2,0,0,0,0,0,0, 3,3,0,0,0,0,0,0, 4,4,0,0,0,0,0,0, 5,5,0,0,0,0,0,0, 6,6,0,0,0,0,0,0, 7,7,0,0,0,0,0,0};
+        realm_path path;
+
+        auto config = realm::db_config();
+        config.set_encryption_key(example_key);
+        config.set_path(path);
+        auto realm = experimental::db(config);
+
+        // Missing encryption key
+        auto config2 = realm::db_config();
+        config2.set_path(path);
+        REQUIRE_THROWS(experimental::db(config2));
+    }
 }

--- a/tests/experimental/sync/app_tests.cpp
+++ b/tests/experimental/sync/app_tests.cpp
@@ -6,7 +6,7 @@
 using namespace realm;
 
 TEST_CASE("app", "[sync]") {
-    auto app = realm::App(Admin::shared().cached_app_id(), Admin::shared().base_url());
+    auto app = realm::App(realm::App::configuration({Admin::shared().cached_app_id(), Admin::shared().base_url()}));
 
     SECTION("get_current_user") {
         auto user = app.login(realm::App::credentials::anonymous()).get();
@@ -31,7 +31,7 @@ TEST_CASE("app", "[sync]") {
 
     SECTION("clear_cached_apps") {
         auto temp_app_id = Admin::shared().create_app({"str_col", "_id"});
-        auto temp_app = realm::App(temp_app_id, Admin::shared().base_url());
+        auto temp_app = realm::App(realm::App::configuration({temp_app_id, Admin::shared().base_url()}));
         auto cached_app = temp_app.get_cached_app(temp_app_id, Admin::shared().base_url());
         CHECK(cached_app.has_value());
         app.clear_cached_apps();

--- a/tests/experimental/sync/asymmetric_object_tests.cpp
+++ b/tests/experimental/sync/asymmetric_object_tests.cpp
@@ -8,7 +8,7 @@ using namespace realm;
 TEST_CASE("asymmetric object", "[sync_beta]") {
     SECTION("basic", "[sync]") {
         auto asymmetric_app_id = Admin::shared().create_app({}, "test", true);
-        auto app = realm::App(asymmetric_app_id, Admin::shared().base_url());
+        auto app = realm::App(realm::App::configuration({asymmetric_app_id, Admin::shared().base_url()}));
         auto user = app.login(realm::App::credentials::anonymous()).get();
         auto synced_realm = experimental::open<experimental::AllTypesAsymmetricObject, experimental::EmbeddedFoo>(user.flexible_sync_configuration());
 


### PR DESCRIPTION
* The Sync metadata Realm is now encrypted by default on Apple platforms unless the `REALM_DISABLE_METADATA_ENCRYPTION` environment variable is set.
  To enable encryption on the metadata Realm on other platforms you must set an encryption key on `realm::App::configuration`.
```cpp
std::array<char, 64> example_key = {...};
realm::App::configuration app_config;
app_config.app_id = ...
app_config.metadata_encryption_key = example_key;
auto encrypted_app = realm::App(app_config);
```
* Add ability to encrypt a Realm. Usage: `realm::config::set_encryption_key(const std::array<char, 64>&)`.

* `realm::App(const std::string &app_id, const std::optional<std::string> &base_url,
              const std::optional<std::string> &path, const std::optional<std::map<std::string, std::string>> &custom_http_headers)` has been deprecated.
   use `realm::App(const realm::App::configuration&);` instead.