### PR TITLE
Add support for manual compaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ X.Y.Z Release notes (YYYY-MM-DD)
                                                               std::function<void(experimental::db local, experimental::db remote)> after)`
 * Add `realm::experimental::db::close()` for closing an open Realm.
 * Add `realm::experimental::db::is_closed()` for checking if a Realm is closed.
+* Add support for manual compaction via `realm::db_config::should_compact_on_launch(std::function<bool(uint64_t total_bytes, uint64_t unused_bytes)>&&)`.
 
 ### Breaking Changes
 * None

--- a/src/cpprealm/internal/bridge/realm.cpp
+++ b/src/cpprealm/internal/bridge/realm.cpp
@@ -315,6 +315,10 @@ namespace realm::internal::bridge {
         get_config()->encryption_key = std::move(key);
     }
 
+    void realm::config::should_compact_on_launch(std::function<bool(uint64_t total_bytes, uint64_t unused_bytes)>&& fn) {
+        get_config()->should_compact_on_launch_function = std::move(fn);
+    }
+
     enum ::realm::client_reset_mode realm::config::get_client_reset_mode() const {
         return static_cast<enum ::realm::client_reset_mode>(get_config()->sync_config->client_resync_mode);
     }

--- a/src/cpprealm/internal/bridge/realm.hpp
+++ b/src/cpprealm/internal/bridge/realm.hpp
@@ -176,6 +176,7 @@ namespace realm::internal::bridge {
             void set_proxy_config(const sync_config::proxy_config&);
             void set_schema_version(uint64_t version);
             void set_encryption_key(const std::array<char, 64>&);
+            void should_compact_on_launch(std::function<bool(uint64_t total_bytes, uint64_t unused_bytes)>&& fn);
             std::optional<schema> get_schema();
 
             template<typename T>


### PR DESCRIPTION
* Add support for manual compaction via `realm::db_config::should_compact_on_launch(std::function<bool(uint64_t total_bytes, uint64_t unused_bytes)>&&)`