### PR TITLE
Fix notifications when using results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ X.Y.Z Release notes (YYYY-MM-DD)
 =============================================================
 
 ### Fixed
-* None
+* When observing `results<>` the notifications would not fire after the `results<>` instance left the scope.
 
 ### Enhancements
 * Add the following methods for control over the sync session state:

--- a/src/cpprealm/db.hpp
+++ b/src/cpprealm/db.hpp
@@ -57,7 +57,7 @@ namespace realm {
 
     struct sync_subscription_set;
 
-    template <typename T, typename = void>
+    template <typename T>
     struct thread_safe_reference;
 }
 

--- a/src/cpprealm/macros.hpp
+++ b/src/cpprealm/macros.hpp
@@ -520,7 +520,7 @@ rbool managed<std::optional<type>>::operator op(const std::optional<type>& rhs) 
         friend struct db;                                                                          \
         template <typename, typename> friend struct managed;                                       \
         template <typename, typename> friend struct box;                                           \
-        template <typename, typename> friend struct ::realm::thread_safe_reference;                \
+        template <typename> friend struct ::realm::thread_safe_reference;                \
     };                                                                                             \
     struct meta_schema_##cls {   \
         meta_schema_##cls() {                                                    \

--- a/src/cpprealm/notifications.hpp
+++ b/src/cpprealm/notifications.hpp
@@ -42,12 +42,14 @@ struct notification_token {
         m_token = std::move(other.m_token);
         m_dictionary = std::move(other.m_dictionary);
         m_list = std::move(other.m_list);
+        m_results = std::move(other.m_results);
         m_realm = std::move(other.m_realm);
     };
     notification_token &operator=(notification_token &&other) {
         m_token = std::move(other.m_token);
         m_dictionary = std::move(other.m_dictionary);
         m_list = std::move(other.m_list);
+        m_results = std::move(other.m_results);
         m_realm = std::move(other.m_realm);
         return *this;
     };
@@ -64,6 +66,7 @@ struct notification_token {
     std::shared_ptr<internal::bridge::dictionary> m_dictionary;
     std::shared_ptr<internal::bridge::list> m_list;
     std::shared_ptr<internal::bridge::set> m_set;
+    std::shared_ptr<internal::bridge::results> m_results;
     internal::bridge::realm m_realm;
 };
 

--- a/src/cpprealm/results.hpp
+++ b/src/cpprealm/results.hpp
@@ -238,7 +238,6 @@ namespace realm {
             return std::move(token);
         }
 
-
         Derived freeze() {
             auto frozen_realm = m_parent.get_realm().freeze();
             return Derived(internal::bridge::results(frozen_realm, frozen_realm.table_for_object_type(managed<T>::schema.name)));

--- a/src/cpprealm/thread_safe_reference.hpp
+++ b/src/cpprealm/thread_safe_reference.hpp
@@ -21,12 +21,10 @@
 
 #include <cpprealm/internal/bridge/thread_safe_reference.hpp>
 
-#include <cpprealm/db.hpp>
-
 namespace realm {
 
     template <typename T>
-    struct thread_safe_reference<T> {
+    struct thread_safe_reference {
         explicit thread_safe_reference(const managed<T>& object)
             : m_tsr(internal::bridge::thread_safe_reference(internal::bridge::object(object.m_realm, object.m_obj))) { }
     private:


### PR DESCRIPTION
When observing `results<>` the notifications would not fire after the `results<>` instance left the scope as the reference to the `internal::bridge::results` instance would call the destructor and tear down the collection notifier. To fix this the same pattern that we use with the other collection types must be followed when creating the notification token.