### PR TITLE
Fix missing shell in Doxygen publishing pipeline

### DIFF
--- a/.github/actions/publish-doxygen/action.yml
+++ b/.github/actions/publish-doxygen/action.yml
@@ -24,6 +24,7 @@ runs:
       env:
         DOXYGEN_PROJECT_NUMBER: ${{ inputs.version }}
     - name: Fix doxygen titles for SEO
+      shell: bash
       run: bash /docs/fix-doxygen-titles.sh
     - name: Upload docs
       uses: jakejarvis/s3-sync-action@master


### PR DESCRIPTION
The Doxygen API reference pipeline has been failing due to a [missing shell error](https://github.com/realm/realm-cpp/actions/runs/6577926595/job/17870601142). Adding the shell here to resolve that failure.