### PR TITLE
Fix Doxygen publishing pipeline

### DIFF
--- a/.github/actions/publish-doxygen/action.yml
+++ b/.github/actions/publish-doxygen/action.yml
@@ -25,7 +25,7 @@ runs:
         DOXYGEN_PROJECT_NUMBER: ${{ inputs.version }}
     - name: Fix doxygen titles for SEO
       shell: bash
-      run: bash /docs/fix-doxygen-titles.sh
+      run: bash docs/fix-doxygen-titles.sh
     - name: Upload docs
       uses: jakejarvis/s3-sync-action@master
       with:
@@ -34,5 +34,5 @@ runs:
         AWS_S3_BUCKET: ${{ inputs.AWS_S3_BUCKET }}
         AWS_ACCESS_KEY_ID: ${{ inputs.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ inputs.AWS_SECRET_ACCESS_KEY }}
-        SOURCE_DIR: docs/html
+        SOURCE_DIR: docs/modified-doxygen-output
         DEST_DIR: docs/realm-sdks/cpp/${{ inputs.destination }}

--- a/docs/fix-doxygen-titles.sh
+++ b/docs/fix-doxygen-titles.sh
@@ -10,6 +10,6 @@ do
   # Make the output SEO friendly by converting the "div" title to the proper "h1"
   sed -i -e 's|<div class="title">\([^<]*\)</div>|<h1>\1</h1>|' "$ln"
 done
-find ./modified-doxygen-output -iname "*.html-e" | xargs rm
+find ./modified-doxygen-output -iname "*.html-e" -exec rm '{}' \:
 
 popd

--- a/docs/fix-doxygen-titles.sh
+++ b/docs/fix-doxygen-titles.sh
@@ -10,6 +10,6 @@ do
   # Make the output SEO friendly by converting the "div" title to the proper "h1"
   sed -i -e 's|<div class="title">\([^<]*\)</div>|<h1>\1</h1>|' "$ln"
 done
-find ./modified-doxygen-output -iname "*.html-e" -exec rm '{}' \:
+find ./modified-doxygen-output -iname "*.html-e" -exec rm '{}' \;
 
 popd

--- a/docs/fix-doxygen-titles.sh
+++ b/docs/fix-doxygen-titles.sh
@@ -1,18 +1,12 @@
 #!/bin/bash -ex
 
 # Output this to a temp directory because we can't write to the html directory
-root_directory=$(dirname "$0")
-mkdir "$root_directory"/modified-doxygen-output
-
 # Assume doxygen was run first
-pushd "`dirname "$0"`"/html
 cp -R html modified-doxygen-output
 
-popd
-
-find ."$root_directory"/modified-doxygen-output -name "*.html" | while read ln
+find ./modified-doxygen-output -name "*.html" | while read ln
 do
   # Make the output SEO friendly by converting the "div" title to the proper "h1"
   sed -i -e 's|<div class="title">\([^<]*\)</div>|<h1>\1</h1>|' "$ln"
 done
-find ."$root_directory"/modified-doxygen-output -iname "*.html-e" | xargs rm
+find ./modified-doxygen-output -iname "*.html-e" | xargs rm

--- a/docs/fix-doxygen-titles.sh
+++ b/docs/fix-doxygen-titles.sh
@@ -2,6 +2,7 @@
 
 # Output this to a temp directory because we can't write to the html directory
 # Assume doxygen was run first
+pushd "`dirname "$0"`"
 cp -R html modified-doxygen-output
 
 find ./modified-doxygen-output -name "*.html" | while read ln
@@ -10,3 +11,5 @@ do
   sed -i -e 's|<div class="title">\([^<]*\)</div>|<h1>\1</h1>|' "$ln"
 done
 find ./modified-doxygen-output -iname "*.html-e" | xargs rm
+
+popd

--- a/docs/fix-doxygen-titles.sh
+++ b/docs/fix-doxygen-titles.sh
@@ -1,13 +1,19 @@
 #!/bin/bash -ex
 
 # Assume doxygen was run first
-pushd "`dirname "$0"`"/html
+current_directory=$(dirname "$0")
 
-find . -name "*.html" | while read ln
+# Run this in a temp directory because we can't write to the html directory
+mkdir "$current_directory"/modified-doxygen-output
+
+find "$current_directory/html" -name "*.html" | while read ln
 do
-  # Make the output SEO friendly by converting the "div" title to the proper "h1"
-  sed -i -e 's|<div class="title">\([^<]*\)</div>|<h1>\1</h1>|' "$ln"
-done
-find . -iname "*.html-e" | xargs rm
+  tempfile=$(mktemp)
 
-popd
+  # Make the output SEO friendly by converting the "div" title to the proper "h1"
+  sed -e 's|<div class="title">\([^<]*\)</div>|<h1>\1</h1>|' "$ln" > "$tempfile"
+  filename=$(basename "$ln")
+
+  # Move the temp file to the modified-doxygen-output where we will upload it from
+  mv "$tempfile" "docs/modified-doxygen-output/$filename"
+done

--- a/docs/fix-doxygen-titles.sh
+++ b/docs/fix-doxygen-titles.sh
@@ -1,19 +1,18 @@
 #!/bin/bash -ex
 
+# Output this to a temp directory because we can't write to the html directory
+root_directory=$(dirname "$0")
+mkdir "$root_directory"/modified-doxygen-output
+
 # Assume doxygen was run first
-current_directory=$(dirname "$0")
+pushd "`dirname "$0"`"/html
+cp -R html modified-doxygen-output
 
-# Run this in a temp directory because we can't write to the html directory
-mkdir "$current_directory"/modified-doxygen-output
+popd
 
-find "$current_directory/html" -name "*.html" | while read ln
+find ."$root_directory"/modified-doxygen-output -name "*.html" | while read ln
 do
-  tempfile=$(mktemp)
-
   # Make the output SEO friendly by converting the "div" title to the proper "h1"
-  sed -e 's|<div class="title">\([^<]*\)</div>|<h1>\1</h1>|' "$ln" > "$tempfile"
-  filename=$(basename "$ln")
-
-  # Move the temp file to the modified-doxygen-output where we will upload it from
-  mv "$tempfile" "docs/modified-doxygen-output/$filename"
+  sed -i -e 's|<div class="title">\([^<]*\)</div>|<h1>\1</h1>|' "$ln"
 done
+find ."$root_directory"/modified-doxygen-output -iname "*.html-e" | xargs rm


### PR DESCRIPTION
Modify the Doxygen title fixup script to bypass permissions issues writing to `docs/html` directory. This should fix the Doxygen API reference docs publishing pipeline.