### PR TITLE
RCPP-61 Add BSON support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ X.Y.Z Release notes (YYYY-MM-DD)
 * Add `managed<std::vector<>>::as_results()` to allow the ability to derive a `realm::results<>` collection from a managed vector.
 * Allow a `realm::uuid` to be constructed with `std::array<uint8_t, 16>`.
 * Add support for integrating `cpprealm` with the Conan package manager.
+* Add BSON support for `user::call_function` and `user::get_custom_data` API's.
+* Add `user::get_custom_data()` and deprecate `user::custom_data()`.
 
 ### Breaking Changes
 * None

--- a/Package.swift
+++ b/Package.swift
@@ -115,7 +115,8 @@ let package = Package(
                 "db/results_tests.cpp",
                 "db/run_loop_tests.cpp",
                 "db/set_tests.cpp",
-                "db/string_tests.cpp"
+                "db/string_tests.cpp",
+                "db/bson_tests.cpp"
             ],
             resources: [
                 .copy("setup_baas.rb"),

--- a/conanfile.py
+++ b/conanfile.py
@@ -36,7 +36,7 @@ class cpprealmRecipe(ConanFile):
         git = Git(self)
         git.clone(url="https://github.com/realm/realm-cpp", target=".")
         git.folder = "."
-        git.checkout(commit="b179797556ea4fd7e919ba0954653fda92b720f4")
+        git.checkout(commit="c1096b169258581927fa1591686bdc1687f368ed")
         git.run("submodule update --init --recursive")
 
     def layout(self):

--- a/conanfile.py
+++ b/conanfile.py
@@ -36,7 +36,7 @@ class cpprealmRecipe(ConanFile):
         git = Git(self)
         git.clone(url="https://github.com/realm/realm-cpp", target=".")
         git.folder = "."
-        git.checkout(commit="3f125272f21ec24d8f7f2be767b1100a8ccaa88b")
+        git.checkout(commit="b179797556ea4fd7e919ba0954653fda92b720f4")
         git.run("submodule update --init --recursive")
 
     def layout(self):

--- a/include/cpprealm/bson.hpp
+++ b/include/cpprealm/bson.hpp
@@ -1,0 +1,1 @@
+../../src/cpprealm/bson.hpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,6 +26,7 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/cpprealm/internal/bridge/bridge_types.
 set(SOURCES
     cpprealm/analytics.cpp
     cpprealm/app.cpp
+    cpprealm/bson.cpp
     cpprealm/db.cpp
     cpprealm/client_reset.cpp
     cpprealm/managed_binary.cpp
@@ -73,6 +74,7 @@ set(HEADERS
     cpprealm/analytics.hpp
     cpprealm/app.hpp
     cpprealm/accessors.hpp
+    cpprealm/bson.hpp
     cpprealm/db.hpp
     cpprealm/client_reset.hpp
     cpprealm/link.hpp

--- a/src/cpprealm/app.hpp
+++ b/src/cpprealm/app.hpp
@@ -191,9 +191,24 @@ struct user {
     [[nodiscard]] std::future<std::optional<std::string>> call_function(const std::string& name,
                                                                         const std::string& args_ejson) const;
 
+    /**
+     Calls the Atlas App Services function with the provided name and arguments.
+
+    @param name The name of the Atlas App Services function to be called.
+    @param arguments The BSON array to be provided to the function.
+    @param callback The completion handler to call when the function call is complete.
+                    This handler is executed on the thread the method was called from.
+    */
     void call_function(const std::string& name, const std::vector<bsoncxx>& args_bson,
                        std::function<void(std::optional<bsoncxx>, std::optional<app_error>)> callback) const;
 
+    /**
+    Calls the Atlas App Services function with the provided name and arguments.
+
+    @param name The name of the Atlas App Services function to be called.
+    @param arguments The BSON array to be provided to the function.
+    @return A future containing optional BSON once the operation has completed.
+    */
     [[nodiscard]] std::future<std::optional<bsoncxx>> call_function(const std::string& name, const std::vector<bsoncxx>& args_bson) const;
 
     /**

--- a/src/cpprealm/app.hpp
+++ b/src/cpprealm/app.hpp
@@ -175,6 +175,7 @@ struct user {
      @param callback The completion handler to call when the function call is complete.
      This handler is executed on the thread the method was called from.
      */
+    [[deprecated("This function is deprecated and will replaced by the BSON based call_function API.")]]
     void call_function(const std::string& name, const std::string& args_ejson,
                        std::function<void(std::optional<std::string>, std::optional<app_error>)> callback) const;
 
@@ -183,9 +184,10 @@ struct user {
 
     @param name The name of the Atlas App Services function to be called.
     @param arguments The string represented extended json to be provided to the function.
-    @param callback The completion handler to call when the function call is complete.
+    @return A future containing an optional std::string once the operation has completed.
     This handler is executed on the thread the method was called from.
     */
+    [[deprecated("This function is deprecated and will replaced by the BSON based call_function API.")]]
     [[nodiscard]] std::future<std::optional<std::string>> call_function(const std::string& name,
                                                                         const std::string& args_ejson) const;
 

--- a/src/cpprealm/app.hpp
+++ b/src/cpprealm/app.hpp
@@ -19,6 +19,7 @@
 #ifndef CPPREALM_APP_HPP
 #define CPPREALM_APP_HPP
 
+#include <cpprealm/bson.hpp>
 #include <cpprealm/db.hpp>
 
 #include <cpprealm/internal/bridge/realm.hpp>
@@ -156,11 +157,15 @@ struct user {
 
     [[nodiscard]] std::future<void> log_out() const;
 
+
+    [[deprecated("Replaced by `get_custom_data()`. This method will be removed in a future release.")]]
+    [[nodiscard]] std::optional<std::string> custom_data() const;
+
     /**
      The custom data of the user.
      This is configured in your Atlas App Services app.
      */
-    [[nodiscard]] std::optional<std::string> custom_data() const;
+    [[nodiscard]] std::optional<bsoncxx::document> get_custom_data() const;
 
     /**
      Calls the Atlas App Services function with the provided name and arguments.
@@ -183,6 +188,11 @@ struct user {
     */
     [[nodiscard]] std::future<std::optional<std::string>> call_function(const std::string& name,
                                                                         const std::string& args_ejson) const;
+
+    void call_function(const std::string& name, const std::vector<bsoncxx>& args_bson,
+                       std::function<void(std::optional<bsoncxx>, std::optional<app_error>)> callback) const;
+
+    [[nodiscard]] std::future<std::optional<bsoncxx>> call_function(const std::string& name, const std::vector<bsoncxx>& args_bson) const;
 
     /**
      Refresh a user's custom data. This will, in effect, refresh the user's auth session.

--- a/src/cpprealm/bson.cpp
+++ b/src/cpprealm/bson.cpp
@@ -435,7 +435,7 @@ namespace realm {
 #ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
         return bsoncxx::document::iterator(CORE_DOCUMENT->begin());
 #else
-        return bsoncxx::document::iterator(m_document.get(), 0);
+        return bsoncxx::document::iterator(m_document->begin());
 #endif
     }
 
@@ -444,7 +444,7 @@ namespace realm {
 #ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
         return bsoncxx::document::iterator(CORE_DOCUMENT->end());
 #else
-        return bsoncxx::document::iterator(m_document.get(), m_document->size());
+        return bsoncxx::document::iterator(m_document->end());
 #endif
     }
 

--- a/src/cpprealm/bson.cpp
+++ b/src/cpprealm/bson.cpp
@@ -250,6 +250,8 @@ namespace realm {
             case realm::bson::Bson::Type::RegularExpression:
                 return bsoncxx::type::b_regular_expression;
         }
+
+        throw std::runtime_error("BSON type not supported");
     }
 
     std::string bsoncxx::to_string() const
@@ -272,7 +274,7 @@ namespace realm {
     {
         m_document = std::make_shared<CoreDocument>();
     }
-    bsoncxx::document::document(const std::vector<std::pair<std::string, bsoncxx>>& v) noexcept
+    bsoncxx::document::document(const std::initializer_list<std::pair<std::string, bsoncxx>>& v) noexcept
     {
         CoreDocument core_document;
         for (auto& [k, v] : v) {

--- a/src/cpprealm/bson.cpp
+++ b/src/cpprealm/bson.cpp
@@ -31,7 +31,7 @@ namespace realm {
 #ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
         *reinterpret_cast<bson::Bson*>(&m_bson) = *reinterpret_cast<const bson::Bson*>(&v.m_bson);
 #else
-        m_table = v.m_table;
+        m_bson = v.m_bson;
 #endif
     }
 
@@ -40,7 +40,7 @@ namespace realm {
 #ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
         *reinterpret_cast<bson::Bson*>(&m_bson) = std::move(*reinterpret_cast<bson::Bson*>(&v.m_bson));
 #else
-        m_table = std::move(v.m_table);
+        m_bson = std::move(v.m_bson);
 #endif
     }
 
@@ -49,7 +49,7 @@ namespace realm {
 #ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
         *reinterpret_cast<bson::Bson*>(&m_bson) = *reinterpret_cast<const bson::Bson*>(&v.m_bson);
 #else
-        m_table = v.m_table;
+        m_bson = v.m_bson;
 #endif
         return *this;
     }
@@ -59,7 +59,7 @@ namespace realm {
 #ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
         *reinterpret_cast<bson::Bson*>(&m_bson) = std::move(*reinterpret_cast<bson::Bson*>(&v.m_bson));
 #else
-        m_table = std::move(v.m_table);
+        m_bson = std::move(v.m_bson);
 #endif
         return *this;
     }
@@ -407,7 +407,11 @@ namespace realm {
 
     bsoncxx::document::value bsoncxx::document::operator[](const std::string& key)
     {
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
         return bsoncxx::document::value(CORE_DOCUMENT, key);
+#else
+        return bsoncxx::document::value(m_document.get(), key);
+#endif
     }
 
     bsoncxx::document::operator CoreDocument() const
@@ -423,12 +427,20 @@ namespace realm {
 
     bsoncxx::document::iterator bsoncxx::document::begin()
     {
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
         return bsoncxx::document::iterator(CORE_DOCUMENT, 0);
+#else
+        return bsoncxx::document::iterator(m_document.get(), 0);
+#endif
     }
 
     bsoncxx::document::iterator bsoncxx::document::end()
     {
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
         return bsoncxx::document::iterator(CORE_DOCUMENT, CONST_CORE_DOCUMENT->size());
+#else
+        return bsoncxx::document::iterator(m_document.get(), m_document->size());
+#endif
     }
 
     std::pair<std::string, bsoncxx> bsoncxx::document::iterator::operator*()

--- a/src/cpprealm/bson.cpp
+++ b/src/cpprealm/bson.cpp
@@ -1,0 +1,191 @@
+#include <cpprealm/bson.hpp>
+
+#include <realm/util/bson/bson.hpp>
+
+namespace realm {
+    bsoncxx::bsoncxx() noexcept
+    {
+        m_bson = std::make_shared<realm::bson::Bson>();
+    }
+    bsoncxx::~bsoncxx() noexcept
+    {
+
+    }
+    bsoncxx::bsoncxx(const bsoncxx& v) noexcept
+    {
+        m_bson = v.m_bson;
+    }
+    bsoncxx::bsoncxx(bsoncxx&& v) noexcept
+    {
+        m_bson = std::move(v.m_bson);
+    }
+    bsoncxx& bsoncxx::operator=(const bsoncxx& v) noexcept
+    {
+        m_bson = v.m_bson;
+        return *this;
+    }
+    bsoncxx& bsoncxx::operator=(bsoncxx&& v) noexcept
+    {
+        m_bson = std::move(v.m_bson);
+        return *this;
+    }
+
+    bsoncxx::bsoncxx(int32_t v) noexcept
+    {
+        m_bson = std::make_shared<realm::bson::Bson>(v);
+    }
+    bsoncxx::bsoncxx(int64_t v) noexcept
+    {
+        m_bson = std::make_shared<realm::bson::Bson>(v);
+    }
+    bsoncxx::bsoncxx(bool v) noexcept
+    {
+        m_bson = std::make_shared<realm::bson::Bson>(v);
+    }
+    bsoncxx::bsoncxx(double v) noexcept
+    {
+        m_bson = std::make_shared<realm::bson::Bson>(v);
+    }
+    bsoncxx::bsoncxx(min_key) noexcept
+    {
+        m_bson = std::make_shared<realm::bson::Bson>(realm::bson::MinKey());
+    }
+    bsoncxx::bsoncxx(max_key) noexcept
+    {
+        m_bson = std::make_shared<realm::bson::Bson>(realm::bson::MaxKey());
+    }
+    bsoncxx::bsoncxx(const std::chrono::time_point<std::chrono::system_clock>& v) noexcept
+    {
+        m_bson = std::make_shared<realm::bson::Bson>(realm::bson::MongoTimestamp(v.time_since_epoch().count(), 0));
+    }
+    bsoncxx::bsoncxx(const decimal128& v) noexcept
+    {
+        m_bson = std::make_shared<realm::bson::Bson>(serialize(v).operator Decimal128());
+    }
+    bsoncxx::bsoncxx(const object_id& v) noexcept
+    {
+        m_bson = std::make_shared<realm::bson::Bson>(serialize(v).operator ObjectId());
+    }
+    bsoncxx::bsoncxx(const uuid& v) noexcept
+    {
+        m_bson = std::make_shared<realm::bson::Bson>(serialize(v).operator UUID());
+    }
+    bsoncxx::bsoncxx(const regular_expression& v) noexcept
+    {
+        m_bson = std::make_shared<realm::bson::Bson>(v.operator bson::RegularExpression());
+    }
+    bsoncxx::bsoncxx(const std::vector<uint8_t>& v) noexcept
+    {
+        m_bson = std::make_shared<realm::bson::Bson>(std::vector<char>(v.begin(), v.end()));
+    }
+    bsoncxx::bsoncxx(const std::string& v) noexcept
+    {
+        m_bson = std::make_shared<realm::bson::Bson>(v);
+    }
+    bsoncxx::bsoncxx(const char* v) noexcept
+    {
+        m_bson = std::make_shared<realm::bson::Bson>(v);
+    }
+    bsoncxx::bsoncxx(const document& v) noexcept
+    {
+        m_bson = std::make_shared<realm::bson::Bson>(v.operator document::CoreDocument());
+    }
+    bsoncxx::bsoncxx(const std::vector<bsoncxx>& v) noexcept
+    {
+        std::vector<realm::bson::Bson> core_bson;
+        std::transform(v.begin(), v.end(), std::back_inserter(core_bson), [](const bsoncxx& b) {
+            return b.operator realm::bson::Bson();
+        });
+        m_bson = std::make_shared<realm::bson::Bson>(std::move(core_bson));
+    }
+
+    bsoncxx::operator realm::bson::Bson() const
+    {
+        return *m_bson;
+    }
+
+    bsoncxx::type bsoncxx::get_type() const {
+        switch(m_bson->type()){
+            case realm::bson::Bson::Type::Null:
+                return bsoncxx::type::b_null;
+            case realm::bson::Bson::Type::Int32:
+                return bsoncxx::type::b_int32;
+            case realm::bson::Bson::Type::Int64:
+                return bsoncxx::type::b_int64;
+            case realm::bson::Bson::Type::Bool:
+                return bsoncxx::type::b_bool;
+            case realm::bson::Bson::Type::Double:
+                return bsoncxx::type::b_double;
+            case realm::bson::Bson::Type::String:
+                return bsoncxx::type::b_string;
+            case realm::bson::Bson::Type::Binary:
+                return bsoncxx::type::b_binary;
+            case realm::bson::Bson::Type::Timestamp:
+                return bsoncxx::type::b_timestamp;
+            case realm::bson::Bson::Type::Datetime:
+                return bsoncxx::type::b_datetime;
+            case realm::bson::Bson::Type::ObjectId:
+                return bsoncxx::type::b_objectId;
+            case realm::bson::Bson::Type::Decimal128:
+                return bsoncxx::type::b_decimal128;
+            case realm::bson::Bson::Type::MaxKey:
+                return bsoncxx::type::b_max_key;
+            case realm::bson::Bson::Type::MinKey:
+                return bsoncxx::type::b_min_key;
+            case realm::bson::Bson::Type::Document:
+                return bsoncxx::type::b_document;
+            case realm::bson::Bson::Type::Array:
+                return bsoncxx::type::b_array;
+            case realm::bson::Bson::Type::Uuid:
+                return bsoncxx::type::b_uuid;
+            case realm::bson::Bson::Type::RegularExpression:
+                return bsoncxx::type::b_regular_expression;
+        }
+    }
+
+
+    bsoncxx::document::document() noexcept
+    {
+        m_document = std::make_shared<CoreDocument>();
+    }
+    bsoncxx::document::document(const std::vector<std::pair<std::string, bsoncxx>>& v) noexcept
+    {
+        CoreDocument core_document;
+        for (auto& [k, v] : v) {
+            core_document[k] = v.operator realm::bson::Bson();
+        }
+        m_document = std::make_shared<CoreDocument>(std::move(core_document));
+    }
+    bsoncxx::document::document(const document& v)
+    {
+        m_document = v.m_document;
+    }
+    bsoncxx::document::document(document&& v)
+    {
+        m_document = std::move(v.m_document);
+    }
+    bsoncxx::document::~document()
+    {
+
+    }
+    bsoncxx::document& bsoncxx::document::operator=(const document& v)
+    {
+        m_document = v.m_document;
+        return *this;
+    }
+    bsoncxx::document& bsoncxx::document::operator=(document&& v)
+    {
+        m_document = std::move(v.m_document);
+        return *this;
+    }
+
+    bsoncxx::document::operator CoreDocument() const
+    {
+        return *m_document;
+    }
+
+    bsoncxx::regular_expression::operator realm::bson::RegularExpression() const
+    {
+        return realm::bson::RegularExpression();
+    }
+}

--- a/src/cpprealm/bson.cpp
+++ b/src/cpprealm/bson.cpp
@@ -379,7 +379,7 @@ namespace realm {
     bsoncxx::document::document(CoreDocument& doc) noexcept
     {
 #ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
-        *reinterpret_cast<CoreDocument*>(&m_document) = *reinterpret_cast<const CoreDocument*>(&doc);
+        new (&m_document) CoreDocument(doc);
 #else
         m_document = std::make_shared<CoreDocument>(doc);
 #endif

--- a/src/cpprealm/bson.cpp
+++ b/src/cpprealm/bson.cpp
@@ -339,7 +339,7 @@ namespace realm {
     bsoncxx::document::document(const document& v)
     {
 #ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
-        *reinterpret_cast<CoreDocument*>(&m_document) = *reinterpret_cast<const CoreDocument*>(&v.m_document);
+        new (&m_document) CoreDocument(*reinterpret_cast<const CoreDocument*>(&v.m_document));
 #else
         m_document = v.m_document;
 #endif
@@ -347,7 +347,7 @@ namespace realm {
     bsoncxx::document::document(document&& v)
     {
 #ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
-        *reinterpret_cast<CoreDocument*>(&m_document) = std::move(*reinterpret_cast<const CoreDocument*>(&v.m_document));
+        new (&m_document) CoreDocument(std::move(*reinterpret_cast<CoreDocument*>(&v.m_document)));
 #else
         m_document = std::move(v.m_document);
 #endif

--- a/src/cpprealm/bson.cpp
+++ b/src/cpprealm/bson.cpp
@@ -12,104 +12,136 @@ namespace realm {
 
     bsoncxx::bsoncxx() noexcept
     {
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+        new (&m_bson) realm::bson::Bson();
+#else
         m_bson = std::make_shared<realm::bson::Bson>();
+#endif
     }
 
     bsoncxx::~bsoncxx() noexcept
     {
-
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+        reinterpret_cast<bson::Bson*>(&m_bson)->~Bson();
+#endif
     }
 
     bsoncxx::bsoncxx(const bsoncxx& v) noexcept
     {
-        m_bson = v.m_bson;
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+        *reinterpret_cast<bson::Bson*>(&m_bson) = *reinterpret_cast<const bson::Bson*>(&v.m_bson);
+#else
+        m_table = v.m_table;
+#endif
     }
 
     bsoncxx::bsoncxx(bsoncxx&& v) noexcept
     {
-        m_bson = std::move(v.m_bson);
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+        *reinterpret_cast<bson::Bson*>(&m_bson) = std::move(*reinterpret_cast<bson::Bson*>(&v.m_bson));
+#else
+        m_table = std::move(v.m_table);
+#endif
     }
 
     bsoncxx& bsoncxx::operator=(const bsoncxx& v) noexcept
     {
-        m_bson = v.m_bson;
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+        *reinterpret_cast<bson::Bson*>(&m_bson) = *reinterpret_cast<const bson::Bson*>(&v.m_bson);
+#else
+        m_table = v.m_table;
+#endif
         return *this;
     }
 
     bsoncxx& bsoncxx::operator=(bsoncxx&& v) noexcept
     {
-        m_bson = std::move(v.m_bson);
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+        *reinterpret_cast<bson::Bson*>(&m_bson) = std::move(*reinterpret_cast<bson::Bson*>(&v.m_bson));
+#else
+        m_table = std::move(v.m_table);
+#endif
         return *this;
     }
 
     bsoncxx::bsoncxx(realm::bson::Bson& b) noexcept
     {
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+        new (&m_bson) realm::bson::Bson(b);
+#else
         m_bson = std::make_shared<realm::bson::Bson>(b);
+#endif
     }
+
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+#define INIT_BSON(value) new (&m_bson) realm::bson::Bson(value);
+#else
+#define INIT_BSON(value) m_bson = std::make_shared<realm::bson::Bson>(value);
+#endif
 
     bsoncxx::bsoncxx(int32_t v) noexcept
     {
-        m_bson = std::make_shared<realm::bson::Bson>(v);
+        INIT_BSON(v);
     }
     bsoncxx::bsoncxx(int64_t v) noexcept
     {
-        m_bson = std::make_shared<realm::bson::Bson>(v);
+        INIT_BSON(v);
     }
     bsoncxx::bsoncxx(bool v) noexcept
     {
-        m_bson = std::make_shared<realm::bson::Bson>(v);
+        INIT_BSON(v);
     }
     bsoncxx::bsoncxx(double v) noexcept
     {
-        m_bson = std::make_shared<realm::bson::Bson>(v);
+        INIT_BSON(v);
     }
     bsoncxx::bsoncxx(min_key) noexcept
     {
-        m_bson = std::make_shared<realm::bson::Bson>(realm::bson::MinKey());
+        INIT_BSON(realm::bson::MinKey());
     }
     bsoncxx::bsoncxx(max_key) noexcept
     {
-        m_bson = std::make_shared<realm::bson::Bson>(realm::bson::MaxKey());
+        INIT_BSON(realm::bson::MaxKey());
     }
     bsoncxx::bsoncxx(const timestamp& v) noexcept
     {
-        m_bson = std::make_shared<realm::bson::Bson>(realm::bson::MongoTimestamp(v.m_seconds, v.m_increment));
+        INIT_BSON(realm::bson::MongoTimestamp(v.m_seconds, v.m_increment));
     }
     bsoncxx::bsoncxx(const date& v) noexcept
     {
-        m_bson = std::make_shared<realm::bson::Bson>(realm::Timestamp(v.m_date));
+        INIT_BSON(realm::Timestamp(v.m_date));
     }
     bsoncxx::bsoncxx(const decimal128& v) noexcept
     {
-        m_bson = std::make_shared<realm::bson::Bson>(serialize(v).operator Decimal128());
+        INIT_BSON(serialize(v).operator Decimal128());
     }
     bsoncxx::bsoncxx(const object_id& v) noexcept
     {
-        m_bson = std::make_shared<realm::bson::Bson>(serialize(v).operator ObjectId());
+        INIT_BSON(serialize(v).operator ObjectId());
     }
     bsoncxx::bsoncxx(const uuid& v) noexcept
     {
-        m_bson = std::make_shared<realm::bson::Bson>(serialize(v).operator UUID());
+        INIT_BSON(serialize(v).operator UUID());
     }
     bsoncxx::bsoncxx(const regular_expression& v) noexcept
     {
-        m_bson = std::make_shared<realm::bson::Bson>(v.operator bson::RegularExpression());
+        INIT_BSON(v.operator bson::RegularExpression());
     }
     bsoncxx::bsoncxx(const std::vector<uint8_t>& v) noexcept
     {
-        m_bson = std::make_shared<realm::bson::Bson>(std::vector<char>(v.begin(), v.end()));
+        INIT_BSON(std::vector<char>(v.begin(), v.end()));
     }
     bsoncxx::bsoncxx(const std::string& v) noexcept
     {
-        m_bson = std::make_shared<realm::bson::Bson>(v);
+        INIT_BSON(v);
     }
     bsoncxx::bsoncxx(const char* v) noexcept
     {
-        m_bson = std::make_shared<realm::bson::Bson>(v);
+        INIT_BSON(v);
     }
     bsoncxx::bsoncxx(const document& v) noexcept
     {
-        m_bson = std::make_shared<realm::bson::Bson>(v.operator document::CoreDocument());
+        INIT_BSON(v.operator document::CoreDocument());
     }
     bsoncxx::bsoncxx(const std::vector<bsoncxx>& v) noexcept
     {
@@ -117,12 +149,18 @@ namespace realm {
         std::transform(v.begin(), v.end(), std::back_inserter(core_bson), [](const bsoncxx& b) {
             return b.operator realm::bson::Bson();
         });
-        m_bson = std::make_shared<realm::bson::Bson>(std::move(core_bson));
+        INIT_BSON(std::move(core_bson));
     }
+
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+#define CONST_CORE_BSON reinterpret_cast<const bson::Bson*>(&m_bson)
+#else
+#define CONST_CORE_BSON m_bson
+#endif
 
     bsoncxx::operator realm::bson::Bson() const
     {
-        return *m_bson;
+        return *CONST_CORE_BSON;
     }
 
     bool operator==(const bsoncxx& lhs, const bsoncxx& rhs)
@@ -136,85 +174,85 @@ namespace realm {
 
     bsoncxx::operator std::nullopt_t() const
     {
-        return m_bson->operator util::None();
+        return CONST_CORE_BSON->operator util::None();
     }
     bsoncxx::operator int32_t() const
     {
-        return m_bson->operator int32_t();
+        return CONST_CORE_BSON->operator int32_t();
     }
     bsoncxx::operator int64_t() const
     {
-        return m_bson->operator int64_t();
+        return CONST_CORE_BSON->operator int64_t();
     }
     bsoncxx::operator bool() const
     {
-        return m_bson->operator bool();
+        return CONST_CORE_BSON->operator bool();
     }
     bsoncxx::operator double() const
     {
-        return m_bson->operator double();
+        return CONST_CORE_BSON->operator double();
     }
     bsoncxx::operator min_key() const
     {
-        m_bson->operator bson::MinKey();
+        CONST_CORE_BSON->operator bson::MinKey();
         return min_key();
     }
     bsoncxx::operator max_key() const
     {
-        m_bson->operator bson::MaxKey();
+        CONST_CORE_BSON->operator bson::MaxKey();
         return max_key();
     }
     bsoncxx::operator timestamp() const
     {
-        auto ts = m_bson->operator realm::bson::MongoTimestamp();
+        auto ts = CONST_CORE_BSON->operator realm::bson::MongoTimestamp();
         return timestamp(ts.seconds, ts.increment);
     }
     bsoncxx::operator date() const
     {
-        auto d = m_bson->operator realm::Timestamp();
+        auto d = CONST_CORE_BSON->operator realm::Timestamp();
         return date(d.get_time_point());
     }
     bsoncxx::operator decimal128() const
     {
-        return deserialize(internal::bridge::decimal128(m_bson->operator Decimal128()));
+        return deserialize(internal::bridge::decimal128(CONST_CORE_BSON->operator Decimal128()));
     }
     bsoncxx::operator object_id() const
     {
-        return deserialize(internal::bridge::object_id(m_bson->operator ObjectId()));
+        return deserialize(internal::bridge::object_id(CONST_CORE_BSON->operator ObjectId()));
     }
     bsoncxx::operator uuid() const
     {
-        return deserialize(internal::bridge::uuid(m_bson->operator UUID()));
+        return deserialize(internal::bridge::uuid(CONST_CORE_BSON->operator UUID()));
     }
     bsoncxx::operator regular_expression() const
     {
-        return regular_expression(m_bson->operator const realm::bson::RegularExpression &());
+        return regular_expression(CONST_CORE_BSON->operator const realm::bson::RegularExpression &());
     }
     bsoncxx::operator std::vector<uint8_t>() const
     {
-        auto data = m_bson->operator std::vector<char>&();
+        auto data = CONST_CORE_BSON->operator const std::vector<char>&();
         return std::vector<uint8_t>(data.begin(), data.end());
     }
     bsoncxx::operator std::string() const
     {
-        return m_bson->operator std::string &();
+        return CONST_CORE_BSON->operator const std::string &();
     }
     bsoncxx::operator document() const
     {
-        auto doc = m_bson->operator const realm::bson::IndexedMap<realm::bson::Bson>&();
+        auto doc = CONST_CORE_BSON->operator const realm::bson::IndexedMap<realm::bson::Bson>&();
         return bsoncxx::document(doc);
     }
     bsoncxx::operator std::vector<bsoncxx>() const
     {
         std::vector<bsoncxx> ret;
-        for(auto v : m_bson->operator std::vector<realm::bson::Bson>&()) {
+        for(auto v : CONST_CORE_BSON->operator const std::vector<realm::bson::Bson>&()) {
             ret.push_back(v);
         }
         return ret;
     }
 
     bsoncxx::type bsoncxx::get_type() const {
-        switch(m_bson->type()){
+        switch(CONST_CORE_BSON->type()){
             case realm::bson::Bson::Type::Null:
                 return bsoncxx::type::b_null;
             case realm::bson::Bson::Type::Int32:
@@ -256,12 +294,12 @@ namespace realm {
 
     std::string bsoncxx::to_string() const
     {
-        return m_bson->to_string();
+        return CONST_CORE_BSON->to_string();
     }
 
     std::string bsoncxx::to_json() const
     {
-        return m_bson->toJson();
+        return CONST_CORE_BSON->toJson();
     }
 
     /*
@@ -270,9 +308,21 @@ namespace realm {
     ===========================
     */
 
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+#define CONST_CORE_DOCUMENT reinterpret_cast<const CoreDocument*>(&m_document)
+#define CORE_DOCUMENT reinterpret_cast<CoreDocument*>(&m_document)
+#else
+#define CONST_CORE_DOCUMENT m_document
+#define CORE_DOCUMENT CONST_CORE_DOCUMENT
+#endif
+
     bsoncxx::document::document() noexcept
     {
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+        new (&m_document) CoreDocument();
+#else
         m_document = std::make_shared<CoreDocument>();
+#endif
     }
     bsoncxx::document::document(const std::initializer_list<std::pair<std::string, bsoncxx>>& v) noexcept
     {
@@ -280,63 +330,89 @@ namespace realm {
         for (auto& [k, v] : v) {
             core_document[k] = v.operator realm::bson::Bson();
         }
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+        new (&m_document) CoreDocument(std::move(core_document));
+#else
         m_document = std::make_shared<CoreDocument>(std::move(core_document));
+#endif
     }
     bsoncxx::document::document(const document& v)
     {
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+        *reinterpret_cast<CoreDocument*>(&m_document) = *reinterpret_cast<const CoreDocument*>(&v.m_document);
+#else
         m_document = v.m_document;
+#endif
     }
     bsoncxx::document::document(document&& v)
     {
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+        *reinterpret_cast<CoreDocument*>(&m_document) = std::move(*reinterpret_cast<const CoreDocument*>(&v.m_document));
+#else
         m_document = std::move(v.m_document);
+#endif
     }
     bsoncxx::document::~document()
     {
-
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+        reinterpret_cast<CoreDocument*>(&m_document)->~CoreDocument();
+#endif
     }
     bsoncxx::document& bsoncxx::document::operator=(const document& v)
     {
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+        *reinterpret_cast<CoreDocument*>(&m_document) = *reinterpret_cast<const CoreDocument*>(&v.m_document);
+#else
         m_document = v.m_document;
+#endif
         return *this;
     }
     bsoncxx::document& bsoncxx::document::operator=(document&& v)
     {
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+        *reinterpret_cast<CoreDocument*>(&m_document) = std::move(*reinterpret_cast<const CoreDocument*>(&v.m_document));
+#else
         m_document = std::move(v.m_document);
+#endif
         return *this;
     }
     bsoncxx::document::document(CoreDocument& doc) noexcept
     {
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+        *reinterpret_cast<CoreDocument*>(&m_document) = *reinterpret_cast<const CoreDocument*>(&doc);
+#else
         m_document = std::make_shared<CoreDocument>(doc);
+#endif
     }
 
     void bsoncxx::document::insert(const std::string& key, const bsoncxx& v)
     {
-        m_document->operator[](key) = v.operator realm::bson::Bson();
+        CORE_DOCUMENT->operator[](key) = v.operator realm::bson::Bson();
     }
 
     void bsoncxx::document::pop_back()
     {
-        m_document->pop_back();
+        CORE_DOCUMENT->pop_back();
     };
 
-    bool bsoncxx::document::empty() const
+    bool bsoncxx::document::empty()
     {
-        return m_document->empty();
+        return CORE_DOCUMENT->empty();
     };
 
     size_t bsoncxx::document::size() const
     {
-        return m_document->size();
+        return CONST_CORE_DOCUMENT->size();
     };
 
     bsoncxx::document::value bsoncxx::document::operator[](const std::string& key)
     {
-        return bsoncxx::document::value(m_document, key);
+        return bsoncxx::document::value(CORE_DOCUMENT, key);
     }
 
     bsoncxx::document::operator CoreDocument() const
     {
-        return *m_document;
+        return *CONST_CORE_DOCUMENT;
     }
 
     /*
@@ -347,12 +423,12 @@ namespace realm {
 
     bsoncxx::document::iterator bsoncxx::document::begin()
     {
-        return bsoncxx::document::iterator(m_document, 0);
+        return bsoncxx::document::iterator(CORE_DOCUMENT, 0);
     }
 
     bsoncxx::document::iterator bsoncxx::document::end()
     {
-        return bsoncxx::document::iterator(m_document, m_document->size());
+        return bsoncxx::document::iterator(CORE_DOCUMENT, CONST_CORE_DOCUMENT->size());
     }
 
     std::pair<std::string, bsoncxx> bsoncxx::document::iterator::operator*()
@@ -407,24 +483,29 @@ namespace realm {
 
     bsoncxx::regular_expression::regular_expression(const realm::bson::RegularExpression& v)
     {
-        m_reg_expr = std::make_shared<realm::bson::RegularExpression>(v);
+        m_pattern = v.pattern();
+        m_options = static_cast<bsoncxx::regular_expression::option>(v.options());
     }
     bsoncxx::regular_expression::regular_expression(const std::string& pattern, const std::string& options)
     {
-        m_reg_expr = std::make_shared<realm::bson::RegularExpression>(pattern, options);
+        realm::bson::RegularExpression expression(pattern, options);
+        m_pattern = expression.pattern();
+        m_options = static_cast<bsoncxx::regular_expression::option>(expression.options());
     }
     bsoncxx::regular_expression::regular_expression(const std::string& pattern, option options)
     {
-        m_reg_expr = std::make_shared<realm::bson::RegularExpression>(pattern, static_cast<realm::bson::RegularExpression::Option>(options));
+        m_pattern = pattern;
+        m_options = options;
     }
     bsoncxx::regular_expression::regular_expression()
     {
-        m_reg_expr = std::make_shared<realm::bson::RegularExpression>();
+        m_pattern = "";
+        m_options = bsoncxx::regular_expression::option::none;
     }
 
     bsoncxx::regular_expression::operator realm::bson::RegularExpression() const
     {
-        return *m_reg_expr;
+        return realm::bson::RegularExpression(m_pattern, static_cast<realm::bson::RegularExpression::Option>(m_options));
     }
 
     static_assert((int)realm::bson::RegularExpression::Option::None == (int)bsoncxx::regular_expression::option::none);
@@ -435,12 +516,12 @@ namespace realm {
 
     bsoncxx::regular_expression::option bsoncxx::regular_expression::get_options() const
     {
-        return static_cast<bsoncxx::regular_expression::option>(m_reg_expr->options());
+        return m_options;
     }
 
     std::string bsoncxx::regular_expression::get_pattern() const
     {
-        return m_reg_expr->pattern();
+        return m_pattern;
     }
 
     bsoncxx::regular_expression::option operator|(const bsoncxx::regular_expression::option& lhs,

--- a/src/cpprealm/bson.cpp
+++ b/src/cpprealm/bson.cpp
@@ -419,6 +419,19 @@ namespace realm {
         return *CONST_CORE_DOCUMENT;
     }
 
+    bool operator==(const bsoncxx::document& lhs, const bsoncxx::document& rhs)
+    {
+        auto l = lhs.operator bsoncxx::document::CoreDocument();
+        auto r = rhs.operator bsoncxx::document::CoreDocument();
+        return l.keys() == r.keys() && l.entries() == r.entries();
+    }
+    bool operator!=(const bsoncxx::document& lhs, const bsoncxx::document& rhs)
+    {
+        auto l = lhs.operator bsoncxx::document::CoreDocument();
+        auto r = rhs.operator bsoncxx::document::CoreDocument();
+        return l.keys() != r.keys() || l.entries() != r.entries();
+    }
+
     /*
     ===========================
     bsoncxx::document::iterator

--- a/src/cpprealm/bson.cpp
+++ b/src/cpprealm/bson.cpp
@@ -3,6 +3,13 @@
 #include <realm/util/bson/bson.hpp>
 
 namespace realm {
+
+    /*
+    ===========================
+    bsoncxx
+    ===========================
+    */
+
     bsoncxx::bsoncxx() noexcept
     {
         m_bson = std::make_shared<realm::bson::Bson>();
@@ -127,74 +134,80 @@ namespace realm {
         return lhs.operator realm::bson::Bson() != rhs.operator realm::bson::Bson();
     }
 
-    bsoncxx::operator int32_t() noexcept
+    bsoncxx::operator std::nullopt_t() const
+    {
+        return m_bson->operator util::None();
+    }
+    bsoncxx::operator int32_t() const
     {
         return m_bson->operator int32_t();
     }
-    bsoncxx::operator int64_t() noexcept
+    bsoncxx::operator int64_t() const
     {
         return m_bson->operator int64_t();
     }
-    bsoncxx::operator bool() noexcept
+    bsoncxx::operator bool() const
     {
         return m_bson->operator bool();
     }
-    bsoncxx::operator double() noexcept
+    bsoncxx::operator double() const
     {
         return m_bson->operator double();
     }
-    bsoncxx::operator min_key() noexcept
+    bsoncxx::operator min_key() const
     {
+        m_bson->operator bson::MinKey();
         return min_key();
     }
-    bsoncxx::operator max_key() noexcept
+    bsoncxx::operator max_key() const
     {
+        m_bson->operator bson::MaxKey();
         return max_key();
     }
-    bsoncxx::operator const timestamp() noexcept
+    bsoncxx::operator timestamp() const
     {
         auto ts = m_bson->operator realm::bson::MongoTimestamp();
         return timestamp(ts.seconds, ts.increment);
     }
-    bsoncxx::operator const date() noexcept
+    bsoncxx::operator date() const
     {
         auto d = m_bson->operator realm::Timestamp();
         return date(d.get_time_point());
     }
-    bsoncxx::operator const decimal128() noexcept
+    bsoncxx::operator decimal128() const
     {
         return deserialize(internal::bridge::decimal128(m_bson->operator Decimal128()));
     }
-    bsoncxx::operator const object_id() noexcept
+    bsoncxx::operator object_id() const
     {
         return deserialize(internal::bridge::object_id(m_bson->operator ObjectId()));
     }
-    bsoncxx::operator const uuid() noexcept
+    bsoncxx::operator uuid() const
     {
         return deserialize(internal::bridge::uuid(m_bson->operator UUID()));
     }
-    bsoncxx::operator const regular_expression() noexcept
+    bsoncxx::operator regular_expression() const
     {
         return regular_expression(m_bson->operator const realm::bson::RegularExpression &());
     }
-    bsoncxx::operator const std::vector<uint8_t>() noexcept
+    bsoncxx::operator std::vector<uint8_t>() const
     {
-        auto data = m_bson->operator const std::vector<char>&();
+        auto data = m_bson->operator std::vector<char>&();
         return std::vector<uint8_t>(data.begin(), data.end());
     }
-    bsoncxx::operator const std::string() noexcept
+    bsoncxx::operator std::string() const
     {
         return m_bson->operator std::string &();
     }
-    bsoncxx::operator const document() noexcept
+    bsoncxx::operator document() const
     {
         auto doc = m_bson->operator const realm::bson::IndexedMap<realm::bson::Bson>&();
         return bsoncxx::document(doc);
     }
-    bsoncxx::operator const std::vector<bsoncxx>() noexcept
+    bsoncxx::operator std::vector<bsoncxx>() const
     {
         std::vector<bsoncxx> ret;
-        for(auto v : m_bson->operator const std::vector<realm::bson::Bson>&()) {
+        for(auto v : m_bson->operator std::vector<realm::bson::Bson>&()) {
             ret.push_back(v);
         }
         return ret;
@@ -239,6 +252,21 @@ namespace realm {
         }
     }
 
+    std::string bsoncxx::to_string() const
+    {
+        return m_bson->to_string();
+    }
+
+    std::string bsoncxx::to_json() const
+    {
+        return m_bson->toJson();
+    }
+
+    /*
+    ===========================
+    bsoncxx::document
+    ===========================
+    */
 
     bsoncxx::document::document() noexcept
     {
@@ -309,10 +337,11 @@ namespace realm {
         return *m_document;
     }
 
-    bsoncxx::regular_expression::operator realm::bson::RegularExpression() const
-    {
-        return realm::bson::RegularExpression();
-    }
+    /*
+    ===========================
+    bsoncxx::document::iterator
+    ===========================
+    */
 
     bsoncxx::document::iterator bsoncxx::document::begin()
     {
@@ -367,4 +396,70 @@ namespace realm {
     {
         return bsoncxx(m_document->operator[](key));
     }
-}
+
+    /*
+    ===========================
+    bsoncxx::regular_expression
+    ===========================
+    */
+
+    bsoncxx::regular_expression::regular_expression(const realm::bson::RegularExpression& v)
+    {
+        m_reg_expr = std::make_shared<realm::bson::RegularExpression>(v);
+    }
+    bsoncxx::regular_expression::regular_expression(const std::string& pattern, const std::string& options)
+    {
+        m_reg_expr = std::make_shared<realm::bson::RegularExpression>(pattern, options);
+    }
+    bsoncxx::regular_expression::regular_expression(const std::string& pattern, option options)
+    {
+        m_reg_expr = std::make_shared<realm::bson::RegularExpression>(pattern, static_cast<realm::bson::RegularExpression::Option>(options));
+    }
+    bsoncxx::regular_expression::regular_expression()
+    {
+        m_reg_expr = std::make_shared<realm::bson::RegularExpression>();
+    }
+
+    bsoncxx::regular_expression::operator realm::bson::RegularExpression() const
+    {
+        return *m_reg_expr;
+    }
+
+    static_assert((int)realm::bson::RegularExpression::Option::None == (int)bsoncxx::regular_expression::option::none);
+    static_assert((int)realm::bson::RegularExpression::Option::Multiline == (int)bsoncxx::regular_expression::option::multiline);
+    static_assert((int)realm::bson::RegularExpression::Option::IgnoreCase == (int)bsoncxx::regular_expression::option::ignore_case);
+    static_assert((int)realm::bson::RegularExpression::Option::Extended == (int)bsoncxx::regular_expression::option::extended);
+    static_assert((int)realm::bson::RegularExpression::Option::Dotall == (int)bsoncxx::regular_expression::option::dotall);
+
+    bsoncxx::regular_expression::option bsoncxx::regular_expression::get_options() const
+    {
+        return static_cast<bsoncxx::regular_expression::option>(m_reg_expr->options());
+    }
+
+    std::string bsoncxx::regular_expression::get_pattern() const
+    {
+        return m_reg_expr->pattern();
+    }
+
+    bsoncxx::regular_expression::option operator|(const bsoncxx::regular_expression::option& lhs,
+                                                  const bsoncxx::regular_expression::option& rhs) noexcept
+    {
+        return bsoncxx::regular_expression::option(static_cast<int>(lhs) | static_cast<int>(rhs));
+    }
+
+    bsoncxx::regular_expression::option operator&(const bsoncxx::regular_expression::option& lhs,
+                                                  const bsoncxx::regular_expression::option& rhs) noexcept
+    {
+        return bsoncxx::regular_expression::option(static_cast<int>(lhs) & static_cast<int>(rhs));
+    }
+
+    bool operator==(const bsoncxx::regular_expression& lhs, const bsoncxx::regular_expression& rhs) noexcept
+    {
+        return lhs.operator realm::bson::RegularExpression() == rhs.operator realm::bson::RegularExpression();
+    }
+    bool operator!=(const bsoncxx::regular_expression& lhs, const bsoncxx::regular_expression& rhs) noexcept
+    {
+        return lhs.operator realm::bson::RegularExpression() != rhs.operator realm::bson::RegularExpression();
+    }
+
+} // namespace realm

--- a/src/cpprealm/bson.hpp
+++ b/src/cpprealm/bson.hpp
@@ -21,12 +21,12 @@
 
 #include <cpprealm/types.hpp>
 #include <cpprealm/internal/bridge/utils.hpp>
+#include <any>
 
 namespace realm {
     namespace bson {
         class Bson;
-        template <typename>
-        class IndexedMap;
+        class BsonDocument;
         struct RegularExpression;
     }
 
@@ -82,7 +82,7 @@ namespace realm {
         };
 
         struct document {
-            using CoreDocument = realm::bson::IndexedMap<realm::bson::Bson>;
+            using CoreDocument = realm::bson::BsonDocument;
 
             struct value {
                 value& operator=(const bsoncxx& v);
@@ -105,9 +105,8 @@ namespace realm {
                 bool operator==(const iterator& rhs) const noexcept;
             private:
                 friend struct document;
-                iterator(CoreDocument* d, size_t i) : m_document(d), m_idx(i) {};
-                size_t m_idx = 0;
-                CoreDocument* m_document;
+                iterator(std::any&& i) : m_iterator(i) { }
+                std::any m_iterator;
             };
             iterator begin();
             iterator end();
@@ -120,7 +119,6 @@ namespace realm {
             document& operator=(const document&);
             document& operator=(document&&);
             void insert(const std::string& key, const bsoncxx& value);
-            void pop_back();
             bool empty();
             size_t size() const;
             value operator[](const std::string&);

--- a/src/cpprealm/bson.hpp
+++ b/src/cpprealm/bson.hpp
@@ -244,6 +244,8 @@ namespace realm {
 
     bool operator==(const bsoncxx& lhs, const bsoncxx& rhs);
     bool operator!=(const bsoncxx& lhs, const bsoncxx& rhs);
+    bool operator==(const bsoncxx::document& lhs, const bsoncxx::document& rhs);
+    bool operator!=(const bsoncxx::document& lhs, const bsoncxx::document& rhs);
     bool operator==(const bsoncxx::regular_expression& lhs, const bsoncxx::regular_expression& rhs) noexcept;
     bool operator!=(const bsoncxx::regular_expression& lhs, const bsoncxx::regular_expression& rhs) noexcept;
     bsoncxx::regular_expression::option operator|(const bsoncxx::regular_expression::option& lhs,

--- a/src/cpprealm/bson.hpp
+++ b/src/cpprealm/bson.hpp
@@ -31,6 +31,8 @@ namespace realm {
 
     struct bsoncxx {
 
+        using array = std::vector<bsoncxx>;
+
         enum class type {
             b_null,
             b_int32,
@@ -95,9 +97,9 @@ namespace realm {
             size_t size() const;
             value operator[](const std::string&);
             operator CoreDocument() const;
+            document(CoreDocument&) noexcept;
         private:
             friend struct bsoncxx;
-            document(CoreDocument&) noexcept;
             std::shared_ptr<CoreDocument> m_document;
         };
 
@@ -183,13 +185,12 @@ namespace realm {
         operator std::vector<uint8_t>() const;
         operator std::string() const;
         operator document() const;
-        operator std::vector<bsoncxx>() const;
+        operator array() const;
 
         std::string to_string() const;
         std::string to_json() const;
-    private:
-        friend struct document::value;
         bsoncxx(realm::bson::Bson&) noexcept;
+    private:
         std::shared_ptr<realm::bson::Bson> m_bson;
     };
 

--- a/src/cpprealm/bson.hpp
+++ b/src/cpprealm/bson.hpp
@@ -1,0 +1,108 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2024 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+#ifndef REALMCXX_BSON_HPP
+#define REALMCXX_BSON_HPP
+
+#include <cpprealm/types.hpp>
+
+namespace realm {
+    namespace bson {
+        class Bson;
+        template <typename>
+        class IndexedMap;
+        class RegularExpression;
+    }
+
+
+    struct bsoncxx {
+
+        enum class type {
+            b_null,
+            b_int32,
+            b_int64,
+            b_bool,
+            b_double,
+            b_string,
+            b_binary,
+            b_timestamp,
+            b_datetime,
+            b_objectId,
+            b_decimal128,
+            b_regular_expression,
+            b_max_key,
+            b_min_key,
+            b_document,
+            b_array,
+            b_uuid
+        };
+
+        struct document {
+            document() noexcept;
+            document(const std::vector<std::pair<std::string, bsoncxx>>&) noexcept;
+            document(const document&);
+            document(document&&);
+            ~document();
+            document& operator=(const document&);
+            document& operator=(document&&);
+
+            using CoreDocument = realm::bson::IndexedMap<realm::bson::Bson>;
+            operator CoreDocument() const;
+        private:
+            std::shared_ptr<CoreDocument> m_document;
+        };
+
+        struct min_key {};
+        struct max_key {};
+        struct regular_expression {
+            operator realm::bson::RegularExpression() const;
+        };
+
+        bsoncxx() noexcept;
+        ~bsoncxx() noexcept;
+        bsoncxx(const bsoncxx&) noexcept;
+        bsoncxx(bsoncxx&&) noexcept;
+        bsoncxx& operator=(const bsoncxx&) noexcept;
+        bsoncxx& operator=(bsoncxx&&) noexcept;
+
+        bsoncxx(int32_t) noexcept;
+        bsoncxx(int64_t) noexcept;
+        bsoncxx(bool) noexcept;
+        bsoncxx(double) noexcept;
+        bsoncxx(min_key) noexcept;
+        bsoncxx(max_key) noexcept;
+        bsoncxx(const std::chrono::time_point<std::chrono::system_clock>&) noexcept;
+//        bsoncxx(realm::Timestamp) noexcept;
+        bsoncxx(const decimal128&) noexcept;
+        bsoncxx(const object_id&) noexcept;
+        bsoncxx(const uuid&) noexcept;
+
+        bsoncxx(const regular_expression&) noexcept;
+        bsoncxx(const std::vector<uint8_t>&) noexcept;
+        bsoncxx(const std::string&) noexcept;
+        bsoncxx(const char*) noexcept;
+        bsoncxx(const document&) noexcept;
+        bsoncxx(const std::vector<bsoncxx>&) noexcept;
+        type get_type() const;
+        operator realm::bson::Bson() const;
+    private:
+        std::shared_ptr<realm::bson::Bson> m_bson;
+    };
+} // namespace realm
+
+#endif//REALMCXX_BSON_HPP

--- a/src/cpprealm/bson.hpp
+++ b/src/cpprealm/bson.hpp
@@ -85,7 +85,7 @@ namespace realm {
             iterator end();
 
             document() noexcept;
-            document(const std::vector<std::pair<std::string, bsoncxx>>&) noexcept;
+            document(const std::initializer_list<std::pair<std::string, bsoncxx>>&) noexcept;
             document(const document&);
             document(document&&);
             ~document();

--- a/src/cpprealm/internal/bridge/generator/CMakeLists.txt
+++ b/src/cpprealm/internal/bridge/generator/CMakeLists.txt
@@ -8,6 +8,7 @@ set(BRIDGE_TYPE_REQUIRED_HEADERS
     realm/object-store/sync/app.hpp
     realm/sync/config.hpp
     realm/sync/subscriptions.hpp
+    realm/util/bson/bson.hpp
 )
 
 set(BRIDGE_TYPES
@@ -48,6 +49,8 @@ set(BRIDGE_TYPES
     AppError realm::app::AppError
     SyncSubscriptionSet realm::sync::SubscriptionSet
     MutableSyncSubscriptionSet realm::sync::MutableSubscriptionSet
+    Bson realm::bson::Bson
+    BsonIndexedMap realm::bson::IndexedMap<realm::bson::Bson>
 )
 
 while(BRIDGE_TYPES)

--- a/src/cpprealm/internal/bridge/generator/CMakeLists.txt
+++ b/src/cpprealm/internal/bridge/generator/CMakeLists.txt
@@ -51,6 +51,7 @@ set(BRIDGE_TYPES
     MutableSyncSubscriptionSet realm::sync::MutableSubscriptionSet
     Bson realm::bson::Bson
     BsonIndexedMap realm::bson::IndexedMap<realm::bson::Bson>
+    BsonDocument realm::bson::BsonDocument
 )
 
 while(BRIDGE_TYPES)

--- a/src/cpprealm/sdk.hpp
+++ b/src/cpprealm/sdk.hpp
@@ -21,6 +21,7 @@
 
 #include <utility>
 
+#include <cpprealm/bson.hpp>
 #include <cpprealm/schema.hpp>
 #include <cpprealm/notifications.hpp>
 #include <cpprealm/app.hpp>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -34,6 +34,7 @@ add_executable(cpprealm_db_tests
                 main.cpp
                 db/test_objects.hpp
                 db/binary_tests.cpp
+                db/bson_tests.cpp
                 db/date_tests.cpp
                 db/decimal_tests.cpp
                 db/embedded_object_tests.cpp

--- a/tests/db/bson_tests.cpp
+++ b/tests/db/bson_tests.cpp
@@ -1,0 +1,57 @@
+#include "../main.hpp"
+#include "test_objects.hpp"
+
+TEST_CASE("bson", "[bson]") {
+    SECTION("types") {
+        auto bson = realm::bsoncxx();
+        CHECK(bson.get_type() == realm::bsoncxx::type::b_null);
+
+        bson = realm::bsoncxx((int32_t)123);
+        CHECK(bson.get_type() == realm::bsoncxx::type::b_int32);
+
+        bson = realm::bsoncxx((int64_t)123);
+        CHECK(bson.get_type() == realm::bsoncxx::type::b_int64);
+
+        bson = realm::bsoncxx(true);
+        CHECK(bson.get_type() == realm::bsoncxx::type::b_bool);
+
+        bson = realm::bsoncxx(123.456);
+        CHECK(bson.get_type() == realm::bsoncxx::type::b_double);
+
+        bson = realm::bsoncxx(std::string("foo"));
+        CHECK(bson.get_type() == realm::bsoncxx::type::b_string);
+
+        bson = realm::bsoncxx("foo");
+        CHECK(bson.get_type() == realm::bsoncxx::type::b_string);
+
+        bson = realm::bsoncxx(std::vector<uint8_t>({0,0,0,0}));
+        CHECK(bson.get_type() == realm::bsoncxx::type::b_binary);
+
+        bson = realm::bsoncxx(std::chrono::system_clock::now());
+        CHECK(bson.get_type() == realm::bsoncxx::type::b_timestamp);
+
+        bson = realm::bsoncxx(realm::object_id::generate());
+        CHECK(bson.get_type() == realm::bsoncxx::type::b_objectId);
+
+        bson = realm::bsoncxx(realm::decimal128(123.456));
+        CHECK(bson.get_type() == realm::bsoncxx::type::b_decimal128);
+
+        bson = realm::bsoncxx(realm::bsoncxx::regular_expression());
+        CHECK(bson.get_type() == realm::bsoncxx::type::b_regular_expression);
+
+        bson = realm::bsoncxx(realm::bsoncxx::max_key());
+        CHECK(bson.get_type() == realm::bsoncxx::type::b_max_key);
+
+        bson = realm::bsoncxx(realm::bsoncxx::min_key());
+        CHECK(bson.get_type() == realm::bsoncxx::type::b_min_key);
+
+        bson = realm::bsoncxx(realm::bsoncxx::document({{"name", "foo"}}));
+        CHECK(bson.get_type() == realm::bsoncxx::type::b_document);
+
+        bson = realm::bsoncxx(std::vector<realm::bsoncxx>({{"one", 123, true}}));
+        CHECK(bson.get_type() == realm::bsoncxx::type::b_array);
+
+        bson = realm::bsoncxx(realm::uuid());
+        CHECK(bson.get_type() == realm::bsoncxx::type::b_uuid);
+    }
+}

--- a/tests/db/bson_tests.cpp
+++ b/tests/db/bson_tests.cpp
@@ -123,7 +123,7 @@ TEST_CASE("types", "[bson]") {
 
 TEST_CASE("document", "[bson]") {
     SECTION("assign subscript") {
-        auto doc = realm::bsoncxx::document();
+        auto doc = realm::bsoncxx::document({{}});
         doc["key"] = "value";
         auto str_val = doc["key"];
         CHECK(str_val == "value");

--- a/tests/db/bson_tests.cpp
+++ b/tests/db/bson_tests.cpp
@@ -194,7 +194,7 @@ TEST_CASE("regular expression", "[bson]") {
     SECTION("comparison") {
         auto regex = realm::bsoncxx::regular_expression("[0-9]", "i");
         auto regex2 = realm::bsoncxx::regular_expression("[0-9]", "i");
-        auto regex3 = realm::bsoncxx::regular_expression("[0-9]", "d");
+        auto regex3 = realm::bsoncxx::regular_expression("[0-9]", "m");
         CHECK(regex == regex2);
         CHECK(regex != regex3);
     }

--- a/tests/db/bson_tests.cpp
+++ b/tests/db/bson_tests.cpp
@@ -21,9 +21,6 @@ TEST_CASE("types", "[bson]") {
         bson = realm::bsoncxx(std::string("foo"));
         CHECK(bson.get_type() == realm::bsoncxx::type::b_string);
 
-        bson = realm::bsoncxx("foo");
-        CHECK(bson.get_type() == realm::bsoncxx::type::b_string);
-
         bson = realm::bsoncxx(std::vector<uint8_t>({0, 0, 0, 0}));
         CHECK(bson.get_type() == realm::bsoncxx::type::b_binary);
 
@@ -59,9 +56,68 @@ TEST_CASE("types", "[bson]") {
     }
 
     SECTION("value operator") {
+        auto bson = realm::bsoncxx();
+        CHECK(bson.get_type() == realm::bsoncxx::type::b_null);
+
+        bson = realm::bsoncxx((int32_t) 123);
+        CHECK(bson.operator int32_t() == (int32_t)123);
+
+        bson = realm::bsoncxx((int64_t) 123);
+        CHECK(bson.operator int64_t() == (int64_t)123);
+
+        bson = realm::bsoncxx(true);
+        CHECK(bson.operator bool() == true);
+
+        bson = realm::bsoncxx(123.456);
+        CHECK(bson.operator double() == 123.456);
+
+        bson = realm::bsoncxx(std::string("foo"));
+        CHECK(bson.operator std::string() == std::string("foo"));
+
+        bson = realm::bsoncxx(std::vector<uint8_t>({0, 0, 0, 0}));
+        CHECK(bson.operator std::vector<uint8_t>() == std::vector<uint8_t>({0, 0, 0, 0}));
+
+        bson = realm::bsoncxx(realm::bsoncxx::timestamp(100, 0));
+        CHECK(bson.operator realm::bsoncxx::timestamp() == realm::bsoncxx::timestamp(100, 0));
+
+        auto d = std::chrono::system_clock::now();
+        bson = realm::bsoncxx(realm::bsoncxx::date(d));
+        CHECK(bson.operator realm::bsoncxx::date() == realm::bsoncxx::date(d));
+
+        auto oid = realm::object_id::generate();
+        bson = realm::bsoncxx(oid);
+        CHECK(bson.operator realm::object_id() == oid);
+
+        bson = realm::bsoncxx(realm::decimal128(123.456));
+        CHECK(bson.operator realm::decimal128() == realm::decimal128(123.456));
+
+        bson = realm::bsoncxx(realm::bsoncxx::regular_expression("[0-9]", "i"));
+        CHECK(bson.operator realm::bsoncxx::regular_expression() == realm::bsoncxx::regular_expression("[0-9]", "i"));
+
+        bson = realm::bsoncxx(realm::bsoncxx::max_key());
+        CHECK(bson.operator realm::bsoncxx::max_key() == realm::bsoncxx::max_key());
+
+        bson = realm::bsoncxx(realm::bsoncxx::min_key());
+        CHECK(bson.operator realm::bsoncxx::min_key() == realm::bsoncxx::min_key());
+
+        bson = realm::bsoncxx(realm::bsoncxx::document({{"name", "foo"}}));
+        CHECK(bson.operator realm::bsoncxx::document() == realm::bsoncxx::document({{"name", "foo"}}));
+
+        bson = realm::bsoncxx(std::vector<realm::bsoncxx>({{"one", 123, true}}));
+        CHECK(bson.operator std::vector<realm::bsoncxx>() == std::vector<realm::bsoncxx>({{"one", 123, true}}));
+
+        bson = realm::bsoncxx(realm::uuid());
+        CHECK(bson.operator realm::uuid() == realm::uuid());
     }
 
-    SECTION("assignment operator") {
+    SECTION("comparision") {
+        auto bson1 = realm::bsoncxx();
+        auto bson2 = realm::bsoncxx();
+        auto bson3 = realm::bsoncxx("foo");
+        CHECK(bson1.get_type() == realm::bsoncxx::type::b_null);
+        CHECK(bson2.get_type() == realm::bsoncxx::type::b_null);
+        CHECK(bson1 == bson2);
+        CHECK(bson1 != bson3);
     }
 }
 
@@ -104,9 +160,65 @@ TEST_CASE("document", "[bson]") {
     }
 
     SECTION("comparison") {
+        auto doc = realm::bsoncxx::document();
+        doc["key"] = "value";
 
+        auto doc2 = realm::bsoncxx::document();
+        doc2["key"] = "value";
+        CHECK(doc == doc2);
+
+        doc2["key"] = 123;
+        CHECK(doc != doc2);
     }
 }
 
 TEST_CASE("regular expression", "[bson]") {
+    SECTION("options") {
+        auto regex = realm::bsoncxx::regular_expression("[0-9]", "i");
+        CHECK(regex.get_options() == realm::bsoncxx::regular_expression::option::ignore_case);
+        CHECK(regex.get_pattern() == "[0-9]");
+
+        regex = realm::bsoncxx::regular_expression("[0-9]", realm::bsoncxx::regular_expression::option::dotall);
+        CHECK(regex.get_options() == realm::bsoncxx::regular_expression::option::dotall);
+        CHECK(regex.get_pattern() == "[0-9]");
+        realm::bsoncxx::regular_expression::option options;
+        options = options | realm::bsoncxx::regular_expression::option::dotall;
+        options = options | realm::bsoncxx::regular_expression::option::extended;
+        options = options | realm::bsoncxx::regular_expression::option::ignore_case;
+        options = options | realm::bsoncxx::regular_expression::option::multiline;
+        regex = realm::bsoncxx::regular_expression("[0-9]", options);
+        CHECK(regex.get_options() == options);
+        CHECK(regex.get_pattern() == "[0-9]");
+    }
+
+    SECTION("comparison") {
+        auto regex = realm::bsoncxx::regular_expression("[0-9]", "i");
+        auto regex2 = realm::bsoncxx::regular_expression("[0-9]", "i");
+        auto regex3 = realm::bsoncxx::regular_expression("[0-9]", "d");
+        CHECK(regex == regex2);
+        CHECK(regex != regex3);
+    }
+}
+
+TEST_CASE("timestamps", "[bson]") {
+    auto timestamp1 = realm::bsoncxx::timestamp(100, 200);
+    auto timestamp2 = realm::bsoncxx::timestamp(100, 200);
+    auto timestamp3 = realm::bsoncxx::timestamp(300, 200);
+
+    CHECK(timestamp1 == timestamp2);
+    CHECK(timestamp1 != timestamp3);
+
+    CHECK(timestamp1.get_seconds() == 100);
+    CHECK(timestamp1.get_increment() == 200);
+
+    auto d = std::chrono::system_clock::now();
+
+    auto date1 = realm::bsoncxx::date(d);
+    auto date2 = realm::bsoncxx::date(d);
+    auto date3 = realm::bsoncxx::date(std::chrono::system_clock::time_point());
+
+    CHECK(date1 == date2);
+    CHECK(date1 != date3);
+
+    CHECK(date1.get_date() == d);
 }

--- a/tests/db/bson_tests.cpp
+++ b/tests/db/bson_tests.cpp
@@ -1,15 +1,15 @@
 #include "../main.hpp"
 #include "test_objects.hpp"
 
-TEST_CASE("bson", "[bson]") {
-    SECTION("types") {
+TEST_CASE("types", "[bson]") {
+    SECTION("creates correct type") {
         auto bson = realm::bsoncxx();
         CHECK(bson.get_type() == realm::bsoncxx::type::b_null);
 
-        bson = realm::bsoncxx((int32_t)123);
+        bson = realm::bsoncxx((int32_t) 123);
         CHECK(bson.get_type() == realm::bsoncxx::type::b_int32);
 
-        bson = realm::bsoncxx((int64_t)123);
+        bson = realm::bsoncxx((int64_t) 123);
         CHECK(bson.get_type() == realm::bsoncxx::type::b_int64);
 
         bson = realm::bsoncxx(true);
@@ -24,11 +24,14 @@ TEST_CASE("bson", "[bson]") {
         bson = realm::bsoncxx("foo");
         CHECK(bson.get_type() == realm::bsoncxx::type::b_string);
 
-        bson = realm::bsoncxx(std::vector<uint8_t>({0,0,0,0}));
+        bson = realm::bsoncxx(std::vector<uint8_t>({0, 0, 0, 0}));
         CHECK(bson.get_type() == realm::bsoncxx::type::b_binary);
 
-        bson = realm::bsoncxx(std::chrono::system_clock::now());
+        bson = realm::bsoncxx(realm::bsoncxx::timestamp(100, 0));
         CHECK(bson.get_type() == realm::bsoncxx::type::b_timestamp);
+
+        bson = realm::bsoncxx(realm::bsoncxx::date(std::chrono::system_clock::now()));
+        CHECK(bson.get_type() == realm::bsoncxx::type::b_datetime);
 
         bson = realm::bsoncxx(realm::object_id::generate());
         CHECK(bson.get_type() == realm::bsoncxx::type::b_objectId);
@@ -54,4 +57,56 @@ TEST_CASE("bson", "[bson]") {
         bson = realm::bsoncxx(realm::uuid());
         CHECK(bson.get_type() == realm::bsoncxx::type::b_uuid);
     }
+
+    SECTION("value operator") {
+    }
+
+    SECTION("assignment operator") {
+    }
+}
+
+TEST_CASE("document", "[bson]") {
+    SECTION("assign subscript") {
+        auto doc = realm::bsoncxx::document();
+        doc["key"] = "value";
+        auto str_val = doc["key"];
+        CHECK(str_val == "value");
+    }
+
+    SECTION("iterate") {
+        auto doc = realm::bsoncxx::document();
+        doc["key"] = "value";
+        doc["key2"] = (int64_t)123;
+        auto str_val = doc["key"];
+        CHECK(str_val == "value");
+        auto int_val = doc["key2"];
+        CHECK(int_val == (int64_t)123);
+        size_t count = 0;
+        for(auto [k, v] : doc) {
+            count++;
+            if (count == 1) {
+                CHECK(k == "key");
+                CHECK(v == "value");
+            }
+            else if (count == 2) {
+                CHECK(k == "key2");
+                CHECK(v.operator int64_t() == 123);
+            }
+        }
+        CHECK(count == 2);
+        CHECK(doc.empty() == false);
+        CHECK(doc.size() == 2);
+
+        doc.pop_back();
+        CHECK(doc.size() == 1);
+        doc.pop_back();
+        CHECK(doc.empty() == true);
+    }
+
+    SECTION("comparison") {
+
+    }
+}
+
+TEST_CASE("regular expression", "[bson]") {
 }

--- a/tests/db/bson_tests.cpp
+++ b/tests/db/bson_tests.cpp
@@ -101,7 +101,7 @@ TEST_CASE("types", "[bson]") {
         CHECK(bson.operator realm::bsoncxx::min_key() == realm::bsoncxx::min_key());
 
         bson = realm::bsoncxx(realm::bsoncxx::document({{"name", "foo"}}));
-        CHECK(bson.operator realm::bsoncxx::document() == realm::bsoncxx::document({{"name", "foo"}}));
+        CHECK((bson.operator realm::bsoncxx::document() == realm::bsoncxx::document({{"name", "foo"}})));
 
         bson = realm::bsoncxx(std::vector<realm::bsoncxx>({{"one", 123, true}}));
         CHECK(bson.operator std::vector<realm::bsoncxx>() == std::vector<realm::bsoncxx>({{"one", 123, true}}));
@@ -165,10 +165,10 @@ TEST_CASE("document", "[bson]") {
 
         auto doc2 = realm::bsoncxx::document();
         doc2["key"] = "value";
-        CHECK(doc == doc2);
+        CHECK((doc == doc2));
 
         doc2["key"] = 123;
-        CHECK(doc != doc2);
+        CHECK((doc != doc2));
     }
 }
 

--- a/tests/db/bson_tests.cpp
+++ b/tests/db/bson_tests.cpp
@@ -152,11 +152,6 @@ TEST_CASE("document", "[bson]") {
         CHECK(count == 2);
         CHECK(doc.empty() == false);
         CHECK(doc.size() == 2);
-
-        doc.pop_back();
-        CHECK(doc.size() == 1);
-        doc.pop_back();
-        CHECK(doc.empty() == true);
     }
 
     SECTION("comparison") {

--- a/tests/sync/asymmetric_object_tests.cpp
+++ b/tests/sync/asymmetric_object_tests.cpp
@@ -20,8 +20,10 @@ TEST_CASE("asymmetric object", "[sync]") {
 
         synced_realm.get_sync_session()->wait_for_upload_completion().get();
 
-        auto result = user.call_function("asymmetricSyncData", bson::Bson(bson::BsonArray({bson::BsonDocument{{"_id", oid.to_string()}}})).toJson()).get();
-        CHECK(result);
-        CHECK(result->find(oid.to_string()) != std::string::npos);
+        auto result = user.call_function("asymmetricSyncData", { bsoncxx::document({{"_id", oid.to_string()}}) }).get();
+        bsoncxx::array bson_array = *result;
+        CHECK(bson_array.size() == 1);
+        bsoncxx::document doc = bson_array[0];
+        CHECK(doc["_id"] == oid);
     }
 }

--- a/tests/sync/client_reset_tests.cpp
+++ b/tests/sync/client_reset_tests.cpp
@@ -25,14 +25,14 @@ void simulate_client_reset_error_for_session(sync_session&& session) {
 }
 
 void prepare_realm(const realm::db_config& flx_sync_config, const user& sync_user) {
-    sync_user.call_function("deleteClientResetObjects", "[]").get();
+    sync_user.call_function("deleteClientResetObjects", std::vector<bsoncxx>()).get();
     auto synced_realm = db(flx_sync_config);
     auto update_success = synced_realm.subscriptions().update([](realm::mutable_sync_subscription_set &subs) {
                                                           subs.add<client_reset_obj>("foo-strings");
                                                       }).get();
     CHECK(update_success == true);
     CHECK(synced_realm.subscriptions().size() == 1);
-    sync_user.call_function("insertClientResetObject", "[]").get();
+    sync_user.call_function("insertClientResetObject", bsoncxx::array()).get();
 
     auto session = synced_realm.get_sync_session()->operator std::weak_ptr<::realm::SyncSession>().lock().get();
     session->pause();

--- a/tests/sync/test_objects.hpp
+++ b/tests/sync/test_objects.hpp
@@ -1,7 +1,7 @@
 #ifndef CPPREALM_TEST_OBJECTS_HPP
 #define CPPREALM_TEST_OBJECTS_HPP
 
-#include "cpprealm/sdk.hpp"
+#include <cpprealm/sdk.hpp>
 
 namespace realm {
 
@@ -30,9 +30,9 @@ namespace realm {
 
         Enum enum_col = Enum::one;
         std::chrono::time_point<std::chrono::system_clock> date_col;
-        realm::uuid uuid_col;
-        realm::object_id object_id_col;
-        realm::decimal128 decimal_col;
+        uuid uuid_col;
+        object_id object_id_col;
+        decimal128 decimal_col;
         std::vector<std::uint8_t> binary_col;
         using my_mixed = std::variant<
                 std::monostate,
@@ -41,12 +41,12 @@ namespace realm {
                 std::string,
                 double,
                 std::chrono::time_point<std::chrono::system_clock>,
-                realm::uuid,
-                realm::object_id,
-                realm::decimal128,
+                uuid,
+                object_id,
+                decimal128,
                 std::vector<uint8_t>
                 >;
-        my_mixed mixed_col;
+        mixed mixed_col;
         my_mixed my_mixed_col;
 
         std::optional<int64_t> opt_int_col;
@@ -55,9 +55,9 @@ namespace realm {
         std::optional<bool> opt_bool_col;
         std::optional<Enum> opt_enum_col;
         std::optional<std::chrono::time_point<std::chrono::system_clock>> opt_date_col;
-        std::optional<realm::uuid> opt_uuid_col;
-        std::optional<realm::object_id> opt_object_id_col;
-        std::optional<realm::decimal128> opt_decimal_col;
+        std::optional<uuid> opt_uuid_col;
+        std::optional<object_id> opt_object_id_col;
+        std::optional<decimal128> opt_decimal_col;
         std::optional<std::vector<uint8_t>> opt_binary_col;
         AllTypesObjectLink* opt_obj_col = nullptr;
         AllTypesObjectEmbedded* opt_embedded_obj_col = nullptr;
@@ -66,12 +66,12 @@ namespace realm {
         std::vector<double> list_double_col;
         std::vector<bool> list_bool_col;
         std::vector<std::string> list_str_col;
-        std::vector<realm::uuid> list_uuid_col;
-        std::vector<realm::object_id> list_object_id_col;
-        std::vector<realm::decimal128> list_decimal_col;
+        std::vector<uuid> list_uuid_col;
+        std::vector<object_id> list_object_id_col;
+        std::vector<decimal128> list_decimal_col;
         std::vector<std::vector<std::uint8_t>> list_binary_col;
         std::vector<std::chrono::time_point<std::chrono::system_clock>> list_date_col;
-        std::vector<realm::mixed> list_mixed_col;
+        std::vector<mixed> list_mixed_col;
         std::vector<Enum> list_enum_col;
         std::vector<AllTypesObjectLink*> list_obj_col;
         std::vector<AllTypesObjectEmbedded*> list_embedded_obj_col;
@@ -80,24 +80,24 @@ namespace realm {
         std::set<double> set_double_col;
         std::set<bool> set_bool_col;
         std::set<std::string> set_str_col;
-        std::set<realm::uuid> set_uuid_col;
-        std::set<realm::object_id> set_object_id_col;
+        std::set<uuid> set_uuid_col;
+        std::set<object_id> set_object_id_col;
         std::set<std::vector<std::uint8_t>> set_binary_col;
         std::set<std::chrono::time_point<std::chrono::system_clock>> set_date_col;
-        std::set<realm::mixed> set_mixed_col;
+        std::set<mixed> set_mixed_col;
         std::set<AllTypesObjectLink*> set_obj_col;
 
         std::map<std::string, int64_t> map_int_col;
         std::map<std::string, double> map_double_col;
         std::map<std::string, bool> map_bool_col;
         std::map<std::string, std::string> map_str_col;
-        std::map<std::string, realm::uuid> map_uuid_col;
-        std::map<std::string, realm::object_id> map_object_id_col;
-        std::map<std::string, realm::decimal128> map_decimal_col;
+        std::map<std::string, uuid> map_uuid_col;
+        std::map<std::string, object_id> map_object_id_col;
+        std::map<std::string, decimal128> map_decimal_col;
         std::map<std::string, std::vector<std::uint8_t>> map_binary_col;
         std::map<std::string, std::chrono::time_point<std::chrono::system_clock>> map_date_col;
         std::map<std::string, Enum> map_enum_col;
-        std::map<std::string, realm::mixed> map_mixed_col;
+        std::map<std::string, mixed> map_mixed_col;
 
         std::map<std::string, AllTypesObjectLink*> map_link_col;
         std::map<std::string, AllTypesObjectEmbedded*> map_embedded_col;
@@ -130,7 +130,7 @@ namespace realm {
 
         Enum enum_col = Enum::one;
         std::chrono::time_point<std::chrono::system_clock> date_col;
-        realm::uuid uuid_col;
+        uuid uuid_col;
         std::vector<std::uint8_t> binary_col;
         using my_mixed = std::variant<
                 std::monostate,
@@ -139,9 +139,9 @@ namespace realm {
                 std::string,
                 double,
                 std::chrono::time_point<std::chrono::system_clock>,
-                realm::uuid,
-                realm::object_id,
-                realm::decimal128,
+                uuid,
+                object_id,
+                decimal128,
                 std::vector<uint8_t>
                 >;
         my_mixed mixed_col;
@@ -151,26 +151,26 @@ namespace realm {
         std::optional<bool> opt_bool_col;
         std::optional<Enum> opt_enum_col;
         std::optional<std::chrono::time_point<std::chrono::system_clock>> opt_date_col;
-        std::optional<realm::uuid> opt_uuid_col;
+        std::optional<uuid> opt_uuid_col;
         std::optional<std::vector<uint8_t>> opt_binary_col;
         EmbeddedFoo* opt_embedded_obj_col;
 
         std::vector<int64_t> list_int_col;
         std::vector<bool> list_bool_col;
         std::vector<std::string> list_str_col;
-        std::vector<realm::uuid> list_uuid_col;
+        std::vector<uuid> list_uuid_col;
         std::vector<std::vector<std::uint8_t>> list_binary_col;
         std::vector<std::chrono::time_point<std::chrono::system_clock>> list_date_col;
-        std::vector<realm::mixed> list_mixed_col;
+        std::vector<mixed> list_mixed_col;
         std::vector<EmbeddedFoo*> list_embedded_obj_col;
 
         std::map<std::string, int64_t> map_int_col;
         std::map<std::string, bool> map_bool_col;
         std::map<std::string, std::string> map_str_col;
-        std::map<std::string, realm::uuid> map_uuid_col;
+        std::map<std::string, uuid> map_uuid_col;
         std::map<std::string, std::chrono::time_point<std::chrono::system_clock>> map_date_col;
         std::map<std::string, Enum> map_enum_col;
-        std::map<std::string, realm::mixed> map_mixed_col;
+        std::map<std::string, mixed> map_mixed_col;
 
         std::map<std::string, EmbeddedFoo*> map_embedded_col;
     };


### PR DESCRIPTION
This PR adds back BSON functionality by bridging the BSON classes found in RealmCore.
usage:
```cpp
        auto bson = realm::bsoncxx();

        bson = realm::bsoncxx((int32_t) 123);

        bson = realm::bsoncxx((int64_t) 123);

        bson = realm::bsoncxx(true);

        bson = realm::bsoncxx(123.456);

        bson = realm::bsoncxx(std::string("foo"));

        bson = realm::bsoncxx(std::vector<uint8_t>({0, 0, 0, 0}));

        bson = realm::bsoncxx(realm::bsoncxx::timestamp(100, 0));

        auto d = std::chrono::system_clock::now();
        bson = realm::bsoncxx(realm::bsoncxx::date(d));

        auto oid = realm::object_id::generate();
        bson = realm::bsoncxx(oid);

        bson = realm::bsoncxx(realm::decimal128(123.456));

        bson = realm::bsoncxx(realm::bsoncxx::regular_expression("[0-9]", "i"));

        bson = realm::bsoncxx(realm::bsoncxx::max_key());

        bson = realm::bsoncxx(realm::bsoncxx::min_key());

        bson = realm::bsoncxx(realm::bsoncxx::document({{"name", "foo"}}));

        bson = realm::bsoncxx(std::vector<realm::bsoncxx>({{"one", 123, true}}));

        bson = realm::bsoncxx(realm::uuid());    
```