### PR TITLE
Add support for Frozen Objects / Realm's

### DIFF
--- a/.idea/.name
+++ b/.idea/.name
@@ -1,1 +1,1 @@
-realm
+RealmCxx

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,28 +5,9 @@ X.Y.Z Release notes (YYYY-MM-DD)
 * None
 
 ### Enhancements
-* None
-
-### Breaking Changes
-* None
-
-### Compatibility
-* Fileformat: Generates files with format v23. Reads and automatically upgrade from fileformat v5.
-
-### Internals
-* Upgraded to Core v13.23.4
-
-----------------------------------------------
-
-0.4.0 Release notes (2022-10-17)
-=============================================================
-
-### Fixed
-* None
-
-### Enhancements
-* Add support for Frozen Realm / Objects. An object can be made frozen by calling the `freeze()` method on the instance. Subsequently, if you can make a frozen Realm / Object live
-  again by calling `thaw()`. It is not recommended to have too many long-lived frozen Realm's / Objects in your application as it may balloon memory consumption.
+* Add support for Frozen Realm / Objects. An object can be made frozen by calling the `freeze()` method on the instance. 
+  Subsequently, if you  can make a frozen Realm / Object live again by calling `thaw()`. 
+  It is not recommended to have too many long-lived frozen Realm's / Objects in your application as it may balloon memory consumption.
 * Add ability to sort `experimental::results` / `managed<std::vector<T>>`. 
 
 ### Breaking Changes
@@ -36,7 +17,7 @@ X.Y.Z Release notes (YYYY-MM-DD)
 * Fileformat: Generates files with format v23. Reads and automatically upgrade from fileformat v5.
 
 ### Internals
-* None
+* Upgraded to Core v13.23.4
 
 ----------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,28 @@ X.Y.Z Release notes (YYYY-MM-DD)
 =============================================================
 
 ### Fixed
+* None
+
+### Enhancements
+* Add support for Frozen Realm / Objects. An object can be made frozen by calling the `freeze()` method on the instance. Subsequently, if you can make a frozen Realm / Object live
+  again by calling `thaw()`. It is not recommended to have too many long-lived frozen Realm's / Objects in your application as it may balloon memory consumption.
+* Add ability to sort `experimental::results` / `managed<std::vector<T>>`. 
+
+### Breaking Changes
+* None
+
+### Compatibility
+* Fileformat: Generates files with format v23. Reads and automatically upgrade from fileformat v5.
+
+### Internals
+* None
+
+----------------------------------------------
+
+0.4.0 Release notes (2022-10-17)
+=============================================================
+
+### Fixed
 * Primary keys could be changed after an object was inserted (since 0.1.0)
 * Using a property type of vector of enums would cause a compilation error (since 0.1.0).
 * Fixed a bug preventing SSL handshake from completing successfully due to failed hostname verification when linking against BoringSSL. (PR #7034)

--- a/src/cpprealm/experimental/db.cpp
+++ b/src/cpprealm/experimental/db.cpp
@@ -5,4 +5,27 @@ namespace realm::experimental {
     ::realm::sync_subscription_set db::subscriptions() {
         return ::realm::sync_subscription_set(m_realm);
     }
+
+    bool db::is_frozen() const {
+        return m_realm.is_frozen();
+    }
+    db db::freeze() {
+        return db(m_realm.freeze());
+    }
+
+    db db::thaw() {
+        return db(m_realm.thaw());
+    }
+
+    void db::invalidate() {
+        m_realm.invalidate();
+    }
+
+    bool operator==(const db& lhs, const db& rhs) {
+        return lhs.m_realm == rhs.m_realm;
+    }
+    bool operator!=(const db& lhs, const db& rhs) {
+        return lhs.m_realm != rhs.m_realm;
+    }
+
 } // namespace realm::experimental

--- a/src/cpprealm/experimental/db.hpp
+++ b/src/cpprealm/experimental/db.hpp
@@ -173,13 +173,22 @@ namespace realm::experimental {
             return m;
         }
 
+        bool is_frozen() const;
+        db freeze();
+        db thaw();
+        void invalidate();
     private:
         friend struct ::realm::thread_safe_reference<experimental::db>;
         db(internal::bridge::realm&& r)
         {
             m_realm = std::move(r);
         }
+
+        std::unordered_map<std::string, internal::bridge::table> m_object_tables;
     };
+
+    bool operator==(const db&, const db&);
+    bool operator!=(const db&, const db&);
 
     template <typename ...Ts>
     inline db open(const db_config& config) {

--- a/src/cpprealm/experimental/managed_list.hpp
+++ b/src/cpprealm/experimental/managed_list.hpp
@@ -138,7 +138,7 @@ namespace realm::experimental {
 
         results<T> sort(bool ascending) {
             auto l = internal::bridge::list(*m_realm, *m_obj, m_key);
-            return results<T>(l.sort({{"self", ascending}}));
+            return ::realm::experimental::results<T>(l.sort(std::vector<internal::bridge::sort_descriptor>({{"self", ascending}})));
         }
     };
 
@@ -313,34 +313,34 @@ namespace realm::experimental {
             return token;
         }
 
-        results<T> where(const std::string &query, const std::vector<realm::mixed>& arguments) {
+        ::realm::experimental::results<T> where(const std::string &query, const std::vector<realm::mixed> &arguments) {
             std::vector<internal::bridge::mixed> mixed_args;
             for(auto& a : arguments)
                 mixed_args.push_back(serialize(a));
-            return results<T>(internal::bridge::results(*m_realm, m_obj->get_target_table(m_key).query(query, std::move(mixed_args))));
+            return ::realm::experimental::results<T>(internal::bridge::results(*m_realm, m_obj->get_target_table(m_key).query(query, std::move(mixed_args))));
         }
 
-        results<T> where(std::function<rbool(experimental::managed<T>&)>&& fn) {
+        ::realm::experimental::results<T> where(std::function<rbool(experimental::managed<T> &)> &&fn) {
             auto schema = m_realm->schema().find(experimental::managed<T>::schema.name);
             auto table_ref = m_obj->get_target_table(m_key);
             auto builder = internal::bridge::query(table_ref);
             auto q = realm::experimental::query<experimental::managed<T>>(builder, std::move(schema), *m_realm);
             auto full_query = fn(q).q;
-            return results<T>(internal::bridge::results(*m_realm, full_query));
+            return ::realm::experimental::results<T>(internal::bridge::results(*m_realm, full_query));
         }
 
-        results<T> sort(const std::string& key_path, bool ascending) {
+        ::realm::experimental::results<T> sort(const std::string &key_path, bool ascending) {
             auto schema = m_realm->schema().find(experimental::managed<T>::schema.name);
             auto group = m_realm->read_group();
             auto table_ref = group.get_table(schema.table_key());
-            return results<T>(internal::bridge::results(*m_realm, table_ref)).sort({{key_path, ascending}});
+            return ::realm::experimental::results<T>(internal::bridge::results(*m_realm, table_ref)).sort({{key_path, ascending}});
         }
 
-        results<T> sort(const std::vector<sort_descriptor>& sort_descriptors) {
+        ::realm::experimental::results<T> sort(const std::vector<internal::bridge::sort_descriptor> &sort_descriptors) {
             auto schema = m_realm->schema().find(experimental::managed<T>::schema.name);
             auto group = m_realm->read_group();
             auto table_ref = group.get_table(schema.table_key());
-            return results<T>(internal::bridge::results(*m_realm, table_ref)).sort(sort_descriptors);
+            return ::realm::experimental::results<T>(internal::bridge::results(*m_realm, table_ref)).sort(sort_descriptors);
         }
     };
 } // namespace realm::experimental

--- a/src/cpprealm/experimental/managed_list.hpp
+++ b/src/cpprealm/experimental/managed_list.hpp
@@ -137,8 +137,8 @@ namespace realm::experimental {
         }
 
         results<T> sort(bool ascending) {
-            auto l = internal::bridge::list(*m_realm, *m_obj, m_key);
-            return ::realm::experimental::results<T>(l.sort(std::vector<internal::bridge::sort_descriptor>({{"self", ascending}})));
+            return results<T>(internal::bridge::list(*m_realm, *m_obj, m_key)
+                                      .sort(std::vector<internal::bridge::sort_descriptor>({{"self", ascending}})));
         }
     };
 
@@ -313,34 +313,32 @@ namespace realm::experimental {
             return token;
         }
 
-        ::realm::experimental::results<T> where(const std::string &query, const std::vector<realm::mixed> &arguments) {
+        results<T> where(const std::string &query, const std::vector<realm::mixed> &arguments) {
             std::vector<internal::bridge::mixed> mixed_args;
             for(auto& a : arguments)
                 mixed_args.push_back(serialize(a));
-            return ::realm::experimental::results<T>(internal::bridge::results(*m_realm, m_obj->get_target_table(m_key).query(query, std::move(mixed_args))));
+            return results<T>(internal::bridge::results(*m_realm, m_obj->get_target_table(m_key).query(query, std::move(mixed_args))));
         }
 
-        ::realm::experimental::results<T> where(std::function<rbool(experimental::managed<T> &)> &&fn) {
+        results<T> where(std::function<rbool(experimental::managed<T> &)> &&fn) {
             auto schema = m_realm->schema().find(experimental::managed<T>::schema.name);
             auto table_ref = m_obj->get_target_table(m_key);
             auto builder = internal::bridge::query(table_ref);
             auto q = realm::experimental::query<experimental::managed<T>>(builder, std::move(schema), *m_realm);
             auto full_query = fn(q).q;
-            return ::realm::experimental::results<T>(internal::bridge::results(*m_realm, full_query));
+            return results<T>(internal::bridge::results(*m_realm, full_query));
         }
 
-        ::realm::experimental::results<T> sort(const std::string &key_path, bool ascending) {
+        results<T> sort(const std::string &key_path, bool ascending) {
             auto schema = m_realm->schema().find(experimental::managed<T>::schema.name);
-            auto group = m_realm->read_group();
-            auto table_ref = group.get_table(schema.table_key());
-            return ::realm::experimental::results<T>(internal::bridge::results(*m_realm, table_ref)).sort({{key_path, ascending}});
+            auto table_ref = m_obj->get_target_table(m_key);
+            return results<T>(internal::bridge::results(*m_realm, table_ref)).sort({{key_path, ascending}});
         }
 
-        ::realm::experimental::results<T> sort(const std::vector<internal::bridge::sort_descriptor> &sort_descriptors) {
+        results<T> sort(const std::vector<internal::bridge::sort_descriptor> &sort_descriptors) {
             auto schema = m_realm->schema().find(experimental::managed<T>::schema.name);
-            auto group = m_realm->read_group();
-            auto table_ref = group.get_table(schema.table_key());
-            return ::realm::experimental::results<T>(internal::bridge::results(*m_realm, table_ref)).sort(sort_descriptors);
+            auto table_ref = m_obj->get_target_table(m_key);
+            return results<T>(internal::bridge::results(*m_realm, table_ref)).sort(sort_descriptors);
         }
     };
 } // namespace realm::experimental

--- a/src/cpprealm/experimental/results.hpp
+++ b/src/cpprealm/experimental/results.hpp
@@ -242,14 +242,14 @@ namespace realm::experimental {
     };
 
     template<typename T>
-    using results_is_trivial = std::enable_if_t<!managed<T>::is_object && !std::is_enum_v<T> && !internal::type_info::is_variant_t<T>::value>;
+    using results_is_primitive = std::enable_if_t<!managed<T>::is_object && !std::is_enum_v<T> && !internal::type_info::is_variant_t<T>::value>;
     template<typename T>
     using results_is_enum = std::enable_if_t<!managed<T>::is_object && std::is_enum_v<T> && !internal::type_info::is_variant_t<T>::value>;
     template<typename T>
     using results_is_mixed = std::enable_if_t<!managed<T>::is_object && !std::is_enum_v<T> && internal::type_info::is_variant_t<T>::value>;
 
     template<typename T, typename Derived>
-    struct results_base<T, Derived, results_is_trivial<T>> : public results_common_base<T, Derived> {
+    struct results_base<T, Derived, results_is_primitive<T>> : public results_common_base<T, Derived> {
         explicit results_base(internal::bridge::results &&parent)
             : results_common_base<T, Derived>(std::move(parent)) {
         }

--- a/src/cpprealm/internal/bridge/list.cpp
+++ b/src/cpprealm/internal/bridge/list.cpp
@@ -4,8 +4,11 @@
 #include <cpprealm/internal/bridge/mixed.hpp>
 #include <cpprealm/internal/bridge/obj.hpp>
 #include <cpprealm/internal/bridge/table.hpp>
+#include <cpprealm/internal/bridge/results.hpp>
 
+#include "realm/object-store/shared_realm.hpp"
 #include <realm/object-store/list.hpp>
+#include <realm/object-store/results.hpp>
 
 namespace realm::internal::bridge {
 
@@ -115,6 +118,16 @@ namespace realm::internal::bridge {
 
     list::operator List() const {
         return *get_list();
+    }
+
+    results list::sort(const std::vector<sort_descriptor>& descriptors) {
+        std::vector<std::pair<std::string, bool>> results_descriptors;
+        results_descriptors.resize(descriptors.size());
+        std::transform(descriptors.begin(), descriptors.end(), results_descriptors.begin(),
+                       [](const sort_descriptor& sd) -> std::pair<std::string, bool>{
+                           return sd.operator std::pair<std::string, bool>();
+                       });
+        return get_list()->sort(results_descriptors);
     }
 
     table list::get_table() const {

--- a/src/cpprealm/internal/bridge/list.cpp
+++ b/src/cpprealm/internal/bridge/list.cpp
@@ -7,8 +7,8 @@
 #include <cpprealm/internal/bridge/table.hpp>
 
 #include <realm/object-store/list.hpp>
-#include "realm/object-store/shared_realm.hpp"
 #include <realm/object-store/results.hpp>
+#include <realm/object-store/shared_realm.hpp>
 
 namespace realm::internal::bridge {
 

--- a/src/cpprealm/internal/bridge/list.cpp
+++ b/src/cpprealm/internal/bridge/list.cpp
@@ -3,11 +3,11 @@
 #include <cpprealm/internal/bridge/col_key.hpp>
 #include <cpprealm/internal/bridge/mixed.hpp>
 #include <cpprealm/internal/bridge/obj.hpp>
-#include <cpprealm/internal/bridge/table.hpp>
 #include <cpprealm/internal/bridge/results.hpp>
+#include <cpprealm/internal/bridge/table.hpp>
 
-#include "realm/object-store/shared_realm.hpp"
 #include <realm/object-store/list.hpp>
+#include "realm/object-store/shared_realm.hpp"
 #include <realm/object-store/results.hpp>
 
 namespace realm::internal::bridge {

--- a/src/cpprealm/internal/bridge/list.hpp
+++ b/src/cpprealm/internal/bridge/list.hpp
@@ -31,6 +31,8 @@ namespace realm::internal::bridge {
     struct table;
     struct notification_token;
     struct collection_change_callback;
+    struct results;
+    struct sort_descriptor;
 
     struct list {
         list();
@@ -84,6 +86,9 @@ namespace realm::internal::bridge {
         size_t find(const timestamp &);
         size_t find(const binary&);
         size_t find(const obj_key&);
+
+        results sort(const std::vector<sort_descriptor>&);
+
         notification_token add_notification_callback(std::shared_ptr<collection_change_callback>);
     private:
         template <typename ValueType>

--- a/src/cpprealm/internal/bridge/obj.hpp
+++ b/src/cpprealm/internal/bridge/obj.hpp
@@ -120,7 +120,7 @@ namespace realm::internal::bridge {
         [[nodiscard]] table get_target_table(col_key) const noexcept;
         [[nodiscard]] bool is_null(const col_key& col_key) const;
         [[nodiscard]] bool is_valid() const;
-        obj get_linked_object(const col_key& col_key);
+        [[nodiscard]] obj get_linked_object(const col_key& col_key);
         template <typename T>
         T get(const col_key& col_key) const {
             if constexpr (is_optional<T>::value) {

--- a/src/cpprealm/internal/bridge/query.cpp
+++ b/src/cpprealm/internal/bridge/query.cpp
@@ -198,6 +198,14 @@ namespace realm::internal::bridge {
         return *this;
     }
 
+    std::string query::description() const {
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+        return reinterpret_cast<const Query *>(&m_query)->get_description();
+#else
+        return m_query->get_description();
+#endif
+    }
+
     __generate_query_operator_case_sensitive(equal, std::string_view)
     __generate_query_operator_case_sensitive(not_equal, std::string_view)
     __generate_query_operator_case_sensitive(contains, std::string_view)

--- a/src/cpprealm/internal/bridge/query.hpp
+++ b/src/cpprealm/internal/bridge/query.hpp
@@ -124,6 +124,8 @@ namespace realm::internal::bridge {
         query& equal(col_key column_key, bool value);
         query& not_equal(col_key column_key, bool value);
         using underlying = Query;
+
+        std::string description() const;
     private:
         inline Query* get_query();
 #ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES

--- a/src/cpprealm/internal/bridge/realm.hpp
+++ b/src/cpprealm/internal/bridge/realm.hpp
@@ -24,6 +24,7 @@ namespace realm::internal::bridge {
     struct table;
     struct dictionary;
     struct thread_safe_reference;
+    struct obj;
     struct object;
     struct async_open_task;
     struct sync_session;
@@ -192,6 +193,11 @@ namespace realm::internal::bridge {
         [[nodiscard]] std::shared_ptr<struct scheduler> scheduler() const;
         static async_open_task get_synchronized_realm(const config&);
         bool refresh();
+        bool is_frozen() const;
+        realm freeze(); // throws
+        realm thaw(); // throws
+        void invalidate();
+        obj import_copy_of(const obj&) const;
         [[nodiscard]] std::optional<sync_session> get_sync_session() const;
     private:
         std::shared_ptr<Realm> m_realm;

--- a/src/cpprealm/internal/bridge/results.cpp
+++ b/src/cpprealm/internal/bridge/results.cpp
@@ -211,7 +211,7 @@ namespace realm::internal::bridge {
     template <>
     mixed get(results& res, size_t v) {
 #ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
-        return mixed(reinterpret_cast<Results*>(&res.m_results)->get<Mixed>(v));
+        return mixed(reinterpret_cast<Results*>(&res.m_results)->get_any(v));
 #else
         return mixed(res.m_results->get<Mixed>(v));
 #endif

--- a/src/cpprealm/internal/bridge/results.cpp
+++ b/src/cpprealm/internal/bridge/results.cpp
@@ -7,6 +7,10 @@
 #include <realm/object-store/results.hpp>
 
 namespace realm::internal::bridge {
+    sort_descriptor::operator std::pair<std::string, bool>() const {
+        return {key_path, ascending};
+    }
+
     results::results() {
 #ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
         new (&m_results) Results();
@@ -99,12 +103,117 @@ namespace realm::internal::bridge {
 #endif
     }
 
+    results results::sort(const std::vector<sort_descriptor>& descriptors) {
+        std::vector<std::pair<std::string, bool>> results_descriptors;
+        results_descriptors.resize(descriptors.size());
+        std::transform(descriptors.begin(), descriptors.end(), results_descriptors.begin(),
+                       [](const sort_descriptor& sd) -> std::pair<std::string, bool>{
+            return sd.operator std::pair<std::string, bool>();
+        });
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+        return reinterpret_cast<const Results*>(&m_results)->sort(results_descriptors);
+#else
+        return m_results->sort(results_descriptors);
+#endif
+    }
+
     template <>
     obj get(results& res, size_t v) {
 #ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
         return reinterpret_cast<Results*>(&res.m_results)->get(v);
 #else
         return res.m_results->get(v);
+#endif
+    }
+
+    template <>
+    int64_t get(results& res, size_t v) {
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+        return reinterpret_cast<Results*>(&res.m_results)->get<int64_t>(v);
+#else
+        return res.m_results->get<int64_t>(v);
+#endif
+    }
+
+    template <>
+    bool get(results& res, size_t v) {
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+        return reinterpret_cast<Results*>(&res.m_results)->get<bool>(v);
+#else
+        return res.m_results->get<bool>(v);
+#endif
+    }
+
+    template <>
+    double get(results& res, size_t v) {
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+        return reinterpret_cast<Results*>(&res.m_results)->get<double>(v);
+#else
+        return res.m_results->get<double>(v);
+#endif
+    }
+
+    template <>
+    std::string get(results& res, size_t v) {
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+        return reinterpret_cast<Results*>(&res.m_results)->get<StringData>(v);
+#else
+        return res.m_results->get<StringData>(v);
+#endif
+    }
+
+    template <>
+    ::realm::uuid get(results& res, size_t v) {
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+        return uuid(reinterpret_cast<Results*>(&res.m_results)->get<UUID>(v)).operator ::realm::uuid();
+#else
+        return uuid(res.m_results->get<UUID>(v)).operator ::realm::uuid();
+#endif
+    }
+
+    template <>
+    ::realm::object_id get(results& res, size_t v) {
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+        return object_id(reinterpret_cast<Results*>(&res.m_results)->get<ObjectId>(v)).operator ::realm::object_id();
+#else
+        return object_id(res.m_results->get<ObjectId>(v)).operator ::realm::object_id();
+#endif
+    }
+
+    template <>
+    ::realm::decimal128 get(results& res, size_t v) {
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+        return decimal128(reinterpret_cast<Results*>(&res.m_results)->get<Decimal128>(v)).operator ::realm::decimal128();
+#else
+        return decimal128(res.m_results->get<Decimal128>(v)).operator ::realm::decimal128();
+#endif
+    }
+
+    template <>
+    std::vector<uint8_t> get(results& res, size_t v) {
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+        return binary(reinterpret_cast<Results*>(&res.m_results)->get<BinaryData>(v)).operator std::vector<uint8_t>();
+#else
+        return binary(res.m_results->get<BinaryData>(v)).operator std::vector<uint8_t>();
+#endif
+    }
+
+    template <>
+    std::chrono::time_point<std::chrono::system_clock> get(results& res, size_t v) {
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+        return timestamp(reinterpret_cast<Results*>(&res.m_results)->get<Timestamp>(v)).operator std::chrono::time_point<std::chrono::system_clock>();
+#else
+        return timestamp(res.m_results->get<Timestamp>(v)).operator std::chrono::time_point<std::chrono::system_clock>();
+#endif
+    }
+
+
+    template <>
+    mixed get(results& res, size_t v) {
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+        return mixed(reinterpret_cast<Results*>(&res.m_results)->get<Mixed>(v));
+#else
+        return mixed(res.m_results->get<Mixed>(v));
 #endif
     }
 

--- a/src/cpprealm/internal/bridge/results.hpp
+++ b/src/cpprealm/internal/bridge/results.hpp
@@ -16,6 +16,15 @@ namespace realm::internal::bridge {
     struct obj;
     struct collection_change_set;
 
+    struct sort_descriptor {
+        std::string key_path;
+        bool ascending;
+    private:
+        friend struct results;
+        friend struct list;
+        operator std::pair<std::string, bool>() const;
+    };
+
     struct results {
         results();
         results(const results& other) ;
@@ -30,6 +39,7 @@ namespace realm::internal::bridge {
         [[nodiscard]] realm get_realm() const;
         [[nodiscard]] table get_table() const;
         results(const realm&, const query&);
+        results sort(const std::vector<sort_descriptor>&);
         notification_token add_notification_callback(std::shared_ptr<collection_change_callback>&&);
     private:
         template <typename T>
@@ -45,6 +55,26 @@ namespace realm::internal::bridge {
     T get(results&, size_t);
     template <>
     obj get(results&, size_t);
+    template <>
+    int64_t get(results&, size_t);
+    template <>
+    bool get(results&, size_t);
+    template <>
+    double get(results&, size_t);
+    template <>
+    std::string get(results&, size_t);
+    template <>
+    ::realm::uuid get(results&, size_t);
+    template <>
+    ::realm::object_id get(results&, size_t);
+    template <>
+    ::realm::decimal128 get(results&, size_t);
+    template <>
+    std::vector<uint8_t> get(results&, size_t);
+    template <>
+    std::chrono::time_point<std::chrono::system_clock> get(results&, size_t);
+    template <>
+    mixed get(results&, size_t);
 }
 
 #endif //CPP_REALM_BRIDGE_RESULTS_HPP

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -35,7 +35,8 @@ if(MSVC)
             experimental/db/realm_tests.cpp
             experimental/db/results_tests.cpp
             experimental/db/run_loop_tests.cpp
-            experimental/db/string_tests.cpp)
+            experimental/db/string_tests.cpp
+            experimental/db/frozen_tests.cpp)
     target_compile_definitions(cpprealm_sync_tests PUBLIC CPPREALM_ENABLE_SYNC_TESTS)
 
     set_property(TARGET cpprealm_sync_tests PROPERTY
@@ -80,7 +81,9 @@ else()
             experimental/db/string_tests.cpp
             experimental/db/performance_tests.cpp
             experimental/db/numeric_tests.cpp
-            experimental/db/set_tests.cpp)
+            experimental/db/set_tests.cpp
+            experimental/db/frozen_tests.cpp)
+
     target_compile_definitions(cpprealm_sync_tests PUBLIC CPPREALM_ENABLE_SYNC_TESTS)
 
     if(ENABLE_ALPHA_SDK)

--- a/tests/experimental/db/binary_tests.cpp
+++ b/tests/experimental/db/binary_tests.cpp
@@ -1,5 +1,5 @@
-#include "test_objects.hpp"
 #include "../../main.hpp"
+#include "test_objects.hpp"
 
 TEST_CASE("binary", "[binary]") {
     realm_path path;

--- a/tests/experimental/db/date_tests.cpp
+++ b/tests/experimental/db/date_tests.cpp
@@ -1,5 +1,5 @@
-#include "test_objects.hpp"
 #include "../../main.hpp"
+#include "test_objects.hpp"
 
 TEST_CASE("date", "[date]") {
     realm_path path;

--- a/tests/experimental/db/decimal_tests.cpp
+++ b/tests/experimental/db/decimal_tests.cpp
@@ -1,5 +1,5 @@
-#include "test_objects.hpp"
 #include "../../main.hpp"
+#include "test_objects.hpp"
 
 using namespace realm;
 

--- a/tests/experimental/db/embedded_object_tests.cpp
+++ b/tests/experimental/db/embedded_object_tests.cpp
@@ -1,5 +1,5 @@
-#include "test_objects.hpp"
 #include "../../main.hpp"
+#include "test_objects.hpp"
 
 TEST_CASE("embedded_objects") {
     realm_path path;

--- a/tests/experimental/db/frozen_tests.cpp
+++ b/tests/experimental/db/frozen_tests.cpp
@@ -1,0 +1,19 @@
+#include "test_objects.hpp"
+#include "../../main.hpp"
+
+namespace realm::experimental {
+    TEST_CASE("frozen") {
+        SECTION("realm") {
+            realm_path path;
+            realm::db_config config;
+            config.set_path(path);
+            auto realm = db(std::move(config));
+            auto o = realm.write([&] {
+                return realm.add(AllTypesObject());
+            });
+
+            realm.freeze();
+
+        }
+    }
+}

--- a/tests/experimental/db/frozen_tests.cpp
+++ b/tests/experimental/db/frozen_tests.cpp
@@ -12,8 +12,26 @@ namespace realm::experimental {
                 return realm.add(AllTypesObject());
             });
 
-            realm.freeze();
+            //realm.freeze();
 
+
+            // List:
+            // testIsFrozen
+            // testFreezingObjectReturnsSelf
+            // testAccessFrozenObjectFromDifferentThread
+            // testObserveFrozenArray
+            // testQueryFrozenArray
+            // testFrozenListsDoNotUpdate
+
+            // Same for Map and Set
+
+
+            // testLinkingObjectsOnFrozenObject
+
+            // testMutateFrozenObject
+            // testFrozenObjectEquality
+
+            // Realm
         }
     }
 }

--- a/tests/experimental/db/frozen_tests.cpp
+++ b/tests/experimental/db/frozen_tests.cpp
@@ -2,36 +2,294 @@
 #include "../../main.hpp"
 
 namespace realm::experimental {
-    TEST_CASE("frozen") {
-        SECTION("realm") {
-            realm_path path;
-            realm::db_config config;
-            config.set_path(path);
+    TEST_CASE("frozen_realm") {
+        realm_path path;
+        realm::db_config config;
+        config.set_path(path);
+
+        SECTION("is_frozen") {
             auto realm = db(std::move(config));
-            auto o = realm.write([&] {
+            auto frozen_realm = realm.freeze();
+            CHECK(frozen_realm.is_frozen());
+
+            auto frozen_realm_copy = frozen_realm;
+            CHECK(frozen_realm_copy.is_frozen());
+        }
+
+        SECTION("refresh_frozen") {
+            auto realm = db(std::move(config));
+            auto frozen_realm = db(realm.freeze());
+            CHECK(frozen_realm.is_frozen());
+
+            realm.write([&realm]() {
+                realm.add(AllTypesObject());
+            });
+
+            CHECK_FALSE(frozen_realm.refresh());
+            CHECK(frozen_realm.objects<AllTypesObject>().size() == 0);
+        }
+
+        SECTION("forbidden_methods") {
+            auto realm = db(std::move(config));
+            auto frozen_realm = db(realm.freeze());
+            CHECK(frozen_realm.is_frozen());
+
+            CHECK_THROWS_WITH(frozen_realm.begin_write(), "Can't perform transactions on a frozen Realm");
+            CHECK_THROWS_WITH(frozen_realm.objects<AllTypesObject>().observe([](auto) { }), "Notifications are not available on frozen collections since they do not change.");
+        }
+
+        SECTION("object_is_frozen_from_results") {
+            auto realm = db(std::move(config));
+            realm.write([&realm]() {
+                realm.add(AllTypesObject());
+            });
+            auto frozen_realm = db(realm.freeze());
+            frozen_realm.invalidate();
+            auto managed_obj = frozen_realm.objects<AllTypesObject>()[0];
+            CHECK(managed_obj.is_frozen());
+        }
+
+        SECTION("thaw") {
+            auto realm = db(std::move(config));
+            realm.write([&realm]() {
+                realm.add(AllTypesObject());
+            });
+            auto frozen_realm = realm.freeze();
+            CHECK(frozen_realm.is_frozen());
+
+            auto thawed = frozen_realm.thaw();
+            CHECK_FALSE(thawed.is_frozen());
+            thawed.write([&thawed]() {
+                auto o = AllTypesObject();
+                o._id = 2;
+                thawed.add(std::move(o));
+            });
+            thawed.write([&thawed]() {
+                auto o = AllTypesObject();
+                o._id = 3;
+                thawed.add(std::move(o));
+            });
+            CHECK_FALSE(thawed.refresh());
+            CHECK(thawed.objects<AllTypesObject>().size() == 3);
+
+            CHECK(frozen_realm.is_frozen());
+            CHECK_FALSE(frozen_realm.refresh());
+            CHECK(frozen_realm.objects<AllTypesObject>().size() == 1);
+        }
+
+        SECTION("thaw_different_thread") {
+            auto realm = db(std::move(config));
+            realm.write([&realm]() {
+                realm.add(AllTypesObject());
+            });
+            auto frozen_realm = realm.freeze();
+            CHECK(frozen_realm.is_frozen());
+
+            auto async = std::async(std::launch::async, [&frozen_realm](){
+                auto thawed = frozen_realm.thaw();
+                CHECK_FALSE(thawed.is_frozen());
+                thawed.write([&thawed]() {
+                    auto o = AllTypesObject();
+                    o._id = 2;
+                    thawed.add(std::move(o));
+                });
+                thawed.write([&thawed]() {
+                    auto o = AllTypesObject();
+                    o._id = 3;
+                    thawed.add(std::move(o));
+                });
+                CHECK_FALSE(thawed.refresh());
+                CHECK(thawed.objects<AllTypesObject>().size() == 3);
+
+                CHECK(frozen_realm.is_frozen());
+                CHECK_FALSE(frozen_realm.refresh());
+                CHECK(frozen_realm.objects<AllTypesObject>().size() == 1);
+                return true;
+            });
+            CHECK(async.get());
+        }
+
+        SECTION("thaw_previous_version") {
+            auto realm = db(std::move(config));
+            auto frozen_realm = realm.freeze();
+            CHECK(frozen_realm.is_frozen());
+            realm.write([&realm]() {
+                realm.add(AllTypesObject());
+            });
+            CHECK(frozen_realm.objects<AllTypesObject>().size() == 0);
+
+            auto thawed = frozen_realm.thaw();
+            CHECK_FALSE(thawed.is_frozen());
+            CHECK(thawed.refresh());
+            CHECK(thawed.objects<AllTypesObject>().size() == 1);
+        }
+
+        SECTION("freeze_same_realm_returns_self") {
+            db realm = db(std::move(config));
+            db frozen_realm1 = realm.freeze();
+            db frozen_realm2 = realm.freeze();
+            db frozen_realm3 = frozen_realm2.freeze();
+
+            CHECK(frozen_realm1 == frozen_realm2);
+            CHECK(frozen_realm2 == frozen_realm3);
+            CHECK_FALSE(realm == frozen_realm1);
+        }
+
+        SECTION("frozen_object") {
+            auto realm = db(std::move(config));
+            auto object = realm.write([&realm]() {
                 return realm.add(AllTypesObject());
             });
 
-            //realm.freeze();
+            auto frozen_object = object.freeze();
+            CHECK(frozen_object.is_frozen());
+            auto same_frozen_object = frozen_object.freeze();
+            CHECK(frozen_object == same_frozen_object);
+            CHECK_FALSE(frozen_object == object);
+        }
 
+        SECTION("frozen_object_different_thread") {
+            auto realm = db(std::move(config));
+            auto object = realm.write([&realm]() {
+                auto o = AllTypesObject();
+                o.str_col = "bar";
+                o._id = 1;
 
-            // List:
-            // testIsFrozen
-            // testFreezingObjectReturnsSelf
-            // testAccessFrozenObjectFromDifferentThread
-            // testObserveFrozenArray
-            // testQueryFrozenArray
-            // testFrozenListsDoNotUpdate
+                auto link = AllTypesObjectLink();
+                link._id = 1;
+                link.str_col = "foobar";
 
-            // Same for Map and Set
+                o.opt_obj_col = &link;
+                o.list_obj_col.push_back(&link);
+                o.set_obj_col.insert(&link);
+                o.map_link_col["foo"] = &link;
 
+                return realm.add(std::move(o));
+            });
 
-            // testLinkingObjectsOnFrozenObject
+            auto frozen_object = object.freeze();
+            CHECK(frozen_object.is_frozen());
 
-            // testMutateFrozenObject
-            // testFrozenObjectEquality
+            auto async = std::async(std::launch::async, [&frozen_object]() {
+                CHECK(frozen_object.is_frozen());
+                CHECK(frozen_object._id == 1);
+                CHECK(frozen_object.str_col == "bar");
+                CHECK(frozen_object.opt_obj_col->_id == 1);
+                CHECK(frozen_object.opt_obj_col->str_col == "foobar");
+                CHECK(frozen_object.list_obj_col[0]->str_col == "foobar");
+                CHECK(frozen_object.map_link_col["foo"]->str_col == "foobar");
+                CHECK((*frozen_object.set_obj_col.find(frozen_object.opt_obj_col)).str_col == "foobar");
 
-            // Realm
+                return true;
+            });
+            CHECK(async.get());
+        }
+
+        SECTION("frozen_object_observe") {
+            auto realm = db(std::move(config));
+            auto object = realm.write([&realm]() {
+                auto o = AllTypesObject();
+                o._id = 1;
+                return realm.add(std::move(o));
+            });
+
+            auto frozen_object = object.freeze();
+            CHECK(frozen_object.is_frozen());
+
+            CHECK_THROWS_WITH(frozen_object.observe([](auto) { }), "Notifications are not available on frozen collections since they do not change.");
+            CHECK_THROWS_WITH(frozen_object.list_int_col.observe([](auto) { }), "Notifications are not available on frozen collections since they do not change.");
+            CHECK_THROWS_WITH(frozen_object.list_obj_col.observe([](auto) { }), "Notifications are not available on frozen collections since they do not change.");
+            CHECK_THROWS_WITH(frozen_object.set_int_col.observe([](auto) { }), "Notifications are not available on frozen collections since they do not change.");
+            CHECK_THROWS_WITH(frozen_object.set_obj_col.observe([](auto) { }), "Notifications are not available on frozen collections since they do not change.");
+            CHECK_THROWS_WITH(frozen_object.map_int_col.observe([](auto) { }), "Notifications are not available on frozen collections since they do not change.");
+            CHECK_THROWS_WITH(frozen_object.map_link_col.observe([](auto) { }), "Notifications are not available on frozen collections since they do not change.");
+        }
+
+        SECTION("frozen_object_comparison") {
+            auto realm = db(std::move(config));
+            auto object = realm.write([&realm]() {
+                auto o = AllTypesObject();
+                o._id = 1;
+                return realm.add(std::move(o));
+            });
+
+            auto frozen_object = object.freeze();
+            CHECK(frozen_object.is_frozen());
+            auto frozen_object2 = object.freeze();
+            CHECK(frozen_object2.is_frozen());
+
+            CHECK(frozen_object == frozen_object2);
+            CHECK_FALSE(frozen_object != frozen_object2);
+            CHECK(object != frozen_object2);
+            CHECK_FALSE(object == frozen_object2);
+        }
+
+        SECTION("frozen_object_mutate") {
+            auto realm = db(std::move(config));
+            auto object = realm.write([&realm]() {
+                auto o = AllTypesObject();
+                o._id = 1;
+                return realm.add(std::move(o));
+            });
+
+            auto frozen_object = object.freeze();
+            realm.write([&realm, &object]() {
+                object.str_col = "doesn't throw exception";
+            });
+
+            CHECK_THROWS_WITH(
+                realm.write([&realm, &frozen_object]() {
+                    frozen_object.str_col = "throws exception";
+                }), "Trying to modify database while in read transaction"
+            );
+        }
+
+        SECTION("frozen_object_linking_objects") {
+            auto realm = db(std::move(config));
+
+            realm.write([&realm]() {
+                Dog dog;
+                dog._id = 1;
+                dog.name = "Spot";
+
+                Person person;
+                person.name = "John";
+                person._id = 1;
+                person.dog = &dog;
+                realm.add(std::move(person));
+            });
+
+            auto dog = realm.objects<Dog>().freeze()[0];
+            auto frozen_object = dog;
+            auto owner = frozen_object.owners[0];
+            CHECK(owner.is_frozen());
+            CHECK(owner.name == "John");
+        }
+
+        SECTION("frozen_thawed_results") {
+            auto realm = db(std::move(config));
+
+            realm.write([&realm]() {
+                Dog dog;
+                dog._id = 1;
+                dog.name = "Spot";
+
+                Person person;
+                person.name = "John";
+                person._id = 1;
+                person.dog = &dog;
+                realm.add(std::move(person));
+            });
+
+            auto frozen_results = realm.objects<Dog>().freeze();
+            auto dog = frozen_results[0];
+            CHECK(dog.is_frozen());
+            CHECK(frozen_results.is_frozen());
+            CHECK_THROWS_WITH(frozen_results.observe([](auto) { }), "Notifications are not available on frozen collections since they do not change.");
+            auto thawed_results = frozen_results.thaw();
+            CHECK_FALSE(thawed_results.is_frozen());
+            dog = thawed_results[0];
+            CHECK_FALSE(dog.is_frozen());
         }
     }
 }

--- a/tests/experimental/db/frozen_tests.cpp
+++ b/tests/experimental/db/frozen_tests.cpp
@@ -1,5 +1,5 @@
-#include "test_objects.hpp"
 #include "../../main.hpp"
+#include "test_objects.hpp"
 
 namespace realm::experimental {
     TEST_CASE("frozen_realm") {

--- a/tests/experimental/db/list_tests.cpp
+++ b/tests/experimental/db/list_tests.cpp
@@ -592,8 +592,8 @@ TEST_CASE("list", "[list]") {
             managed_obj.list_date_col.push_back(date2);
             managed_obj.list_date_col.push_back(date3);
 
-            managed_obj.list_mixed_col.push_back(realm::mixed(1));
-            managed_obj.list_mixed_col.push_back(realm::mixed("foo"));
+            managed_obj.list_mixed_col.push_back(realm::mixed((int64_t)1));
+            managed_obj.list_mixed_col.push_back(realm::mixed(std::string("foo")));
             managed_obj.list_mixed_col.push_back(realm::mixed(date1));
 
             managed_obj.list_enum_col.push_back(experimental::AllTypesObject::Enum::one);
@@ -614,11 +614,11 @@ TEST_CASE("list", "[list]") {
         CHECK(object_results[0]._id == 1);
         CHECK(object_results.size() == 1);
 
-        auto object_results2 = managed_obj.list_obj_col.where("_id == $0", {1});
+        auto object_results2 = managed_obj.list_obj_col.where("_id == $0", std::vector<realm::mixed>({realm::mixed((int64_t)1)}));
         CHECK(object_results2[0]._id == 1);
 
         auto sorted_object_results1 = managed_obj.list_obj_col.sort("str_col", true);
-        auto sorted_object_results2 = managed_obj.list_obj_col.sort({{"str_col", false}});
+        auto sorted_object_results2 = managed_obj.list_obj_col.sort(std::vector<realm::experimental::sort_descriptor>({{"str_col", false}}));
         auto sorted_object_results_embedded1 = managed_obj.list_embedded_obj_col.sort("str_col", true);
         auto sorted_object_results_embedded2 = managed_obj.list_embedded_obj_col.sort({{"str_col", false}});
 
@@ -727,14 +727,15 @@ TEST_CASE("list", "[list]") {
         CHECK(sorted_object_results20[2] == date1);
 
         auto sorted_object_results21 = managed_obj.list_mixed_col.sort(true);
-        CHECK(sorted_object_results21[0] == realm::mixed(1));
-        CHECK(sorted_object_results21[1] == realm::mixed("foo"));
+        CHECK(sorted_object_results21[0] == realm::mixed((int64_t)1));
+
+        CHECK(sorted_object_results21[1] == realm::mixed(std::string("foo")));
         CHECK(sorted_object_results21[2] == realm::mixed(date1));
 
         auto sorted_object_results22 = managed_obj.list_mixed_col.sort(false);
         CHECK(sorted_object_results22[0] == realm::mixed(date1));
-        CHECK(sorted_object_results22[1] == realm::mixed("foo"));
-        CHECK(sorted_object_results22[2] == realm::mixed(1));
+        CHECK(sorted_object_results22[1] == realm::mixed(std::string("foo")));
+        CHECK(sorted_object_results22[2] == realm::mixed((int64_t)1));
 
         auto sorted_object_results23 = managed_obj.list_enum_col.sort(true);
         CHECK(sorted_object_results23[0] == experimental::AllTypesObject::Enum::one);

--- a/tests/experimental/db/list_tests.cpp
+++ b/tests/experimental/db/list_tests.cpp
@@ -47,6 +47,7 @@ TEST_CASE("list", "[list]") {
         CHECK(obj.list_int_col[0] == 42);
 
         realm::experimental::AllTypesObjectLink o1;
+        o1._id = 0;
         o1.str_col = "Fido";
         obj.list_obj_col.push_back(&o1);
         CHECK(obj.list_obj_col[0]->str_col == "Fido");

--- a/tests/experimental/db/object_id_tests.cpp
+++ b/tests/experimental/db/object_id_tests.cpp
@@ -1,5 +1,5 @@
-#include "test_objects.hpp"
 #include "../../main.hpp"
+#include "test_objects.hpp"
 
 using namespace realm;
 

--- a/tests/experimental/db/object_tests.cpp
+++ b/tests/experimental/db/object_tests.cpp
@@ -1,5 +1,5 @@
-#include "test_objects.hpp"
 #include "../../main.hpp"
+#include "test_objects.hpp"
 
 namespace realm::experimental {
 

--- a/tests/experimental/db/query_tests.cpp
+++ b/tests/experimental/db/query_tests.cpp
@@ -6,6 +6,9 @@ namespace realm::experimental {
 #define query_results_size(Cls, fn)  \
     realm.template objects<Cls>().where(fn).size()
 
+#define query_string_results_size(Cls, str, args...)  \
+    realm.template objects<Cls>().where(str, args).size()
+
     TEST_CASE("query") {
         realm_path path;
         db_config config;
@@ -46,31 +49,57 @@ namespace realm::experimental {
 
             // With literal as RHS.
             CHECK(query_results_size(AllTypesObject, [](auto &o) { return o._id == 123; }) == 1);
+            CHECK(query_string_results_size(AllTypesObject, "_id == $0", {123}) == 1);
+
             CHECK(query_results_size(AllTypesObject, [](auto &o) { return o._id != 123; }) == 0);
+            CHECK(query_string_results_size(AllTypesObject, "_id != $0", {123}) == 0);
+
             CHECK(query_results_size(AllTypesObject, [](auto &o) { return o.str_col == "foo bar"; }) == 1);
+            CHECK(query_string_results_size(AllTypesObject, "str_col == $0", {"foo bar"}) == 1);
+
             CHECK(query_results_size(AllTypesObject, [](auto &o) { return o.str_col != "foo bar"; }) == 0);
+            CHECK(query_string_results_size(AllTypesObject, "str_col != $0", {"foo bar"}) == 0);
+
             CHECK(query_results_size(AllTypesObject, [](auto &o) {
                       return o.binary_col == std::vector<uint8_t>({0, 1, 2, 3});
                   }) == 1);
+
+            CHECK(query_string_results_size(AllTypesObject, "binary_col == $0", {std::vector<uint8_t>({0, 1, 2, 3})}) == 1);
+
             CHECK(query_results_size(AllTypesObject,
                                      [](auto &o) { return o.binary_col != std::vector<uint8_t>({0, 1, 2, 3}); }) == 0);
+            CHECK(query_string_results_size(AllTypesObject, "binary_col != $0", {std::vector<uint8_t>({0, 1, 2, 3})}) == 0);
+
             CHECK(query_results_size(AllTypesObject, [](auto &o) { return o.enum_col == AllTypesObject::Enum::two; }) == 1);
+            CHECK(query_string_results_size(AllTypesObject, "enum_col == $0", {static_cast<int>(AllTypesObject::Enum::two)}) == 1);
+
             CHECK(query_results_size(AllTypesObject, [](auto &o) { return o.enum_col != AllTypesObject::Enum::two; }) == 0);
+            CHECK(query_string_results_size(AllTypesObject, "enum_col != $0", {static_cast<int>(AllTypesObject::Enum::two)}) == 0);
+
             CHECK(query_results_size(AllTypesObject, [&date](auto &o) {
                       return o.date_col == std::chrono::system_clock::from_time_t(date);
                   }) == 1);
+            CHECK(query_string_results_size(AllTypesObject, "date_col == $0", {std::chrono::system_clock::from_time_t(date)}) == 1);
+
             CHECK(query_results_size(AllTypesObject, [&date](auto &o) {
                       return o.date_col != std::chrono::system_clock::from_time_t(date);
                   }) == 0);
+            CHECK(query_string_results_size(AllTypesObject, "date_col != $0", {std::chrono::system_clock::from_time_t(date)}) == 0);
+
             CHECK(query_results_size(AllTypesObject, [](auto &o) {
                       return o.uuid_col == realm::uuid("18de7916-7f84-11ec-a8a3-0242ac120002");
                   }) == 1);
+            CHECK(query_string_results_size(AllTypesObject, "uuid_col == $0", {realm::uuid("18de7916-7f84-11ec-a8a3-0242ac120002")}) == 1);
+
             CHECK(query_results_size(AllTypesObject, [](auto &o) {
                       return o.uuid_col != realm::uuid("18de7916-7f84-11ec-a8a3-0242ac120002");
                   }) == 0);
+            CHECK(query_string_results_size(AllTypesObject, "uuid_col != $0", {realm::uuid("18de7916-7f84-11ec-a8a3-0242ac120002")}) == 0);
 
-            auto x = realm.objects<AllTypesObject>().where([](auto& o) { return o.opt_obj_col->str_col == "foo"; }).size();
-            CHECK(x == 1);
+            auto objs = realm.objects<AllTypesObject>().where([](auto& o) { return o.opt_obj_col->str_col == "foo"; }).size();
+            CHECK(objs == 1);
+            objs = realm.objects<AllTypesObject>().where("opt_obj_col.str_col == $0", {"foo"}).size();
+            CHECK(objs == 1);
         }
 
         SECTION("tsq_greater_less_than", "[query]") {
@@ -93,28 +122,48 @@ namespace realm::experimental {
 
             // With literal as RHS.
             CHECK(query_results_size(AllTypesObject, [](auto &o) { return o._id > 123; }) == 0);
+            CHECK(query_string_results_size(AllTypesObject, "_id > $0", {123}) == 0);
+
             CHECK(query_results_size(AllTypesObject, [](auto &o) { return o._id >= 123; }) == 1);
+            CHECK(query_string_results_size(AllTypesObject, "_id >= $0", {123}) == 1);
+
             CHECK(query_results_size(AllTypesObject, [](auto &o) { return o._id < 123; }) == 0);
+            CHECK(query_string_results_size(AllTypesObject, "_id < $0", {123}) == 0);
+
             CHECK(query_results_size(AllTypesObject, [](auto &o) { return o._id <= 123; }) == 1);
+            CHECK(query_string_results_size(AllTypesObject, "_id <= $0", {123}) == 1);
 
             CHECK(query_results_size(AllTypesObject, [](auto &o) { return o.enum_col > AllTypesObject::Enum::two; }) == 0);
-            CHECK(query_results_size(AllTypesObject, [](auto &o) { return o.enum_col >= AllTypesObject::Enum::two; }) == 1);
-            CHECK(query_results_size(AllTypesObject, [](auto &o) { return o.enum_col < AllTypesObject::Enum::two; }) == 0);
-            CHECK(query_results_size(AllTypesObject, [](auto &o) { return o.enum_col <= AllTypesObject::Enum::two; }) == 1);
+            CHECK(query_string_results_size(AllTypesObject, "enum_col > $0", {static_cast<int>(AllTypesObject::Enum::two)}) == 0);
 
+            CHECK(query_results_size(AllTypesObject, [](auto &o) { return o.enum_col >= AllTypesObject::Enum::two; }) == 1);
+            CHECK(query_string_results_size(AllTypesObject, "enum_col >= $0", {static_cast<int>(AllTypesObject::Enum::two)}) == 1);
+
+            CHECK(query_results_size(AllTypesObject, [](auto &o) { return o.enum_col < AllTypesObject::Enum::two; }) == 0);
+            CHECK(query_string_results_size(AllTypesObject, "enum_col < $0", {static_cast<int>(AllTypesObject::Enum::two)}) == 0);
+
+            CHECK(query_results_size(AllTypesObject, [](auto &o) { return o.enum_col <= AllTypesObject::Enum::two; }) == 1);
+            CHECK(query_string_results_size(AllTypesObject, "enum_col <= $0", {static_cast<int>(AllTypesObject::Enum::two)}) == 1);
 
             CHECK(query_results_size(AllTypesObject, [&date](auto &o) {
                       return o.date_col > std::chrono::system_clock::from_time_t(date);
                   }) == 0);
+            CHECK(query_string_results_size(AllTypesObject, "date_col > $0", {std::chrono::system_clock::from_time_t(date)}) == 0);
+
             CHECK(query_results_size(AllTypesObject, [&date](auto &o) {
                       return o.date_col >= std::chrono::system_clock::from_time_t(date);
                   }) == 1);
+            CHECK(query_string_results_size(AllTypesObject, "date_col >= $0", {std::chrono::system_clock::from_time_t(date)}) == 1);
+
             CHECK(query_results_size(AllTypesObject, [&date](auto &o) {
                       return o.date_col < std::chrono::system_clock::from_time_t(date);
                   }) == 0);
+            CHECK(query_string_results_size(AllTypesObject, "date_col < $0", {std::chrono::system_clock::from_time_t(date)}) == 0);
+
             CHECK(query_results_size(AllTypesObject, [&date](auto &o) {
                       return o.date_col <= std::chrono::system_clock::from_time_t(date);
                   }) == 1);
+            CHECK(query_string_results_size(AllTypesObject, "date_col <= $0", {std::chrono::system_clock::from_time_t(date)}) == 1);
         }
 
         SECTION("tsq_compound", "[query]") {
@@ -133,30 +182,43 @@ namespace realm::experimental {
                 return o._id == 123 && o.str_col != "John";
             });
             CHECK(results.size() == 0);
+            CHECK(query_string_results_size(AllTypesObject, "_id == $0 && str_col != $1", {123, "John"}) == 0);
+
             results = realm.objects<AllTypesObject>().where([](auto &o) {
                 return o._id == 123 || o.str_col != "John";
             });
             CHECK(results.size() == 1);
+            CHECK(query_string_results_size(AllTypesObject, "_id == $0 || str_col != $1", {123, "John"}) == 1);
+
             results = realm.objects<AllTypesObject>().where([](auto &o) {
                 return o._id == 123 && o.str_col == "John";
             });
             CHECK(results.size() == 1);
+            CHECK(query_string_results_size(AllTypesObject, "_id == $0 && str_col == $1", {123, "John"}) == 1);
+
             results = realm.objects<AllTypesObject>().where([](auto &o) {
                 return o._id == 123 && o.str_col == "John" || o.bool_col == true;
             });
             CHECK(results.size() == 1);
+            CHECK(query_string_results_size(AllTypesObject, "_id == $0 && str_col == $1  || bool_col == $2", {123, "John", true}) == 1);
+
             results = realm.objects<AllTypesObject>().where([](auto &o) {
                 return o._id == 123 && o.str_col.contains("Jo") || o.bool_col == true;
             });
             CHECK(results.size() == 1);
+            CHECK(query_string_results_size(AllTypesObject, "_id == $0 && str_col CONTAINS $1  || bool_col == $2", {123, "John", true}) == 1);
+
             results = realm.objects<AllTypesObject>().where([](auto &o) {
                 return o.str_col.empty();
             });
             CHECK(results.size() == 0);
+            CHECK(query_string_results_size(AllTypesObject, "str_col == ''", {}) == 0);
+
             results = realm.objects<AllTypesObject>().where([](auto &o) {
                 return !o.str_col.empty();
             });
             CHECK(results.size() == 1);
+            CHECK(query_string_results_size(AllTypesObject, "NOT str_col == ''", {}) == 1);
         }
 
         SECTION("optionals") {
@@ -170,21 +232,25 @@ namespace realm::experimental {
                 return obj.opt_str_col == std::nullopt;
             });
             CHECK(res.size() == 1);
+            CHECK(query_string_results_size(AllTypesObject, "opt_str_col == NULL", {}) == 1);
 
             res = realm.objects<AllTypesObject>().where([](auto &obj) {
                 return obj.opt_str_col != std::nullopt;
             });
             CHECK(res.size() == 0);
+            CHECK(query_string_results_size(AllTypesObject, "opt_str_col != NULL", {}) == 0);
 
             res = realm.objects<AllTypesObject>().where([](auto &obj) {
                 return obj.mixed_col == std::nullopt;
             });
             CHECK(res.size() == 1);
+            CHECK(query_string_results_size(AllTypesObject, "mixed_col == NULL", {}) == 1);
 
             res = realm.objects<AllTypesObject>().where([](auto &obj) {
                 return obj.mixed_col != std::nullopt;
             });
             CHECK(res.size() == 0);
+            CHECK(query_string_results_size(AllTypesObject, "mixed_col != NULL", {}) == 0);
         }
 
         SECTION("link column") {
@@ -207,22 +273,31 @@ namespace realm::experimental {
                 return obj.opt_obj_col->str_col == "foo";
             });
             CHECK(res.size() == 1);
+            CHECK(query_string_results_size(AllTypesObject, "opt_obj_col.str_col == $0", {"foo"}) == 1);
+
             res = realm.objects<AllTypesObject>().where([](auto &obj) {
                 return obj.opt_obj_col->str_col == "bar";
             });
             CHECK(res.size() == 0);
+            CHECK(query_string_results_size(AllTypesObject, "opt_obj_col.str_col == $0", {"bar"}) == 0);
+
             res = realm.objects<AllTypesObject>().where([](auto &obj) {
                 return obj.opt_obj_col->str_col != "bar";
             });
             CHECK(res.size() == 1);
+            CHECK(query_string_results_size(AllTypesObject, "str_col != $0", {"bar"}) == 1);
+
             res = realm.objects<AllTypesObject>().where([](auto &obj) {
                 return obj.opt_obj_col->str_link_col->str_col == "bar";
             });
             CHECK(res.size() == 1);
+            CHECK(query_string_results_size(AllTypesObject, "opt_obj_col.str_link_col.str_col == $0", {"bar"}) == 1);
+
             res = realm.objects<AllTypesObject>().where([](auto &obj) {
                 return obj.opt_obj_col->str_link_col->str_col != "bar";
             });
             CHECK(res.size() == 0);
+            CHECK(query_string_results_size(AllTypesObject, "opt_obj_col.str_link_col.str_col != $0", {"bar"}) == 0);
         }
     }
 }

--- a/tests/experimental/db/query_tests.cpp
+++ b/tests/experimental/db/query_tests.cpp
@@ -6,7 +6,7 @@ namespace realm::experimental {
 #define query_results_size(Cls, fn)  \
     realm.template objects<Cls>().where(fn).size()
 
-#define query_string_results_size(Cls, str, args...)  \
+#define query_string_results_size(Cls, str, args)  \
     realm.template objects<Cls>().where(str, args).size()
 
     TEST_CASE("query") {
@@ -49,16 +49,16 @@ namespace realm::experimental {
 
             // With literal as RHS.
             CHECK(query_results_size(AllTypesObject, [](auto &o) { return o._id == 123; }) == 1);
-            CHECK(query_string_results_size(AllTypesObject, "_id == $0", {123}) == 1);
+            CHECK(query_string_results_size(AllTypesObject, "_id == $0", {(int64_t)123}) == 1);
 
             CHECK(query_results_size(AllTypesObject, [](auto &o) { return o._id != 123; }) == 0);
-            CHECK(query_string_results_size(AllTypesObject, "_id != $0", {123}) == 0);
+            CHECK(query_string_results_size(AllTypesObject, "_id != $0", {(int64_t)123}) == 0);
 
             CHECK(query_results_size(AllTypesObject, [](auto &o) { return o.str_col == "foo bar"; }) == 1);
-            CHECK(query_string_results_size(AllTypesObject, "str_col == $0", {"foo bar"}) == 1);
+            CHECK(query_string_results_size(AllTypesObject, "str_col == $0", {std::string("foo bar")}) == 1);
 
             CHECK(query_results_size(AllTypesObject, [](auto &o) { return o.str_col != "foo bar"; }) == 0);
-            CHECK(query_string_results_size(AllTypesObject, "str_col != $0", {"foo bar"}) == 0);
+            CHECK(query_string_results_size(AllTypesObject, "str_col != $0", {std::string("foo bar")}) == 0);
 
             CHECK(query_results_size(AllTypesObject, [](auto &o) {
                       return o.binary_col == std::vector<uint8_t>({0, 1, 2, 3});
@@ -71,10 +71,10 @@ namespace realm::experimental {
             CHECK(query_string_results_size(AllTypesObject, "binary_col != $0", {std::vector<uint8_t>({0, 1, 2, 3})}) == 0);
 
             CHECK(query_results_size(AllTypesObject, [](auto &o) { return o.enum_col == AllTypesObject::Enum::two; }) == 1);
-            CHECK(query_string_results_size(AllTypesObject, "enum_col == $0", {static_cast<int>(AllTypesObject::Enum::two)}) == 1);
+            CHECK(query_string_results_size(AllTypesObject, "enum_col == $0", {static_cast<int64_t>(AllTypesObject::Enum::two)}) == 1);
 
             CHECK(query_results_size(AllTypesObject, [](auto &o) { return o.enum_col != AllTypesObject::Enum::two; }) == 0);
-            CHECK(query_string_results_size(AllTypesObject, "enum_col != $0", {static_cast<int>(AllTypesObject::Enum::two)}) == 0);
+            CHECK(query_string_results_size(AllTypesObject, "enum_col != $0", {static_cast<int64_t>(AllTypesObject::Enum::two)}) == 0);
 
             CHECK(query_results_size(AllTypesObject, [&date](auto &o) {
                       return o.date_col == std::chrono::system_clock::from_time_t(date);
@@ -98,7 +98,7 @@ namespace realm::experimental {
 
             auto objs = realm.objects<AllTypesObject>().where([](auto& o) { return o.opt_obj_col->str_col == "foo"; }).size();
             CHECK(objs == 1);
-            objs = realm.objects<AllTypesObject>().where("opt_obj_col.str_col == $0", {"foo"}).size();
+            objs = realm.objects<AllTypesObject>().where("opt_obj_col.str_col == $0", {std::string("foo")}).size();
             CHECK(objs == 1);
         }
 
@@ -122,28 +122,28 @@ namespace realm::experimental {
 
             // With literal as RHS.
             CHECK(query_results_size(AllTypesObject, [](auto &o) { return o._id > 123; }) == 0);
-            CHECK(query_string_results_size(AllTypesObject, "_id > $0", {123}) == 0);
+            CHECK(query_string_results_size(AllTypesObject, "_id > $0", {(int64_t)123}) == 0);
 
             CHECK(query_results_size(AllTypesObject, [](auto &o) { return o._id >= 123; }) == 1);
-            CHECK(query_string_results_size(AllTypesObject, "_id >= $0", {123}) == 1);
+            CHECK(query_string_results_size(AllTypesObject, "_id >= $0", {(int64_t) 123}) == 1);
 
             CHECK(query_results_size(AllTypesObject, [](auto &o) { return o._id < 123; }) == 0);
-            CHECK(query_string_results_size(AllTypesObject, "_id < $0", {123}) == 0);
+            CHECK(query_string_results_size(AllTypesObject, "_id < $0", {(int64_t) 123}) == 0);
 
             CHECK(query_results_size(AllTypesObject, [](auto &o) { return o._id <= 123; }) == 1);
-            CHECK(query_string_results_size(AllTypesObject, "_id <= $0", {123}) == 1);
+            CHECK(query_string_results_size(AllTypesObject, "_id <= $0", {(int64_t) 123}) == 1);
 
             CHECK(query_results_size(AllTypesObject, [](auto &o) { return o.enum_col > AllTypesObject::Enum::two; }) == 0);
-            CHECK(query_string_results_size(AllTypesObject, "enum_col > $0", {static_cast<int>(AllTypesObject::Enum::two)}) == 0);
+            CHECK(query_string_results_size(AllTypesObject, "enum_col > $0", {static_cast<int64_t>(AllTypesObject::Enum::two)}) == 0);
 
             CHECK(query_results_size(AllTypesObject, [](auto &o) { return o.enum_col >= AllTypesObject::Enum::two; }) == 1);
-            CHECK(query_string_results_size(AllTypesObject, "enum_col >= $0", {static_cast<int>(AllTypesObject::Enum::two)}) == 1);
+            CHECK(query_string_results_size(AllTypesObject, "enum_col >= $0", {static_cast<int64_t>(AllTypesObject::Enum::two)}) == 1);
 
             CHECK(query_results_size(AllTypesObject, [](auto &o) { return o.enum_col < AllTypesObject::Enum::two; }) == 0);
-            CHECK(query_string_results_size(AllTypesObject, "enum_col < $0", {static_cast<int>(AllTypesObject::Enum::two)}) == 0);
+            CHECK(query_string_results_size(AllTypesObject, "enum_col < $0", {static_cast<int64_t>(AllTypesObject::Enum::two)}) == 0);
 
             CHECK(query_results_size(AllTypesObject, [](auto &o) { return o.enum_col <= AllTypesObject::Enum::two; }) == 1);
-            CHECK(query_string_results_size(AllTypesObject, "enum_col <= $0", {static_cast<int>(AllTypesObject::Enum::two)}) == 1);
+            CHECK(query_string_results_size(AllTypesObject, "enum_col <= $0", {static_cast<int64_t>(AllTypesObject::Enum::two)}) == 1);
 
             CHECK(query_results_size(AllTypesObject, [&date](auto &o) {
                       return o.date_col > std::chrono::system_clock::from_time_t(date);
@@ -182,31 +182,31 @@ namespace realm::experimental {
                 return o._id == 123 && o.str_col != "John";
             });
             CHECK(results.size() == 0);
-            CHECK(query_string_results_size(AllTypesObject, "_id == $0 && str_col != $1", {123, "John"}) == 0);
+            CHECK(query_string_results_size(AllTypesObject, "_id == $0 && str_col != $1", std::vector<realm::mixed>({(int64_t)123, std::string("John")})) == 0);
 
             results = realm.objects<AllTypesObject>().where([](auto &o) {
                 return o._id == 123 || o.str_col != "John";
             });
             CHECK(results.size() == 1);
-            CHECK(query_string_results_size(AllTypesObject, "_id == $0 || str_col != $1", {123, "John"}) == 1);
+            CHECK(query_string_results_size(AllTypesObject, "_id == $0 || str_col != $1", std::vector<realm::mixed>({(int64_t)123, std::string("John")})) == 1);
 
             results = realm.objects<AllTypesObject>().where([](auto &o) {
                 return o._id == 123 && o.str_col == "John";
             });
             CHECK(results.size() == 1);
-            CHECK(query_string_results_size(AllTypesObject, "_id == $0 && str_col == $1", {123, "John"}) == 1);
+            CHECK(query_string_results_size(AllTypesObject, "_id == $0 && str_col == $1", std::vector<realm::mixed>({(int64_t)123, std::string("John")})) == 1);
 
             results = realm.objects<AllTypesObject>().where([](auto &o) {
                 return o._id == 123 && o.str_col == "John" || o.bool_col == true;
             });
             CHECK(results.size() == 1);
-            CHECK(query_string_results_size(AllTypesObject, "_id == $0 && str_col == $1  || bool_col == $2", {123, "John", true}) == 1);
+            CHECK(query_string_results_size(AllTypesObject, "_id == $0 && str_col == $1  || bool_col == $2", std::vector<realm::mixed>({(int64_t)123, std::string("John"), true})) == 1);
 
             results = realm.objects<AllTypesObject>().where([](auto &o) {
                 return o._id == 123 && o.str_col.contains("Jo") || o.bool_col == true;
             });
             CHECK(results.size() == 1);
-            CHECK(query_string_results_size(AllTypesObject, "_id == $0 && str_col CONTAINS $1  || bool_col == $2", {123, "John", true}) == 1);
+            CHECK(query_string_results_size(AllTypesObject, "_id == $0 && str_col CONTAINS $1  || bool_col == $2", std::vector<realm::mixed>({(int64_t)123, std::string("John"), true})) == 1);
 
             results = realm.objects<AllTypesObject>().where([](auto &o) {
                 return o.str_col.empty();
@@ -273,31 +273,31 @@ namespace realm::experimental {
                 return obj.opt_obj_col->str_col == "foo";
             });
             CHECK(res.size() == 1);
-            CHECK(query_string_results_size(AllTypesObject, "opt_obj_col.str_col == $0", {"foo"}) == 1);
+            CHECK(query_string_results_size(AllTypesObject, "opt_obj_col.str_col == $0", {std::string("foo")}) == 1);
 
             res = realm.objects<AllTypesObject>().where([](auto &obj) {
                 return obj.opt_obj_col->str_col == "bar";
             });
             CHECK(res.size() == 0);
-            CHECK(query_string_results_size(AllTypesObject, "opt_obj_col.str_col == $0", {"bar"}) == 0);
+            CHECK(query_string_results_size(AllTypesObject, "opt_obj_col.str_col == $0", {std::string("bar")}) == 0);
 
             res = realm.objects<AllTypesObject>().where([](auto &obj) {
                 return obj.opt_obj_col->str_col != "bar";
             });
             CHECK(res.size() == 1);
-            CHECK(query_string_results_size(AllTypesObject, "str_col != $0", {"bar"}) == 1);
+            CHECK(query_string_results_size(AllTypesObject, "str_col != $0", {std::string("bar")}) == 1);
 
             res = realm.objects<AllTypesObject>().where([](auto &obj) {
                 return obj.opt_obj_col->str_link_col->str_col == "bar";
             });
             CHECK(res.size() == 1);
-            CHECK(query_string_results_size(AllTypesObject, "opt_obj_col.str_link_col.str_col == $0", {"bar"}) == 1);
+            CHECK(query_string_results_size(AllTypesObject, "opt_obj_col.str_link_col.str_col == $0", {std::string("bar")}) == 1);
 
             res = realm.objects<AllTypesObject>().where([](auto &obj) {
                 return obj.opt_obj_col->str_link_col->str_col != "bar";
             });
             CHECK(res.size() == 0);
-            CHECK(query_string_results_size(AllTypesObject, "opt_obj_col.str_link_col.str_col != $0", {"bar"}) == 0);
+            CHECK(query_string_results_size(AllTypesObject, "opt_obj_col.str_link_col.str_col != $0", {std::string("bar")}) == 0);
         }
     }
 }

--- a/tests/experimental/db/realm_tests.cpp
+++ b/tests/experimental/db/realm_tests.cpp
@@ -1,5 +1,5 @@
-#include "test_objects.hpp"
 #include "../../main.hpp"
+#include "test_objects.hpp"
 #include <realm/object-store/shared_realm.hpp>
 
 namespace realm::experimental {

--- a/tests/experimental/db/results_tests.cpp
+++ b/tests/experimental/db/results_tests.cpp
@@ -281,11 +281,11 @@ namespace realm::experimental {
             CHECK(queried_results.size() == 1);
             CHECK(queried_results[0]._id == 1);
 
-            auto queried_results_string = results.where("_id == $0", {2});
+            auto queried_results_string = results.where("_id == $0", {(int64_t)2});
             CHECK(queried_results_string.size() == 1);
             CHECK(queried_results_string[0]._id == 2);
 
-            queried_results_string = results.where("_id == $0", {3});
+            queried_results_string = results.where("_id == $0", {(int64_t)3});
             CHECK(queried_results_string.size() == 0);
         }
 

--- a/tests/experimental/sync/asymmetric_object_tests.cpp
+++ b/tests/experimental/sync/asymmetric_object_tests.cpp
@@ -20,7 +20,6 @@ TEST_CASE("asymmetric object", "[sync_beta]") {
         });
 
         test::wait_for_sync_uploads(user).get();
-        test::wait_for_sync_downloads(user).get();
 
         auto result = user.call_function("asymmetricSyncData", bson::BsonArray({bson::BsonDocument{{"_id", oid.to_string()}}})).get();
         CHECK(result);

--- a/tests/experimental/sync/flexible_sync_tests.cpp
+++ b/tests/experimental/sync/flexible_sync_tests.cpp
@@ -110,7 +110,6 @@ void test_set(realm::experimental::managed<T>* property, Func f,
 
 TEST_CASE("set collection sync", "[set]") {
     auto app = realm::App(realm::App::configuration({Admin::shared().cached_app_id(), Admin::shared().base_url()}));
-
     SECTION("insert") {
         auto user = app.login(realm::App::credentials::anonymous()).get();
         auto flx_sync_config = user.flexible_sync_configuration();


### PR DESCRIPTION
- Add support for Frozen Objects / Realm's
Usage: 
```cpp
           auto realm = db(std::move(config));
            realm.write([&realm]() {
                realm.add(AllTypesObject());
            });
            auto frozen_realm = realm.freeze();
            MY_ASSERT(frozen_realm.is_frozen();

            auto async = std::async(std::launch::async, [&frozen_realm]() {
                auto thawed = frozen_realm.thaw();
                MY_ASSERT_FALSE(thawed.is_frozen());
                thawed.write([&thawed]() {
                    auto o = AllTypesObject();
                    o._id = 2;
                    thawed.add(std::move(o));
                });
                thawed.write([&thawed]() {
                    auto o = AllTypesObject();
                    o._id = 3;
                    thawed.add(std::move(o));
                });
                MY_ASSERT_FALSE(thawed.refresh());
                MY_ASSERT(thawed.objects<AllTypesObject>().size() == 3);

                MY_ASSERT(frozen_realm.is_frozen());
                MY_ASSERT_FALSE(frozen_realm.refresh());
                MY_ASSERT(frozen_realm.objects<AllTypesObject>().size() == 1);
                return true;
            });
            MY_ASSERT(async.get());
```
- Add support for sorting `experimental::results` / `managed<std::vector<T>>`
Usage: 
```cpp
            // For sorting on a single property ascending / descending.
            auto sorted_results_ascending = realm.objects<AllTypesObject>().sort("str_col", true);
            // For sorting on a order of multiple properties ascending / descending.
            auto sorted_results_with_descriptors_ascending = realm.objects<AllTypesObject>().sort({{"str_col", true}, {"_id", true}});

```
