### PR TITLE
Address object lifetime issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,27 @@
+X.Y.Z Release notes (YYYY-MM-DD)
+=============================================================
+
+### Fixed
+* Managed objects would exhibit undefined behaviour when returned from the subscript operator in `std::vector` & `std::map`.
+
+### Enhancements
+* Add `realm::holds_alternative` which acts as a substitute to `std::holds_alternative` when using `managed<realm::mixed>`.
+* Add `managed<realm::mixed>::get_stored_link` for retrieving a link from a mixed proeprty type.
+* Add `managed<realm::mixed>::set_link` for setting a link in a mixed proeprty type.
+* Add compile time checking to prevent misuse of managed property types.
+* Add `managed<std::vector<>>::as_results()` to allow the ability to derive a `realm::results<>` collection from a managed vector.
+
+### Breaking Changes
+* None
+
+### Compatibility
+* Fileformat: Generates files with format v23. Reads and automatically upgrade from fileformat v5.
+
+### Internals
+* None
+
+----------------------------------------------
+
 1.0.0 Release notes (2024-01-08)
 =============================================================
 

--- a/src/cpprealm/internal/bridge/list.cpp
+++ b/src/cpprealm/internal/bridge/list.cpp
@@ -130,6 +130,10 @@ namespace realm::internal::bridge {
         return get_list()->sort(results_descriptors);
     }
 
+    [[nodiscard]] results list::as_results() const {
+        return get_list()->as_results();
+    }
+
     table list::get_table() const {
         return get_list()->get_table();
     }

--- a/src/cpprealm/internal/bridge/list.hpp
+++ b/src/cpprealm/internal/bridge/list.hpp
@@ -100,6 +100,7 @@ namespace realm::internal::bridge {
         size_t find(const obj_key&);
 
         results sort(const std::vector<sort_descriptor>&);
+        [[nodiscard]] results as_results() const;
 
         notification_token add_notification_callback(std::shared_ptr<collection_change_callback>);
     private:

--- a/src/cpprealm/internal/bridge/obj_key.cpp
+++ b/src/cpprealm/internal/bridge/obj_key.cpp
@@ -44,6 +44,15 @@ namespace realm::internal::bridge {
 #endif
     }
 
+    obj_link::obj_link(uint32_t table_key, obj_key obj_key) {
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+        new (&m_obj_link) ObjLink(TableKey(table_key), obj_key);
+#else
+        m_obj_link = std::make_shared<ObjLink>(TableKey(table_key), obj_key);
+#endif
+    }
+
+
     obj_link& obj_link::operator=(const obj_link& other) {
 #ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
         if (this != &other) {
@@ -101,6 +110,14 @@ namespace realm::internal::bridge {
         return reinterpret_cast<const ObjLink*>(&m_obj_link)->get_obj_key();
 #else
         return m_obj_link->get_obj_key();
+#endif
+    }
+
+    uint32_t obj_link::get_table_key() {
+#ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
+        return reinterpret_cast<const ObjLink*>(&m_obj_link)->get_table_key().value;
+#else
+        return m_obj_link->get_table_key().value;
 #endif
     }
 

--- a/src/cpprealm/internal/bridge/obj_key.hpp
+++ b/src/cpprealm/internal/bridge/obj_key.hpp
@@ -53,13 +53,15 @@ namespace realm::internal::bridge {
     struct obj_link {
         obj_link(const ObjLink&);
         obj_link();
-        obj_link(const obj_link& other) ;
-        obj_link& operator=(const obj_link& other) ;
+        obj_link(const obj_link& other);
+        obj_link(uint32_t table_key, obj_key obj_key);
+        obj_link& operator=(const obj_link& other);
         obj_link(obj_link&& other);
         obj_link& operator=(obj_link&& other);
         ~obj_link();
         operator ObjLink() const;
         obj_key get_obj_key();
+        uint32_t get_table_key();
     private:
 #ifdef CPPREALM_HAVE_GENERATED_BRIDGE_TYPES
         storage::ObjLink m_obj_link[1];

--- a/src/cpprealm/internal/bridge/object_schema.cpp
+++ b/src/cpprealm/internal/bridge/object_schema.cpp
@@ -117,6 +117,9 @@ namespace realm::internal::bridge {
     void object_schema::set_name(const std::string &name) {
         get_object_schema()->name = name;
     }
+    std::string object_schema::get_name() const {
+        return get_object_schema()->name;
+    }
     property object_schema::property_for_name(const std::string &v) {
         return *get_object_schema()->property_for_name(v);
     }

--- a/src/cpprealm/internal/bridge/object_schema.hpp
+++ b/src/cpprealm/internal/bridge/object_schema.hpp
@@ -52,6 +52,7 @@ namespace realm::internal::bridge {
         void add_property(const property&);
 
         void set_name(const std::string& name);
+        std::string get_name() const;
         void set_primary_key(const std::string& primary_key);
         void set_object_type(object_type);
         property property_for_name(const std::string&);

--- a/src/cpprealm/internal/bridge/table.cpp
+++ b/src/cpprealm/internal/bridge/table.cpp
@@ -122,6 +122,14 @@ namespace realm::internal::bridge {
         return static_cast<TableRef>(*this)->get_column_key(name);
     }
 
+    uint32_t table::get_key() const {
+        return static_cast<TableRef>(*this)->get_key().value;
+    }
+
+    std::string table::get_name() const {
+        return static_cast<TableRef>(*this)->get_name();
+    }
+
     table table::get_link_target(const col_key col_key) const {
         return static_cast<TableRef>(*this)->get_link_target(col_key);
     }

--- a/src/cpprealm/internal/bridge/table.hpp
+++ b/src/cpprealm/internal/bridge/table.hpp
@@ -48,6 +48,8 @@ namespace realm {
             operator ConstTableRef() const;
 
             col_key get_column_key(const std::string_view &name) const;
+            uint32_t get_key() const;
+            std::string get_name() const;
 
             obj create_object_with_primary_key(const mixed &key) const;
 

--- a/src/cpprealm/macros.hpp
+++ b/src/cpprealm/macros.hpp
@@ -119,6 +119,106 @@
 #define FE_97(WHAT, cls, X, ...) WHAT(cls, X)FE_96(WHAT, cls, __VA_ARGS__)
 #define FE_98(WHAT, cls, X, ...) WHAT(cls, X)FE_97(WHAT, cls, __VA_ARGS__)
 #define FE_99(WHAT, cls, X, ...) WHAT(cls, X)FE_98(WHAT, cls, __VA_ARGS__)
+#define FE_100(WHAT, cls, X, ...) WHAT(cls, X) FE_99(WHAT, cls, __VA_ARGS__)
+#define FE_101(WHAT, cls, X, ...) WHAT(cls, X) FE_100(WHAT, cls, __VA_ARGS__)
+#define FE_102(WHAT, cls, X, ...) WHAT(cls, X) FE_101(WHAT, cls, __VA_ARGS__)
+#define FE_103(WHAT, cls, X, ...) WHAT(cls, X) FE_102(WHAT, cls, __VA_ARGS__)
+#define FE_104(WHAT, cls, X, ...) WHAT(cls, X) FE_103(WHAT, cls, __VA_ARGS__)
+#define FE_105(WHAT, cls, X, ...) WHAT(cls, X) FE_104(WHAT, cls, __VA_ARGS__)
+#define FE_106(WHAT, cls, X, ...) WHAT(cls, X) FE_105(WHAT, cls, __VA_ARGS__)
+#define FE_107(WHAT, cls, X, ...) WHAT(cls, X) FE_106(WHAT, cls, __VA_ARGS__)
+#define FE_108(WHAT, cls, X, ...) WHAT(cls, X) FE_107(WHAT, cls, __VA_ARGS__)
+#define FE_109(WHAT, cls, X, ...) WHAT(cls, X) FE_108(WHAT, cls, __VA_ARGS__)
+#define FE_110(WHAT, cls, X, ...) WHAT(cls, X) FE_109(WHAT, cls, __VA_ARGS__)
+#define FE_111(WHAT, cls, X, ...) WHAT(cls, X) FE_110(WHAT, cls, __VA_ARGS__)
+#define FE_112(WHAT, cls, X, ...) WHAT(cls, X) FE_111(WHAT, cls, __VA_ARGS__)
+#define FE_113(WHAT, cls, X, ...) WHAT(cls, X) FE_112(WHAT, cls, __VA_ARGS__)
+#define FE_114(WHAT, cls, X, ...) WHAT(cls, X) FE_113(WHAT, cls, __VA_ARGS__)
+#define FE_115(WHAT, cls, X, ...) WHAT(cls, X) FE_114(WHAT, cls, __VA_ARGS__)
+#define FE_116(WHAT, cls, X, ...) WHAT(cls, X) FE_115(WHAT, cls, __VA_ARGS__)
+#define FE_117(WHAT, cls, X, ...) WHAT(cls, X) FE_116(WHAT, cls, __VA_ARGS__)
+#define FE_118(WHAT, cls, X, ...) WHAT(cls, X) FE_117(WHAT, cls, __VA_ARGS__)
+#define FE_119(WHAT, cls, X, ...) WHAT(cls, X) FE_118(WHAT, cls, __VA_ARGS__)
+#define FE_120(WHAT, cls, X, ...) WHAT(cls, X) FE_119(WHAT, cls, __VA_ARGS__)
+#define FE_121(WHAT, cls, X, ...) WHAT(cls, X) FE_120(WHAT, cls, __VA_ARGS__)
+#define FE_122(WHAT, cls, X, ...) WHAT(cls, X) FE_121(WHAT, cls, __VA_ARGS__)
+#define FE_123(WHAT, cls, X, ...) WHAT(cls, X) FE_122(WHAT, cls, __VA_ARGS__)
+#define FE_124(WHAT, cls, X, ...) WHAT(cls, X) FE_123(WHAT, cls, __VA_ARGS__)
+#define FE_125(WHAT, cls, X, ...) WHAT(cls, X) FE_124(WHAT, cls, __VA_ARGS__)
+#define FE_126(WHAT, cls, X, ...) WHAT(cls, X) FE_125(WHAT, cls, __VA_ARGS__)
+#define FE_127(WHAT, cls, X, ...) WHAT(cls, X) FE_126(WHAT, cls, __VA_ARGS__)
+#define FE_128(WHAT, cls, X, ...) WHAT(cls, X) FE_127(WHAT, cls, __VA_ARGS__)
+#define FE_129(WHAT, cls, X, ...) WHAT(cls, X) FE_128(WHAT, cls, __VA_ARGS__)
+#define FE_130(WHAT, cls, X, ...) WHAT(cls, X) FE_129(WHAT, cls, __VA_ARGS__)
+#define FE_131(WHAT, cls, X, ...) WHAT(cls, X) FE_130(WHAT, cls, __VA_ARGS__)
+#define FE_132(WHAT, cls, X, ...) WHAT(cls, X) FE_131(WHAT, cls, __VA_ARGS__)
+#define FE_133(WHAT, cls, X, ...) WHAT(cls, X) FE_132(WHAT, cls, __VA_ARGS__)
+#define FE_134(WHAT, cls, X, ...) WHAT(cls, X) FE_133(WHAT, cls, __VA_ARGS__)
+#define FE_135(WHAT, cls, X, ...) WHAT(cls, X) FE_134(WHAT, cls, __VA_ARGS__)
+#define FE_136(WHAT, cls, X, ...) WHAT(cls, X) FE_135(WHAT, cls, __VA_ARGS__)
+#define FE_137(WHAT, cls, X, ...) WHAT(cls, X) FE_136(WHAT, cls, __VA_ARGS__)
+#define FE_138(WHAT, cls, X, ...) WHAT(cls, X) FE_137(WHAT, cls, __VA_ARGS__)
+#define FE_139(WHAT, cls, X, ...) WHAT(cls, X) FE_138(WHAT, cls, __VA_ARGS__)
+#define FE_140(WHAT, cls, X, ...) WHAT(cls, X) FE_139(WHAT, cls, __VA_ARGS__)
+#define FE_141(WHAT, cls, X, ...) WHAT(cls, X) FE_140(WHAT, cls, __VA_ARGS__)
+#define FE_142(WHAT, cls, X, ...) WHAT(cls, X) FE_141(WHAT, cls, __VA_ARGS__)
+#define FE_143(WHAT, cls, X, ...) WHAT(cls, X) FE_142(WHAT, cls, __VA_ARGS__)
+#define FE_144(WHAT, cls, X, ...) WHAT(cls, X) FE_143(WHAT, cls, __VA_ARGS__)
+#define FE_145(WHAT, cls, X, ...) WHAT(cls, X) FE_144(WHAT, cls, __VA_ARGS__)
+#define FE_146(WHAT, cls, X, ...) WHAT(cls, X) FE_145(WHAT, cls, __VA_ARGS__)
+#define FE_147(WHAT, cls, X, ...) WHAT(cls, X) FE_146(WHAT, cls, __VA_ARGS__)
+#define FE_148(WHAT, cls, X, ...) WHAT(cls, X) FE_147(WHAT, cls, __VA_ARGS__)
+#define FE_149(WHAT, cls, X, ...) WHAT(cls, X) FE_148(WHAT, cls, __VA_ARGS__)
+#define FE_150(WHAT, cls, X, ...) WHAT(cls, X) FE_149(WHAT, cls, __VA_ARGS__)
+#define FE_151(WHAT, cls, X, ...) WHAT(cls, X) FE_150(WHAT, cls, __VA_ARGS__)
+#define FE_152(WHAT, cls, X, ...) WHAT(cls, X) FE_151(WHAT, cls, __VA_ARGS__)
+#define FE_153(WHAT, cls, X, ...) WHAT(cls, X) FE_152(WHAT, cls, __VA_ARGS__)
+#define FE_154(WHAT, cls, X, ...) WHAT(cls, X) FE_153(WHAT, cls, __VA_ARGS__)
+#define FE_155(WHAT, cls, X, ...) WHAT(cls, X) FE_154(WHAT, cls, __VA_ARGS__)
+#define FE_156(WHAT, cls, X, ...) WHAT(cls, X) FE_155(WHAT, cls, __VA_ARGS__)
+#define FE_157(WHAT, cls, X, ...) WHAT(cls, X) FE_156(WHAT, cls, __VA_ARGS__)
+#define FE_158(WHAT, cls, X, ...) WHAT(cls, X) FE_157(WHAT, cls, __VA_ARGS__)
+#define FE_159(WHAT, cls, X, ...) WHAT(cls, X) FE_158(WHAT, cls, __VA_ARGS__)
+#define FE_160(WHAT, cls, X, ...) WHAT(cls, X) FE_159(WHAT, cls, __VA_ARGS__)
+#define FE_161(WHAT, cls, X, ...) WHAT(cls, X) FE_160(WHAT, cls, __VA_ARGS__)
+#define FE_162(WHAT, cls, X, ...) WHAT(cls, X) FE_161(WHAT, cls, __VA_ARGS__)
+#define FE_163(WHAT, cls, X, ...) WHAT(cls, X) FE_162(WHAT, cls, __VA_ARGS__)
+#define FE_164(WHAT, cls, X, ...) WHAT(cls, X) FE_163(WHAT, cls, __VA_ARGS__)
+#define FE_165(WHAT, cls, X, ...) WHAT(cls, X) FE_164(WHAT, cls, __VA_ARGS__)
+#define FE_166(WHAT, cls, X, ...) WHAT(cls, X) FE_165(WHAT, cls, __VA_ARGS__)
+#define FE_167(WHAT, cls, X, ...) WHAT(cls, X) FE_166(WHAT, cls, __VA_ARGS__)
+#define FE_168(WHAT, cls, X, ...) WHAT(cls, X) FE_167(WHAT, cls, __VA_ARGS__)
+#define FE_169(WHAT, cls, X, ...) WHAT(cls, X) FE_168(WHAT, cls, __VA_ARGS__)
+#define FE_170(WHAT, cls, X, ...) WHAT(cls, X) FE_169(WHAT, cls, __VA_ARGS__)
+#define FE_171(WHAT, cls, X, ...) WHAT(cls, X) FE_170(WHAT, cls, __VA_ARGS__)
+#define FE_172(WHAT, cls, X, ...) WHAT(cls, X) FE_171(WHAT, cls, __VA_ARGS__)
+#define FE_173(WHAT, cls, X, ...) WHAT(cls, X) FE_172(WHAT, cls, __VA_ARGS__)
+#define FE_174(WHAT, cls, X, ...) WHAT(cls, X) FE_173(WHAT, cls, __VA_ARGS__)
+#define FE_175(WHAT, cls, X, ...) WHAT(cls, X) FE_174(WHAT, cls, __VA_ARGS__)
+#define FE_176(WHAT, cls, X, ...) WHAT(cls, X) FE_175(WHAT, cls, __VA_ARGS__)
+#define FE_177(WHAT, cls, X, ...) WHAT(cls, X) FE_176(WHAT, cls, __VA_ARGS__)
+#define FE_178(WHAT, cls, X, ...) WHAT(cls, X) FE_177(WHAT, cls, __VA_ARGS__)
+#define FE_179(WHAT, cls, X, ...) WHAT(cls, X) FE_178(WHAT, cls, __VA_ARGS__)
+#define FE_180(WHAT, cls, X, ...) WHAT(cls, X) FE_179(WHAT, cls, __VA_ARGS__)
+#define FE_181(WHAT, cls, X, ...) WHAT(cls, X) FE_180(WHAT, cls, __VA_ARGS__)
+#define FE_182(WHAT, cls, X, ...) WHAT(cls, X) FE_181(WHAT, cls, __VA_ARGS__)
+#define FE_183(WHAT, cls, X, ...) WHAT(cls, X) FE_182(WHAT, cls, __VA_ARGS__)
+#define FE_184(WHAT, cls, X, ...) WHAT(cls, X) FE_183(WHAT, cls, __VA_ARGS__)
+#define FE_185(WHAT, cls, X, ...) WHAT(cls, X) FE_184(WHAT, cls, __VA_ARGS__)
+#define FE_186(WHAT, cls, X, ...) WHAT(cls, X) FE_185(WHAT, cls, __VA_ARGS__)
+#define FE_187(WHAT, cls, X, ...) WHAT(cls, X) FE_186(WHAT, cls, __VA_ARGS__)
+#define FE_188(WHAT, cls, X, ...) WHAT(cls, X) FE_187(WHAT, cls, __VA_ARGS__)
+#define FE_189(WHAT, cls, X, ...) WHAT(cls, X) FE_188(WHAT, cls, __VA_ARGS__)
+#define FE_190(WHAT, cls, X, ...) WHAT(cls, X) FE_189(WHAT, cls, __VA_ARGS__)
+#define FE_191(WHAT, cls, X, ...) WHAT(cls, X) FE_190(WHAT, cls, __VA_ARGS__)
+#define FE_192(WHAT, cls, X, ...) WHAT(cls, X) FE_191(WHAT, cls, __VA_ARGS__)
+#define FE_193(WHAT, cls, X, ...) WHAT(cls, X) FE_192(WHAT, cls, __VA_ARGS__)
+#define FE_194(WHAT, cls, X, ...) WHAT(cls, X) FE_193(WHAT, cls, __VA_ARGS__)
+#define FE_195(WHAT, cls, X, ...) WHAT(cls, X) FE_194(WHAT, cls, __VA_ARGS__)
+#define FE_196(WHAT, cls, X, ...) WHAT(cls, X) FE_195(WHAT, cls, __VA_ARGS__)
+#define FE_197(WHAT, cls, X, ...) WHAT(cls, X) FE_196(WHAT, cls, __VA_ARGS__)
+#define FE_198(WHAT, cls, X, ...) WHAT(cls, X) FE_197(WHAT, cls, __VA_ARGS__)
+#define FE_199(WHAT, cls, X, ...) WHAT(cls, X) FE_198(WHAT, cls, __VA_ARGS__)
 
 #define GET_MACRO(_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, \
     _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26,\
@@ -126,19 +226,39 @@
     _41, _42, _43, _44, _45, _46, _47, _48, _49, _50, _51, _52, _53, _54,\
     _55, _56, _57, _58, _59, _60, _61, _62, _63, _64, _65, _66, _67, _68,\
     _69, _70, _71, _72, _73, _74, _75, _76, _77, _78, _79, _80, _81, _82,\
-    _83, _84, _85, _86, _87, _88, _89, _90, _91, _92, _93, _94, _95, _96, _97, _98, _99, NAME, ...) NAME
+    _83, _84, _85, _86, _87, _88, _89, _90, _91, _92, _93, _94, _95, _96, \
+    _97, _98, _99, _100, _101, _102, _103, _104, _105, _106, _107, _108, _109, \
+    _110, _111, _112, _113, _114, _115, _116, _117, _118, _119, _120, _121, \
+    _122, _123, _124, _125, _126, _127, _128, _129, _130, _131, _132, _133, \
+    _134, _135, _136, _137, _138, _139, _140, _141, _142, _143, _144, _145, \
+    _146, _147, _148, _149, _150, _151, _152, _153, _154, _155, _156, _157, \
+    _158, _159, _160, _161, _162, _163, _164, _165, _166, _167, _168, _169, \
+    _170, _171, _172, _173, _174, _175, _176, _177, _178, _179, _180, _181, \
+    _182, _183, _184, _185, _186, _187, _188, _189, _190, _191, _192, _193, \
+    _194, _195, _196, _197, _198, _199, NAME, ...) NAME \
 
 #define FOR_EACH(action, cls, ...) \
   GET_MACRO(_0, __VA_ARGS__,        \
-        FE_99, FE_98, FE_97, FE_96, FE_95, FE_94, FE_93, FE_92, FE_91, FE_90, FE_89, FE_88, \
-        FE_87, FE_86, FE_85, FE_84, FE_83, FE_82, FE_81, FE_80, FE_79, FE_78, FE_77, FE_76, \
-        FE_75, FE_74, FE_73, FE_72, FE_71, FE_70, FE_69, FE_68, FE_67, FE_66, FE_65, FE_64, \
-        FE_63, FE_62, FE_61, FE_60, FE_59, FE_58, FE_57, FE_56, FE_55, FE_54, FE_53, FE_52, \
-        FE_51, FE_50, FE_49, FE_48, FE_47, FE_46, FE_45, FE_44, FE_43, FE_42, FE_41, FE_40, \
-        FE_39, FE_38, FE_37, FE_36, FE_35, FE_34, FE_33, FE_32, FE_31, FE_30, FE_29, FE_28, \
-        FE_27, FE_26, FE_25, FE_24, FE_23, FE_22, FE_21, FE_20, FE_19, FE_18, FE_17, FE_16, \
-        FE_15, FE_14, FE_13, FE_12, FE_11, FE_10, FE_9, FE_8, FE_7, FE_6, FE_5, FE_4, FE_3, \
-        FE_2, FE_1, FE_0)(action, cls, __VA_ARGS__)
+        FE_199, FE_198, FE_197, FE_196, FE_195, FE_194, FE_193, FE_192, FE_191, FE_190, \
+        FE_189, FE_188, FE_187, FE_186, FE_185, FE_184, FE_183, FE_182, FE_181, FE_180, \
+        FE_179, FE_178, FE_177, FE_176, FE_175, FE_174, FE_173, FE_172, FE_171, FE_170, \
+        FE_169, FE_168, FE_167, FE_166, FE_165, FE_164, FE_163, FE_162, FE_161, FE_160, \
+        FE_159, FE_158, FE_157, FE_156, FE_155, FE_154, FE_153, FE_152, FE_151, FE_150, \
+        FE_149, FE_148, FE_147, FE_146, FE_145, FE_144, FE_143, FE_142, FE_141, FE_140, \
+        FE_139, FE_138, FE_137, FE_136, FE_135, FE_134, FE_133, FE_132, FE_131, FE_130, \
+        FE_129, FE_128, FE_127, FE_126, FE_125, FE_124, FE_123, FE_122, FE_121, FE_120, \
+        FE_119, FE_118, FE_117, FE_116, FE_115, FE_114, FE_113, FE_112, FE_111, FE_110, \
+        FE_109, FE_108, FE_107, FE_106, FE_105, FE_104, FE_103, FE_102, FE_101, FE_100, \
+        FE_99, FE_98, FE_97, FE_96, FE_95, FE_94, FE_93, FE_92, FE_91, FE_90, \
+        FE_89, FE_88, FE_87, FE_86, FE_85, FE_84, FE_83, FE_82, FE_81, FE_80, \
+        FE_79, FE_78, FE_77, FE_76, FE_75, FE_74, FE_73, FE_72, FE_71, FE_70, \
+        FE_69, FE_68, FE_67, FE_66, FE_65, FE_64, FE_63, FE_62, FE_61, FE_60, \
+        FE_59, FE_58, FE_57, FE_56, FE_55, FE_54, FE_53, FE_52, FE_51, FE_50, \
+        FE_49, FE_48, FE_47, FE_46, FE_45, FE_44, FE_43, FE_42, FE_41, FE_40, \
+        FE_39, FE_38, FE_37, FE_36, FE_35, FE_34, FE_33, FE_32, FE_31, FE_30, \
+        FE_29, FE_28, FE_27, FE_26, FE_25, FE_24, FE_23, FE_22, FE_21, FE_20, \
+        FE_19, FE_18, FE_17, FE_16, FE_15, FE_14, FE_13, FE_12, FE_11, FE_10, \
+        FE_9, FE_8, FE_7, FE_6, FE_5, FE_4, FE_3, FE_2, FE_1, FE_0)(action, cls, __VA_ARGS__)
 
 #define DECLARE_PERSISTED(cls, property) managed<decltype(cls::property)> property;
 #define DECLARE_PROPERTY(cls, p) realm::property<&cls::p>(#p),
@@ -177,6 +297,7 @@ constexpr constant_index< acc > counter_crumb( id, constant_index< rank >, const
 
 namespace realm {
     struct managed_base {
+        protected:
         managed_base() = default;
         managed_base(const managed_base& other) {
             m_obj = other.m_obj;
@@ -219,7 +340,7 @@ namespace realm {
             should_detect_usage_for_queries = false;
             query = nullptr;
         }
-
+    public:
         static constexpr bool is_object = false;
         internal::bridge::obj *m_obj = nullptr;
         internal::bridge::realm *m_realm = nullptr;

--- a/src/cpprealm/managed_binary.hpp
+++ b/src/cpprealm/managed_binary.hpp
@@ -43,6 +43,15 @@ namespace realm {
         //MARK: -   comparison operators
         rbool operator==(const std::vector<uint8_t>& rhs) const noexcept;
         rbool operator!=(const std::vector<uint8_t>& rhs) const noexcept;
+
+    private:
+        managed() = default;
+        managed(const managed&) = delete;
+        managed(managed &&) = delete;
+        managed& operator=(const managed&) = delete;
+        managed& operator=(managed&&) = delete;
+        template<typename, typename>
+        friend struct managed;
     };
 
     template<>
@@ -74,6 +83,15 @@ namespace realm {
         //MARK: -   comparison operators
         rbool operator==(const std::optional<std::vector<uint8_t>>& rhs) const noexcept;
         rbool operator!=(const std::optional<std::vector<uint8_t>>& rhs) const noexcept;
+
+    private:
+        managed() = default;
+        managed(const managed&) = delete;
+        managed(managed &&) = delete;
+        managed& operator=(const managed&) = delete;
+        managed& operator=(managed&&) = delete;
+        template<typename, typename>
+        friend struct managed;
     };
 }
 

--- a/src/cpprealm/managed_decimal.hpp
+++ b/src/cpprealm/managed_decimal.hpp
@@ -59,6 +59,15 @@ namespace realm {
         managed<realm::decimal128>& operator-=(const decimal128& o);
         managed<realm::decimal128>& operator*=(const decimal128& o);
         managed<realm::decimal128>& operator/=(const decimal128& o);
+
+    private:
+        managed() = default;
+        managed(const managed&) = delete;
+        managed(managed &&) = delete;
+        managed& operator=(const managed&) = delete;
+        managed& operator=(managed&&) = delete;
+        template<typename, typename>
+        friend struct managed;
     };
 
     template<>
@@ -97,6 +106,15 @@ namespace realm {
         managed<std::optional<realm::decimal128>>& operator-=(const decimal128& o);
         managed<std::optional<realm::decimal128>>& operator*=(const decimal128& o);
         managed<std::optional<realm::decimal128>>& operator/=(const decimal128& o);
+
+    private:
+        managed() = default;
+        managed(const managed&) = delete;
+        managed(managed &&) = delete;
+        managed& operator=(const managed&) = delete;
+        managed& operator=(managed&&) = delete;
+        template<typename, typename>
+        friend struct managed;
     };
 
 } // namespace realm

--- a/src/cpprealm/managed_dictionary.hpp
+++ b/src/cpprealm/managed_dictionary.hpp
@@ -117,19 +117,6 @@ namespace realm {
         }
     };
     template<>
-    struct box<std::optional<int64_t>> : public box_base<std::optional<int64_t>> {
-        using box_base<std::optional<int64_t>>::box_base;
-        using box_base<std::optional<int64_t>>::operator=;
-        std::optional<int64_t> operator*() {
-            auto v = m_backing_map.get(m_key);
-            if (v.is_null()) {
-                return std::nullopt;
-            } else {
-                return v.operator int64_t();
-            };
-        }
-    };
-    template<>
     struct box<double> : public box_base<double> {
         using box_base<double>::box_base;
         using box_base<double>::operator=;
@@ -138,37 +125,11 @@ namespace realm {
         }
     };
     template<>
-    struct box<std::optional<double>> : public box_base<std::optional<double>> {
-        using box_base<std::optional<double>>::box_base;
-        using box_base<std::optional<double>>::operator=;
-        std::optional<double> operator*() {
-            auto v = m_backing_map.get(m_key);
-            if (v.is_null()) {
-                return std::nullopt;
-            } else {
-                return v.operator double();
-            };
-        }
-    };
-    template<>
     struct box<bool> : public box_base<bool> {
         using box_base<bool>::box_base;
         using box_base<bool>::operator=;
         bool operator*() {
             return m_backing_map.get(m_key).operator bool();
-        }
-    };
-    template<>
-    struct box<std::optional<bool>> : public box_base<std::optional<bool>> {
-        using box_base<std::optional<bool>>::box_base;
-        using box_base<std::optional<bool>>::operator=;
-        std::optional<bool> operator*() {
-            auto v = m_backing_map.get(m_key);
-            if (v.is_null()) {
-                return std::nullopt;
-            } else {
-                return v.operator bool();
-            };
         }
     };
     template<typename V>
@@ -219,19 +180,6 @@ namespace realm {
             return this->m_backing_map.get(this->m_key).operator internal::bridge::uuid().operator ::realm::uuid();
         }
     };
-    template<>
-    struct box<std::optional<uuid>> : public box_base<std::optional<uuid>> {
-        using box_base<std::optional<uuid>>::box_base;
-        using box_base<std::optional<uuid>>::operator=;
-        std::optional<uuid> operator*() {
-            auto v = this->m_backing_map.get(this->m_key);
-            if (v.is_null()) {
-                return std::nullopt;
-            } else {
-                return v.operator internal::bridge::uuid().operator ::realm::uuid();
-            };
-        }
-    };
     template<typename Mixed>
     struct box<Mixed, std::enable_if_t<internal::type_info::MixedPersistableConcept<Mixed>::value>> : public box_base<Mixed> {
         using box_base<Mixed>::box_base;
@@ -246,37 +194,11 @@ namespace realm {
         }
     };
     template<>
-    struct box<std::optional<object_id>> : public box_base<std::optional<object_id>> {
-        using box_base<std::optional<object_id>>::box_base;
-        using box_base<std::optional<object_id>>::operator=;
-        std::optional<object_id> operator*() {
-            auto v = this->m_backing_map.get(this->m_key);
-            if (v.is_null()) {
-                return std::nullopt;
-            } else {
-                return v.operator internal::bridge::object_id().operator ::realm::object_id();
-            };
-        }
-    };
-    template<>
     struct box<decimal128> : public box_base<decimal128> {
         using box_base<decimal128>::box_base;
         using box_base<decimal128>::operator=;
         decimal128 operator*() {
             return this->m_backing_map.get(this->m_key).operator internal::bridge::decimal128().operator ::realm::decimal128();
-        }
-    };
-    template<>
-    struct box<std::optional<decimal128>> : public box_base<std::optional<decimal128>> {
-        using box_base<std::optional<decimal128>>::box_base;
-        using box_base<std::optional<decimal128>>::operator=;
-        std::optional<decimal128> operator*() {
-            auto v = this->m_backing_map.get(this->m_key);
-            if (v.is_null()) {
-                return std::nullopt;
-            } else {
-                return v.operator internal::bridge::decimal128().operator ::realm::decimal128();
-            };
         }
     };
     template<>
@@ -288,19 +210,6 @@ namespace realm {
         }
     };
     template<>
-    struct box<std::optional<std::chrono::time_point<std::chrono::system_clock>>> : public box_base<std::optional<std::chrono::time_point<std::chrono::system_clock>>> {
-        using box_base<std::optional<std::chrono::time_point<std::chrono::system_clock>>>::box_base;
-        using box_base<std::optional<std::chrono::time_point<std::chrono::system_clock>>>::operator=;
-        std::optional<std::chrono::time_point<std::chrono::system_clock>> operator*() {
-            auto v = this->m_backing_map.get(this->m_key);
-            if (v.is_null()) {
-                return std::nullopt;
-            } else {
-                return this->m_backing_map.get(this->m_key).operator internal::bridge::timestamp().operator std::chrono::time_point<std::chrono::system_clock>();
-            };
-        }
-    };
-    template<>
     struct box<std::vector<uint8_t>> : public box_base<std::vector<uint8_t>> {
         using box_base<std::vector<uint8_t>>::box_base;
         using box_base<std::vector<uint8_t>>::operator=;
@@ -309,37 +218,11 @@ namespace realm {
         }
     };
     template<>
-    struct box<std::optional<std::vector<uint8_t>>> : public box_base<std::optional<std::vector<uint8_t>>> {
-        using box_base<std::optional<std::vector<uint8_t>>>::box_base;
-        using box_base<std::optional<std::vector<uint8_t>>>::operator=;
-        std::optional<std::vector<uint8_t>> operator*() {
-            auto v = this->m_backing_map.get(this->m_key);
-            if (v.is_null()) {
-                return std::nullopt;
-            } else {
-                return this->m_backing_map.get(this->m_key).operator internal::bridge::binary().operator std::vector<uint8_t>();
-            };
-        }
-    };
-    template<>
     struct box<std::string> : public box_base<std::string> {
         using box_base<std::string>::box_base;
         using box_base<std::string>::operator=;
         std::string operator*() {
             return this->m_backing_map.get(this->m_key).operator std::string();
-        }
-    };
-    template<>
-    struct box<std::optional<std::string>> : public box_base<std::optional<std::string>> {
-        using box_base<std::optional<std::string>>::box_base;
-        using box_base<std::optional<std::string>>::operator=;
-        std::optional<std::string> operator*() {
-            auto v = this->m_backing_map.get(this->m_key);
-            if (v.is_null()) {
-                return std::nullopt;
-            } else {
-                return this->m_backing_map.get(this->m_key).operator std::string();
-            };
         }
     };
 
@@ -386,31 +269,17 @@ namespace realm {
             return !this->operator==(rhs);
         }
 
-        typename managed<V*>::ref_type operator*() {
+        std::optional<typename managed<V*>::ref_type> operator*() {
             auto obj = this->m_backing_map.get_object(this->m_key);
             if (!obj.is_valid()) {
                 return std::nullopt;
             }
-            auto m = managed<V, void>(std::move(obj), this->m_realm);
-            std::apply([&m](auto &&...ptr) {
-                std::apply([&](auto &&...name) {
-                    ((m.*ptr).assign(&m.m_obj, &m.m_realm, m.m_obj.get_table().get_column_key(name)), ...);
-                },
-                managed<V, void>::managed_pointers_names);
-            },
-            managed<V, void>::managed_pointers());
-            return m;
+            return typename managed<V*>::ref_type(managed<V>(std::move(obj), this->m_realm));
         }
 
         typename managed<V*>::ref_type operator->() {
             auto obj = this->m_backing_map.get_object(this->m_key);
-            auto m = managed<V>(std::move(obj), this->m_realm);
-            std::apply([&m](auto &&...ptr) {
-                std::apply([&](auto &&...name) {
-                    ((m.*ptr).assign(&m.m_obj, &m.m_realm, m.m_obj.get_table().get_column_key(name)), ...);
-                }, managed<V, void>::managed_pointers_names);
-            }, managed<V, void>::managed_pointers());
-            return {std::move(m)};
+            return typename managed<V*>::ref_type(managed<V>(std::move(obj), this->m_realm));
         }
 
         box& operator=(V* o) {
@@ -454,18 +323,6 @@ namespace realm {
             return a.get_key() == b.get_key();
         }
         bool operator!=(const box<managed<V*>> rhs) const {
-            return !this->operator==(rhs);
-        }
-
-        bool operator==(const V& rhs) const {
-            auto a = const_cast<box<managed<V*>> *>(this)->m_backing_map.get_object(this->m_key);
-            auto &b = rhs.m_obj;
-            if (this->m_realm != rhs.m_realm) {
-                return false;
-            }
-            return a.get_key() == b.get_key();
-        }
-        bool operator!=(const V& rhs) const {
             return !this->operator==(rhs);
         }
 
@@ -618,6 +475,15 @@ namespace realm {
             token.m_dictionary = dict;
             return token;
         }
+
+    private:
+        managed() = default;
+        managed(const managed&) = delete;
+        managed(managed &&) = delete;
+        managed& operator=(const managed&) = delete;
+        managed& operator=(managed&&) = delete;
+        template<typename, typename>
+        friend struct managed;
     };
 
 } // namespace realm

--- a/src/cpprealm/managed_mixed.hpp
+++ b/src/cpprealm/managed_mixed.hpp
@@ -28,6 +28,24 @@ namespace realm {
     struct managed<T, std::enable_if_t<realm::internal::type_info::MixedPersistableConcept<T>::value>> : public managed_base {
         using managed<T>::managed_base::operator=;
 
+        enum stored_type {
+            Int = 0,
+            Bool = 1,
+            String = 2,
+            Binary = 4,
+            Mixed = 6,
+            Timestamp = 8,
+            Float = 9,
+            Double = 10,
+            Decimal = 11,
+            Link = 12,
+            LinkList = 13,
+            ObjectId = 15,
+            TypedLink = 16,
+            UUID = 17,
+            Null = 18,
+        };
+
         managed& operator =(const T& v) {
             m_obj->set(m_key, std::visit([](auto&& arg) {
                            using M = typename internal::type_info::type_info<std::decay_t<decltype(arg)>>::internal_type;
@@ -40,6 +58,15 @@ namespace realm {
         managed& operator =(const U& v) {
             m_obj->set(m_key, internal::bridge::mixed(v));
             return *this;
+        }
+
+        [[nodiscard]] stored_type get_stored_type() const {
+            auto val = m_obj->get<realm::internal::bridge::mixed>(m_key);
+            if (val.is_null()) {
+                return stored_type::Null;
+            } else {
+                return static_cast<stored_type>(val.type());
+            }
         }
 
         [[nodiscard]] T detach() const {
@@ -86,7 +113,134 @@ namespace realm {
             }
             return detach() != T(std::monostate());
         }
+
+        bool has_link() const {
+            return (get_stored_type() == stored_type::TypedLink);
+        }
+
+        template<typename U>
+        typename managed<U>::ref_type get_stored_link() const {
+            m_realm->read_group();
+            realm::internal::bridge::mixed m = m_obj->get<realm::internal::bridge::mixed>(m_key);
+
+            auto obj = internal::bridge::object(*m_realm, m.operator internal::bridge::obj_link());
+            uint32_t alternative_key = m_realm->table_for_object_type(managed<std::remove_pointer_t<U>>::schema.name).get_key();
+            uint32_t stored_table = obj.get_obj().get_table().get_key();
+
+            if (alternative_key != stored_table) {
+                throw std::runtime_error("Different link type stored in mixed type. Stored type: " + obj.get_object_schema().get_name());
+            }
+            return typename managed<U>::ref_type(managed<std::remove_pointer_t<U>>(obj.get_obj(), *m_realm));
+        }
+
+        template <typename U>
+        void set_link(U &&v) {
+            static_assert(sizeof(managed<U>), "Must declare schema for T");
+            static_assert(managed<U>::object_type == ObjectType::TopLevel, "Mixed properties can only store Top Level objects.");
+            auto table = m_realm->table_for_object_type(managed<U>::schema.name);
+            internal::bridge::obj o;
+            if constexpr (managed<U>::schema.HasPrimaryKeyProperty) {
+                auto pk = v.*(managed<U>::schema.primary_key().ptr);
+                o = table.create_object_with_primary_key(realm::internal::bridge::mixed(serialize(pk.value)));
+            } else {
+                o = table.create_object();
+            }
+
+            std::apply([&o, &v, this](auto && ...p) {
+                (accessor<typename std::decay_t<decltype(p)>::Result>::set(
+                         o, o.get_table().get_column_key(p.name), *this->m_realm, v.*(std::decay_t<decltype(p)>::ptr)
+                                 ), ...);
+            }, managed<U>::schema.ps);
+            m_obj->set(m_key, internal::bridge::mixed(o.get_link()));
+        }
+
+        template<typename U>
+        std::enable_if_t<managed<U>::is_object && managed<U>::object_type == ObjectType::TopLevel, void>
+        set_link(managed<U>& link) {
+            m_obj->set(m_key, internal::bridge::mixed(internal::bridge::obj_link(link.m_obj.get_table().get_key(), link.m_obj.get_key())));
+        }
+
+    private:
+        managed() = default;
+        managed(const managed&) = delete;
+        managed(managed &&) = delete;
+        managed& operator=(const managed&) = delete;
+        managed& operator=(managed&&) = delete;
+        template<typename, typename>
+        friend struct managed;
     };
+
+    template<typename T, typename Types>
+    const bool holds_alternative(const realm::managed<Types>& v) noexcept {
+        auto val = v.get_stored_type();
+        switch (val) {
+            case realm::managed<Types>::stored_type::Int:
+                if constexpr (std::is_same_v<T, int64_t>)
+                    return true;
+                break;
+            case realm::managed<Types>::stored_type::Bool:
+                if constexpr (std::is_same_v<T, bool>)
+                    return true;
+                break;
+            case realm::managed<Types>::stored_type::String:
+                if constexpr (std::is_same_v<T, std::string>)
+                    return true;
+                break;
+            case realm::managed<Types>::stored_type::Binary:
+                if constexpr (std::is_same_v<T, std::vector<uint8_t>>)
+                    return true;
+                break;
+            case realm::managed<Types>::stored_type::Mixed:
+                if constexpr (std::is_same_v<T, Types>)
+                    return true;
+                break;
+            case realm::managed<Types>::stored_type::Timestamp:
+                if constexpr (std::is_same_v<T, std::chrono::time_point<std::chrono::system_clock>>)
+                    return true;
+                break;
+            case realm::managed<Types>::stored_type::Float:
+                if constexpr (std::is_same_v<T, float>)
+                    return true;
+                break;
+            case realm::managed<Types>::stored_type::Double:
+                if constexpr (std::is_same_v<T, double>)
+                    return true;
+                break;
+            case realm::managed<Types>::stored_type::Decimal:
+                if constexpr (std::is_same_v<T, realm::decimal128>)
+                    return true;
+                break;
+            case realm::managed<Types>::stored_type::ObjectId:
+                if constexpr (std::is_same_v<T, realm::object_id>)
+                    return true;
+                break;
+
+            case realm::managed<Types>::stored_type::UUID:
+                if constexpr (std::is_same_v<T, realm::uuid>)
+                    return true;
+                break;
+            case realm::managed<Types>::stored_type::Null:
+                if constexpr (std::is_same_v<T, std::monostate>)
+                    return true;
+                break;
+            case realm::managed<Types>::stored_type::TypedLink: {
+                if constexpr (std::is_pointer_v<T>) {
+                    auto m = v.m_obj->template get<internal::bridge::mixed>(v.m_key);
+                    uint32_t alternative_key = v.m_realm->table_for_object_type(managed<std::remove_pointer_t<T>>::schema.name).get_key();
+                    uint32_t stored_key = internal::bridge::object(*v.m_realm, m.operator internal::bridge::obj_link()).get_object_schema().table_key();
+                    return alternative_key == stored_key;
+                }
+                break;
+            }
+            case realm::managed<Types>::stored_type::Link:
+            case realm::managed<Types>::stored_type::LinkList:
+                break;
+            default:
+                break;
+        }
+
+        return false;
+    }
 }
 
 #endif//CPPREALM_MANAGED_MIXED_HPP

--- a/src/cpprealm/managed_numeric.hpp
+++ b/src/cpprealm/managed_numeric.hpp
@@ -135,6 +135,15 @@ namespace realm {
             m_obj->template set<int64_t>(this->m_key, old_val * o);
             return *this;
         }
+
+    private:
+        managed() = default;
+        managed(const managed&) = delete;
+        managed(managed &&) = delete;
+        managed& operator=(const managed&) = delete;
+        managed& operator=(managed&&) = delete;
+        template<typename, typename>
+        friend struct managed;
     };
 
     template<>
@@ -250,6 +259,15 @@ namespace realm {
             auto old_val = m_obj->template get<double>(m_key);
             m_obj->template set<double>(this->m_key, old_val * o);
         }
+
+    private:
+        managed() = default;
+        managed(const managed&) = delete;
+        managed(managed &&) = delete;
+        managed& operator=(const managed&) = delete;
+        managed& operator=(managed&&) = delete;
+        template<typename, typename>
+        friend struct managed;
     };
 
     template<>
@@ -268,6 +286,15 @@ namespace realm {
 
         rbool operator==(const bool& rhs) const noexcept;
         rbool operator!=(const bool& rhs) const noexcept;
+
+    private:
+        managed() = default;
+        managed(const managed&) = delete;
+        managed(managed &&) = delete;
+        managed& operator=(const managed&) = delete;
+        managed& operator=(managed&&) = delete;
+        template<typename, typename>
+        friend struct managed;
     };
 
 #define CPP_REALM_MANAGED_OPTIONAL_NUMERIC(type) \
@@ -345,7 +372,15 @@ namespace realm {
                 throw std::runtime_error("Cannot perform arithmetic on null value."); \
             } \
             m_obj->template set<type>(this->m_key, (*old_val) / o); \
-        } \
+        }                                        \
+    private:    \
+        managed() = default; \
+        managed(const managed&) = delete; \
+        managed(managed &&) = delete; \
+        managed& operator=(const managed&) = delete; \
+        managed& operator=(managed&&) = delete; \
+        template<typename, typename> \
+        friend struct managed; \
     }; \
 
 CPP_REALM_MANAGED_OPTIONAL_NUMERIC(int64_t);
@@ -369,6 +404,15 @@ CPP_REALM_MANAGED_OPTIONAL_NUMERIC(double);
 
         rbool operator==(const std::optional<bool>& rhs) const noexcept;
         rbool operator!=(const std::optional<bool>& rhs) const noexcept;
+
+    private:
+        managed() = default;
+        managed(const managed&) = delete;
+        managed(managed &&) = delete;
+        managed& operator=(const managed&) = delete;
+        managed& operator=(managed&&) = delete;
+        template<typename, typename>
+        friend struct managed;
     };
 
     template <typename T>
@@ -439,6 +483,15 @@ CPP_REALM_MANAGED_OPTIONAL_NUMERIC(double);
             }
             return detach() <= rhs;
         }
+
+    private:
+        managed() = default;
+        managed(const managed&) = delete;
+        managed(managed &&) = delete;
+        managed& operator=(const managed&) = delete;
+        managed& operator=(managed&&) = delete;
+        template<typename, typename>
+        friend struct managed;
     };
 
     template <typename T>
@@ -524,6 +577,15 @@ CPP_REALM_MANAGED_OPTIONAL_NUMERIC(double);
             }
             return detach() <= rhs;
         }
+
+    private:
+        managed() = default;
+        managed(const managed&) = delete;
+        managed(managed &&) = delete;
+        managed& operator=(const managed&) = delete;
+        managed& operator=(managed&&) = delete;
+        template<typename, typename>
+        friend struct managed;
     };
 } // namespace realm
 

--- a/src/cpprealm/managed_objectid.hpp
+++ b/src/cpprealm/managed_objectid.hpp
@@ -47,6 +47,15 @@ namespace realm {
         //MARK: -   comparison operators
         rbool operator==(const realm::object_id& rhs) const noexcept;
         rbool operator!=(const realm::object_id& rhs) const noexcept;
+
+    private:
+        managed() = default;
+        managed(const managed&) = delete;
+        managed(managed &&) = delete;
+        managed& operator=(const managed&) = delete;
+        managed& operator=(managed&&) = delete;
+        template<typename, typename>
+        friend struct managed;
     };
 
     template<>
@@ -73,6 +82,15 @@ namespace realm {
         //MARK: -   comparison operators
         rbool operator==(const std::optional<realm::object_id>& rhs) const noexcept;
         rbool operator!=(const std::optional<realm::object_id>& rhs) const noexcept;
+
+    private:
+        managed() = default;
+        managed(const managed&) = delete;
+        managed(managed &&) = delete;
+        managed& operator=(const managed&) = delete;
+        managed& operator=(managed&&) = delete;
+        template<typename, typename>
+        friend struct managed;
     };
 
 } // namespace realm

--- a/src/cpprealm/managed_primary_key.hpp
+++ b/src/cpprealm/managed_primary_key.hpp
@@ -182,7 +182,7 @@ namespace realm {
         };
 
         template<>
-        struct managed<primary_key<int64_t>> : managed_base {
+        struct managed<primary_key<int64_t>> final : managed_base {
             primary_key<int64_t> detach() const {
                 return operator int64_t();
             }
@@ -203,10 +203,19 @@ namespace realm {
             rbool operator>=(const int& rhs) const noexcept;
             rbool operator<(const int& rhs) const noexcept;
             rbool operator<=(const int& rhs) const noexcept;
+
+        private:
+            managed() = default;
+            managed(const managed&) = delete;
+            managed(managed &&) = delete;
+            managed& operator=(const managed&) = delete;
+            managed& operator=(managed&&) = delete;
+            template<typename, typename>
+            friend struct managed;
         };
 
         template<>
-        struct managed<primary_key<std::string>> : managed_base {
+        struct managed<primary_key<std::string>> final : managed_base {
             primary_key<std::string> detach() const {
                 return operator std::string();
             }
@@ -219,6 +228,15 @@ namespace realm {
             rbool operator!=(const std::string& rhs) const noexcept;
             rbool operator==(const char* rhs) const noexcept;
             rbool operator!=(const char* rhs) const noexcept;
+
+        private:
+            managed() = default;
+            managed(const managed&) = default;
+            managed(managed &&) = delete;
+            managed& operator=(const managed&) = delete;
+            managed& operator=(managed&&) = delete;
+            template<typename, typename>
+            friend struct managed;
         };
 
         template<>
@@ -233,10 +251,19 @@ namespace realm {
 
             rbool operator==(const realm::uuid& rhs) const noexcept;
             rbool operator!=(const realm::uuid& rhs) const noexcept;
+
+        private:
+            managed() = default;
+            managed(const managed&) = delete;
+            managed(managed &&) = delete;
+            managed& operator=(const managed&) = delete;
+            managed& operator=(managed&&) = delete;
+            template<typename, typename>
+            friend struct managed;
         };
 
         template<>
-        struct managed<primary_key<realm::object_id>> : managed_base {
+        struct managed<primary_key<realm::object_id>> final : managed_base {
             primary_key<realm::object_id> detach() const {
                 return operator realm::object_id();
             }
@@ -247,10 +274,19 @@ namespace realm {
 
             rbool operator==(const realm::object_id& rhs) const noexcept;
             rbool operator!=(const realm::object_id& rhs) const noexcept;
+
+        private:
+            managed() = default;
+            managed(const managed&) = delete;
+            managed(managed &&) = delete;
+            managed& operator=(const managed&) = delete;
+            managed& operator=(managed&&) = delete;
+            template<typename, typename>
+            friend struct managed;
         };
 
         template<typename T>
-        struct managed<primary_key<T>, std::enable_if_t<std::is_enum_v<T>>> : managed_base {
+        struct managed<primary_key<T>, std::enable_if_t<std::is_enum_v<T>>> final : managed_base {
             primary_key<T> detach() const {
                 return operator T();
             }
@@ -275,10 +311,19 @@ namespace realm {
                 }
                 return serialize(detach().value) != serialize(rhs);
             }
+
+        private:
+            managed() = default;
+            managed(const managed&) = delete;
+            managed(managed &&) = delete;
+            managed& operator=(const managed&) = delete;
+            managed& operator=(managed&&) = delete;
+            template<typename, typename>
+            friend struct managed;
         };
 
         template<>
-        struct managed<primary_key<std::optional<int64_t>>> : managed_base {
+        struct managed<primary_key<std::optional<int64_t>>> final : managed_base {
             primary_key<std::optional<int64_t>> detach() const {
                 return operator std::optional<int64_t>();
             }
@@ -297,11 +342,19 @@ namespace realm {
             rbool operator>=(const int& rhs) const noexcept;
             rbool operator<(const int& rhs) const noexcept;
             rbool operator<=(const int& rhs) const noexcept;
+
+        private:
+            managed() = default;
+            managed(managed &&) = delete;
+            managed& operator=(const managed&) = delete;
+            managed& operator=(managed&&) = delete;
+            template<typename, typename>
+            friend struct managed;
         };
 
         template<typename T>
         struct managed<primary_key<T>, std::enable_if_t<std::conjunction_v<typename internal::type_info::is_optional<T>,
-                                                                           std::is_enum<typename T::value_type> >>> : managed_base {
+                                                                           std::is_enum<typename T::value_type> >>> final : managed_base {
             primary_key<T> detach() const {
                 return operator T();
             }
@@ -339,10 +392,19 @@ namespace realm {
                 }
                 return serialize(detach().value) != serialize(rhs);
             }
+
+        private:
+            managed() = default;
+            managed(const managed&) = delete;
+            managed(managed &&) = delete;
+            managed& operator=(const managed&) = delete;
+            managed& operator=(managed&&) = delete;
+            template<typename, typename>
+            friend struct managed;
         };
 
         template<>
-        struct managed<primary_key<std::optional<std::string>>> : managed_base {
+        struct managed<primary_key<std::optional<std::string>>> final : managed_base {
             primary_key<std::optional<std::string>> detach() const {
                 return operator std::optional<std::string>();
             }
@@ -355,10 +417,19 @@ namespace realm {
             rbool operator!=(const std::optional<std::string>& rhs) const noexcept;
             rbool operator==(const char* rhs) const noexcept;
             rbool operator!=(const char* rhs) const noexcept;
+
+        private:
+            managed() = default;
+            managed(const managed&) = delete;
+            managed(managed &&) = delete;
+            managed& operator=(const managed&) = delete;
+            managed& operator=(managed&&) = delete;
+            template<typename, typename>
+            friend struct managed;
         };
 
         template<>
-        struct managed<primary_key<std::optional<realm::uuid>>> : managed_base {
+        struct managed<primary_key<std::optional<realm::uuid>>> final : managed_base {
             primary_key<std::optional<realm::uuid>> detach() const {
                 return operator std::optional<realm::uuid>();
             }
@@ -373,10 +444,19 @@ namespace realm {
 
             rbool operator==(const std::optional<realm::uuid>& rhs) const noexcept;
             rbool operator!=(const std::optional<realm::uuid>& rhs) const noexcept;
+
+        private:
+            managed() = default;
+            managed(const managed&) = delete;
+            managed(managed &&) = delete;
+            managed& operator=(const managed&) = delete;
+            managed& operator=(managed&&) = delete;
+            template<typename, typename>
+            friend struct managed;
         };
 
         template<>
-        struct managed<primary_key<std::optional<realm::object_id>>> : managed_base {
+        struct managed<primary_key<std::optional<realm::object_id>>> final : managed_base {
             std::optional<realm::object_id> detach() const {
                 return operator std::optional<realm::object_id>();
             }
@@ -391,6 +471,15 @@ namespace realm {
 
             rbool operator==(const std::optional<realm::object_id>& rhs) const noexcept;
             rbool operator!=(const std::optional<realm::object_id>& rhs) const noexcept;
+
+        private:
+            managed() = default;
+            managed(const managed&) = delete;
+            managed(managed &&) = delete;
+            managed& operator=(const managed&) = delete;
+            managed& operator=(managed&&) = delete;
+            template<typename, typename>
+            friend struct managed;
         };
 }
 

--- a/src/cpprealm/managed_set.hpp
+++ b/src/cpprealm/managed_set.hpp
@@ -150,6 +150,15 @@ namespace realm {
         {
             return internal::bridge::set(*m_realm, *m_obj, m_key).size();
         }
+
+    private:
+        managed() = default;
+        managed(const managed&) = delete;
+        managed(managed &&) = delete;
+        managed& operator=(const managed&) = delete;
+        managed& operator=(managed&&) = delete;
+        template<typename, typename>
+        friend struct managed;
     };
 
     template<typename T>
@@ -180,11 +189,6 @@ namespace realm {
             {
                 auto s = realm::internal::bridge::set(*m_parent->m_realm, *m_parent->m_obj, m_parent->m_key);
                 managed<T> m(s.get_obj(m_i), *m_parent->m_realm);
-                std::apply([&m](auto &&...ptr) {
-                    std::apply([&](auto &&...name) {
-                        ((m.*ptr).assign(&m.m_obj, &m.m_realm, m.m_obj.get_table().get_column_key(name)), ...);
-                    }, managed<T>::managed_pointers_names);
-                }, managed<T>::managed_pointers());
                 return {std::move(m)};
             }
 
@@ -356,6 +360,15 @@ namespace realm {
         {
             return internal::bridge::set(*m_realm, *m_obj, m_key).size();
         }
+
+    private:
+        managed() = default;
+        managed(const managed&) = delete;
+        managed(managed &&) = delete;
+        managed& operator=(const managed&) = delete;
+        managed& operator=(managed&&) = delete;
+        template<typename, typename>
+        friend struct managed;
     };
 } // namespace realm
 

--- a/src/cpprealm/managed_string.cpp
+++ b/src/cpprealm/managed_string.cpp
@@ -140,12 +140,4 @@ namespace realm {
 
     __cpprealm_build_optional_query(==, equal, std::string)
     __cpprealm_build_optional_query(!=, not_equal, std::string)
-#ifdef __cpp_lib_starts_ends_with
-    bool managed_string::starts_with(std::string_view v) const noexcept {
-        return get().starts_with(v);
-    }
-    bool managed_string::ends_with(std::string_view v) const noexcept {
-        return get().ends_with(v);
-    }
-#endif
 }

--- a/src/cpprealm/managed_string.hpp
+++ b/src/cpprealm/managed_string.hpp
@@ -65,6 +65,7 @@ namespace realm {
 
     //MARK: - managed string
     template <> struct managed<std::string> : managed_base {
+        using value_type = std::string;
         using managed<std::string>::managed_base::managed_base;
         using managed<std::string>::managed_base::operator=;
 
@@ -102,14 +103,6 @@ namespace realm {
 
 
         [[nodiscard]] size_t size() const noexcept;
-#ifdef __cpp_lib_starts_ends_with
-        [[nodiscard]] bool starts_with(std::string_view) const noexcept;
-        [[nodiscard]] bool ends_with(std::string_view) const noexcept;
-#endif
-#ifdef __cpp_lib_string_contains
-        [[nodiscard]] bool contains(std::string_view) const noexcept;
-#endif
-
         //MARK: -   operations
         void clear() noexcept;
         void push_back(char c);
@@ -127,23 +120,22 @@ namespace realm {
         rbool operator!=(const char* rhs) const noexcept;
         rbool contains(const std::string &s) const noexcept;
         rbool empty() const noexcept;
-#ifdef __cpp_impl_three_way_comparison
-        inline auto operator<=>(const std::string& rhs) const noexcept {
-            return get().compare(rhs) <=> 0;
-        }
-        inline auto operator<=>(const char* rhs) const noexcept {
-            return get().compare(rhs) <=> 0;
-        }
-#else
-#endif
     private:
         friend struct char_reference;
         friend struct const_char_reference;
         void inline set(const std::string& v) { m_obj->template set<std::string>(m_key, v); }
         [[nodiscard]] inline std::string get() const { return m_obj->get<std::string>(m_key); }
+        managed() = default;
+        managed(const managed&) = delete;
+        managed(managed &&) = delete;
+        managed& operator=(const managed&) = delete;
+        managed& operator=(managed&&) = delete;
+        template<typename, typename>
+        friend struct managed;
     };
 
-    template <> struct managed<std::optional<std::string>> : public managed<std::string> {
+    template <> struct managed<std::optional<std::string>> final : public managed<std::string> {
+        using value_type = std::optional<std::string>;
         using managed<std::string>::operator=;
         managed& operator =(std::optional<std::string>&& v) { set(std::move(v)); return *this; }
         managed& operator =(const std::optional<std::string>& v) { set(v); return *this; }
@@ -165,6 +157,13 @@ namespace realm {
         rbool operator!=(const std::optional<std::string>& rhs) const noexcept;
     private:
         void inline set(const std::optional<std::string>& v) { m_obj->template set<std::optional<std::string>>(m_key, v); }
+        managed() = default;
+        managed(const managed&) = delete;
+        managed(managed &&) = delete;
+        managed& operator=(const managed&) = delete;
+        managed& operator=(managed&&) = delete;
+        template<typename, typename>
+        friend struct managed;
     };
 }
 

--- a/src/cpprealm/managed_timestamp.hpp
+++ b/src/cpprealm/managed_timestamp.hpp
@@ -29,6 +29,7 @@ namespace realm {
 
     template<>
     struct managed<std::chrono::time_point<std::chrono::system_clock>> : public managed_base {
+        using value_type = std::chrono::time_point<std::chrono::system_clock>;
         using managed<std::chrono::time_point<std::chrono::system_clock>>::managed_base::operator=;
 
         [[nodiscard]] std::chrono::time_point<std::chrono::system_clock> detach() const {
@@ -57,10 +58,20 @@ namespace realm {
         rbool operator>=(const std::chrono::time_point<std::chrono::system_clock>& rhs) const noexcept;
         rbool operator<(const std::chrono::time_point<std::chrono::system_clock>& rhs) const noexcept;
         rbool operator<=(const std::chrono::time_point<std::chrono::system_clock>& rhs) const noexcept;
+
+    private:
+        managed() = default;
+        managed(const managed&) = delete;
+        managed(managed &&) = delete;
+        managed& operator=(const managed&) = delete;
+        managed& operator=(managed&&) = delete;
+        template<typename, typename>
+        friend struct managed;
     };
 
     template<>
     struct managed<std::optional<std::chrono::time_point<std::chrono::system_clock>>> : managed_base {
+        using value_type = std::optional<std::chrono::time_point<std::chrono::system_clock>>;
         using managed<std::optional<std::chrono::time_point<std::chrono::system_clock>>>::managed_base::operator=;
 
         [[nodiscard]] std::optional<std::chrono::time_point<std::chrono::system_clock>> detach() const {
@@ -98,6 +109,15 @@ namespace realm {
         //MARK: -   comparison operators
         rbool operator==(const std::optional<std::chrono::time_point<std::chrono::system_clock>>& rhs) const noexcept;
         rbool operator!=(const std::optional<std::chrono::time_point<std::chrono::system_clock>>& rhs) const noexcept;
+
+    private:
+        managed() = default;
+        managed(const managed&) = delete;
+        managed(managed &&) = delete;
+        managed& operator=(const managed&) = delete;
+        managed& operator=(managed&&) = delete;
+        template<typename, typename>
+        friend struct managed;
     };
 
 } // namespace realm

--- a/src/cpprealm/managed_uuid.hpp
+++ b/src/cpprealm/managed_uuid.hpp
@@ -29,6 +29,7 @@ namespace realm {
 
     template<>
     struct managed<realm::uuid> : managed_base {
+        using value_type = realm::uuid;
         using managed<realm::uuid>::managed_base::operator=;
 
         [[nodiscard]] realm::uuid detach() const {
@@ -46,10 +47,20 @@ namespace realm {
         //MARK: -   comparison operators
         rbool operator==(const realm::uuid& rhs) const noexcept;
         rbool operator!=(const realm::uuid& rhs) const noexcept;
+
+    private:
+        managed() = default;
+        managed(const managed&) = delete;
+        managed(managed &&) = delete;
+        managed& operator=(const managed&) = delete;
+        managed& operator=(managed&&) = delete;
+        template<typename, typename>
+        friend struct managed;
     };
 
     template<>
     struct managed<std::optional<realm::uuid>> : managed_base {
+        using value_type = std::optional<realm::uuid>;
         using managed<std::optional<realm::uuid>>::managed_base::operator=;
 
         [[nodiscard]] std::optional<realm::uuid> detach() const {
@@ -72,6 +83,15 @@ namespace realm {
         //MARK: -   comparison operators
         rbool operator==(const std::optional<realm::uuid>& rhs) const noexcept;
         rbool operator!=(const std::optional<realm::uuid>& rhs) const noexcept;
+
+    private:
+        managed() = default;
+        managed(const managed&) = delete;
+        managed(managed &&) = delete;
+        managed& operator=(const managed&) = delete;
+        managed& operator=(managed&&) = delete;
+        template<typename, typename>
+        friend struct managed;
     };
 
 } // namespace realm

--- a/tests/db/mixed_tests.cpp
+++ b/tests/db/mixed_tests.cpp
@@ -44,4 +44,117 @@ TEST_CASE("mixed", "[mixed]") {
         });
         CHECK(managed_obj.mixed_col == u);
     }
+
+    SECTION("holds_alternative") {
+        auto obj = AllTypesObject();
+        obj.mixed_col = (int64_t)42;
+        CHECK(obj.mixed_col == realm::mixed((int64_t)42));
+        auto realm = db(std::move(config));
+        auto managed_obj = realm.write([&realm, &obj] {
+            return realm.add(std::move(obj));
+        });
+        bool result = realm::holds_alternative<int64_t>(managed_obj.mixed_col);
+        CHECK(result);
+        result = realm::holds_alternative<bool>(managed_obj.mixed_col);
+        CHECK_FALSE(result);
+
+        realm.write([&realm, &managed_obj] {
+            managed_obj.mixed_col = std::string("foo");
+        });
+        result = realm::holds_alternative<std::string>(managed_obj.mixed_col);
+        CHECK(result);
+
+        realm.write([&realm, &managed_obj] {
+            managed_obj.mixed_col = std::vector<uint8_t>({1,1,1,1});
+        });
+        result = realm::holds_alternative<std::vector<uint8_t>>(managed_obj.mixed_col);
+        CHECK(result);
+
+        realm.write([&realm, &managed_obj] {
+            managed_obj.mixed_col = realm::mixed((int64_t)1234);
+        });
+        result = realm::holds_alternative<int64_t>(managed_obj.mixed_col);
+        CHECK(result);
+
+        realm.write([&realm, &managed_obj] {
+            managed_obj.mixed_col = std::chrono::time_point<std::chrono::system_clock>();
+        });
+        result = realm::holds_alternative<std::chrono::time_point<std::chrono::system_clock>>(managed_obj.mixed_col);
+        CHECK(result);
+
+        realm.write([&realm, &managed_obj] {
+            managed_obj.mixed_col = 123.456;
+        });
+        result = realm::holds_alternative<double>(managed_obj.mixed_col);
+        CHECK(result);
+
+        realm.write([&realm, &managed_obj] {
+            managed_obj.mixed_col = realm::decimal128("123.456");
+        });
+        result = realm::holds_alternative<realm::decimal128>(managed_obj.mixed_col);
+        CHECK(result);
+
+        realm.write([&realm, &managed_obj] {
+            managed_obj.mixed_col = realm::object_id();
+        });
+        result = realm::holds_alternative<realm::object_id>(managed_obj.mixed_col);
+        CHECK(result);
+
+        realm.write([&realm, &managed_obj] {
+            managed_obj.mixed_col = realm::uuid();
+        });
+        result = realm::holds_alternative<realm::uuid>(managed_obj.mixed_col);
+        CHECK(result);
+
+        realm.write([&realm, &managed_obj] {
+            managed_obj.mixed_col = std::monostate();
+        });
+        result = realm::holds_alternative<std::monostate>(managed_obj.mixed_col);
+        CHECK(result);
+    }
+
+    SECTION("links") {
+        auto obj = AllTypesObject();
+        obj.mixed_col = (int64_t)42;
+        CHECK(obj.mixed_col == realm::mixed((int64_t)42));
+        auto realm = db(std::move(config));
+        auto managed_obj = realm.write([&realm, &obj] {
+            return realm.add(std::move(obj));
+        });
+        CHECK_FALSE(managed_obj.mixed_col.has_link());
+
+        auto link = AllTypesObjectLink();
+        link._id = 0;
+        link.str_col = "foo";
+
+        realm.write([&] {
+            managed_obj.mixed_col.set_link(std::move(link));
+        });
+        CHECK(managed_obj.mixed_col.has_link());
+
+        auto mixed_link = managed_obj.mixed_col.get_stored_link<AllTypesObjectLink*>();
+        CHECK(mixed_link->str_col == "foo");
+
+        bool result = realm::holds_alternative<AllTypesObjectLink*>(managed_obj.mixed_col);
+        CHECK(result);
+
+        result = realm::holds_alternative<StringObject*>(managed_obj.mixed_col);
+        CHECK_FALSE(result);
+
+        auto link2 = AllTypesObjectLink();
+        link2._id = 0;
+        link2.str_col = "bar";
+
+        auto managed_link = realm.write([&] {
+            return realm.add(std::move(link2));
+        });
+
+        realm.write([&] {
+            managed_obj.mixed_col.set_link(managed_link);
+        });
+        mixed_link = managed_obj.mixed_col.get_stored_link<AllTypesObjectLink*>();
+        CHECK(mixed_link->str_col == "bar");
+
+        CHECK_THROWS(managed_obj.mixed_col.get_stored_link<StringObject*>());
+    }
 }

--- a/tests/db/object_tests.cpp
+++ b/tests/db/object_tests.cpp
@@ -988,7 +988,6 @@ namespace realm {
             auto obj1 = AllTypesObject();
             obj1._id = 1;
 
-
             auto o = AllTypesObjectLink();
             o.str_col = "bar";
             obj1.opt_obj_col = &o;
@@ -1005,8 +1004,83 @@ namespace realm {
             });
 
             CHECK(realm.objects<AllTypesObject>().size() == 2);
-//            CHECK(realm.objects<AllTypesObjectLink>().size() == 2);
-
+            CHECK(realm.objects<AllTypesObjectLink>().size() == 1);
         }
+
+        static_assert(!std::is_constructible_v<typename managed<AllTypesObjectLink *>::ref_type>, "Default constructor is private.");
+        static_assert(!std::is_constructible_v<managed<int64_t>>, "Default constructor is private.");
+        static_assert(!std::is_constructible_v<managed<double>>, "Default constructor is private.");
+        static_assert(!std::is_constructible_v<managed<bool>>, "Default constructor is private.");
+        static_assert(!std::is_constructible_v<managed<std::string>>, "Default constructor is private.");
+        static_assert(!std::is_constructible_v<managed<primary_key<int64_t>>>, "Default constructor is private.");
+        static_assert(!std::is_constructible_v<managed<primary_key<realm::object_id>>>, "Default constructor is private.");
+        static_assert(!std::is_constructible_v<managed<primary_key<realm::uuid>>>, "Default constructor is private.");
+        static_assert(!std::is_constructible_v<managed<primary_key<std::string>>>, "Default constructor is private.");
+        static_assert(!std::is_constructible_v<managed<primary_key<std::optional<int64_t>>>>, "Default constructor is private.");
+        static_assert(!std::is_constructible_v<managed<primary_key<std::optional<realm::object_id>>>>, "Default constructor is private.");
+        static_assert(!std::is_constructible_v<managed<primary_key<std::optional<realm::uuid>>>>, "Default constructor is private.");
+        static_assert(!std::is_constructible_v<managed<primary_key<std::optional<std::string>>>>, "Default constructor is private.");
+        static_assert(!std::is_constructible_v<managed<realm::AllTypesObject::Enum>>, "Default constructor is private.");
+        static_assert(!std::is_constructible_v<managed<std::chrono::time_point<std::chrono::system_clock>>>, "Default constructor is private.");
+        static_assert(!std::is_constructible_v<managed<realm::uuid>>, "Default constructor is private.");
+        static_assert(!std::is_constructible_v<managed<realm::object_id>>, "Default constructor is private.");
+        static_assert(!std::is_constructible_v<managed<realm::decimal128>>, "Default constructor is private.");
+        static_assert(!std::is_constructible_v<managed<std::vector<std::uint8_t>>>, "Default constructor is private.");
+        static_assert(!std::is_constructible_v<managed<realm::mixed>>, "Default constructor is private.");
+
+        static_assert(!std::is_constructible_v<managed<std::optional<int64_t>>>, "Default constructor is private.");
+        static_assert(!std::is_constructible_v<managed<std::optional<double>>>, "Default constructor is private.");
+        static_assert(!std::is_constructible_v<managed<std::optional<std::string>>>, "Default constructor is private.");
+        static_assert(!std::is_constructible_v<managed<std::optional<bool>>>, "Default constructor is private.");
+        static_assert(!std::is_constructible_v<managed<std::optional<realm::AllTypesObject::Enum>>>, "Default constructor is private.");
+        static_assert(!std::is_constructible_v<managed<std::optional<std::chrono::time_point<std::chrono::system_clock>>>>, "Default constructor is private.");
+        static_assert(!std::is_constructible_v<managed<std::optional<realm::uuid>>>, "Default constructor is private.");
+        static_assert(!std::is_constructible_v<managed<std::optional<realm::object_id>>>, "Default constructor is private.");
+        static_assert(!std::is_constructible_v<managed<std::optional<realm::decimal128>>>, "Default constructor is private.");
+        static_assert(!std::is_constructible_v<managed<std::optional<std::vector<uint8_t>>>>, "Default constructor is private.");
+        static_assert(!std::is_constructible_v<managed<AllTypesObjectLink*>>, "Default constructor is private.");
+        static_assert(!std::is_constructible_v<managed<AllTypesObjectEmbedded*>>, "Default constructor is private.");
+
+        static_assert(!std::is_constructible_v<managed<std::vector<int64_t>>>, "Default constructor is private.");
+        static_assert(!std::is_constructible_v<managed<std::vector<double>>>, "Default constructor is private.");
+        static_assert(!std::is_constructible_v<managed<std::vector<bool>>>, "Default constructor is private.");
+        static_assert(!std::is_constructible_v<managed<std::vector<std::string>>>, "Default constructor is private.");
+        static_assert(!std::is_constructible_v<managed<std::vector<realm::uuid>>>, "Default constructor is private.");
+        static_assert(!std::is_constructible_v<managed<std::vector<realm::object_id>>>, "Default constructor is private.");
+        static_assert(!std::is_constructible_v<managed<std::vector<realm::decimal128>>>, "Default constructor is private.");
+        static_assert(!std::is_constructible_v<managed<std::vector<std::vector<std::uint8_t>>>>, "Default constructor is private.");
+        static_assert(!std::is_constructible_v<managed<std::vector<std::chrono::time_point<std::chrono::system_clock>>>>, "Default constructor is private.");
+        static_assert(!std::is_constructible_v<managed<std::vector<realm::mixed>>>, "Default constructor is private.");
+        static_assert(!std::is_constructible_v<managed<std::vector<realm::AllTypesObject::Enum>>>, "Default constructor is private.");
+        static_assert(!std::is_constructible_v<managed<std::vector<AllTypesObjectLink *>>>, "Default constructor is private.");
+        static_assert(!std::is_constructible_v<managed<std::vector<AllTypesObjectEmbedded *>>>, "Default constructor is private.");
+
+        static_assert(!std::is_constructible_v<managed<std::set<int64_t>>>, "Default constructor is private.");
+        static_assert(!std::is_constructible_v<managed<std::set<double>>>, "Default constructor is private.");
+        static_assert(!std::is_constructible_v<managed<std::set<bool>>>, "Default constructor is private.");
+        static_assert(!std::is_constructible_v<managed<std::set<std::string>>>, "Default constructor is private.");
+        static_assert(!std::is_constructible_v<managed<std::set<realm::uuid>>>, "Default constructor is private.");
+        static_assert(!std::is_constructible_v<managed<std::set<realm::object_id>>>, "Default constructor is private.");
+        static_assert(!std::is_constructible_v<managed<std::set<realm::decimal128>>>, "Default constructor is private.");
+        static_assert(!std::is_constructible_v<managed<std::set<std::vector<std::uint8_t>>>>, "Default constructor is private.");
+        static_assert(!std::is_constructible_v<managed<std::set<std::chrono::time_point<std::chrono::system_clock>>>>, "Default constructor is private.");
+        static_assert(!std::is_constructible_v<managed<std::set<realm::mixed>>>, "Default constructor is private.");
+        static_assert(!std::is_constructible_v<managed<std::set<realm::AllTypesObject::Enum>>>, "Default constructor is private.");
+        static_assert(!std::is_constructible_v<managed<std::set<AllTypesObjectLink *>>>, "Default constructor is private.");
+        static_assert(!std::is_constructible_v<managed<std::set<AllTypesObjectEmbedded *>>>, "Default constructor is private.");
+
+        static_assert(!std::is_constructible_v<managed<std::map<std::string, int64_t>>>, "Default constructor is private.");
+        static_assert(!std::is_constructible_v<managed<std::map<std::string, double>>>, "Default constructor is private.");
+        static_assert(!std::is_constructible_v<managed<std::map<std::string, bool>>>, "Default constructor is private.");
+        static_assert(!std::is_constructible_v<managed<std::map<std::string, std::string>>>, "Default constructor is private.");
+        static_assert(!std::is_constructible_v<managed<std::map<std::string, realm::uuid>>>, "Default constructor is private.");
+        static_assert(!std::is_constructible_v<managed<std::map<std::string, realm::object_id>>>, "Default constructor is private.");
+        static_assert(!std::is_constructible_v<managed<std::map<std::string, realm::decimal128>>>, "Default constructor is private.");
+        static_assert(!std::is_constructible_v<managed<std::map<std::string, std::vector<std::uint8_t>>>>, "Default constructor is private.");
+        static_assert(!std::is_constructible_v<managed<std::map<std::string, std::chrono::time_point<std::chrono::system_clock>>>>, "Default constructor is private.");
+        static_assert(!std::is_constructible_v<managed<std::map<std::string, realm::mixed>>>, "Default constructor is private.");
+        static_assert(!std::is_constructible_v<managed<std::map<std::string, realm::AllTypesObject::Enum>>>, "Default constructor is private.");
+        static_assert(!std::is_constructible_v<managed<std::map<std::string, AllTypesObjectLink *>>>, "Default constructor is private.");
+        static_assert(!std::is_constructible_v<managed<std::map<std::string, AllTypesObjectEmbedded *>>>, "Default constructor is private.");
     }
 }

--- a/tests/db/test_objects.hpp
+++ b/tests/db/test_objects.hpp
@@ -71,8 +71,16 @@ namespace realm {
         primary_key<int64_t> _id;
         std::string str_col;
         StringObject* str_link_col = nullptr;
+
+        std::vector<std::string> list_str_col;
+        std::vector<StringObject*> list_obj_col;
+        std::set<std::string> set_str_col;
+        std::set<StringObject*> set_obj_col;
+        std::map<std::string, std::string> map_str_col;
+        std::map<std::string, StringObject*> map_link_col;
+
     };
-    REALM_SCHEMA(AllTypesObjectLink, _id, str_col, str_link_col)
+    REALM_SCHEMA(AllTypesObjectLink, _id, str_col, str_link_col, list_str_col, list_obj_col, set_str_col, set_obj_col, map_str_col, map_link_col)
 
     struct SetParentObject {
         primary_key<int64_t> _id;


### PR DESCRIPTION
### Fixed
* Managed objects would exhibit undefined behaviour when returned from the subscript operator in `std::vector` & `std::map`.

### Enhancements
* Add `realm::holds_alternative` which acts as a substitute to `std::holds_alternative` when using `managed<realm::mixed>`.
* Add `managed<realm::mixed>::get_stored_link` for retrieving a link from a mixed proeprty type.
* Add `managed<realm::mixed>::set_link` for setting a link in a mixed proeprty type.
* Add compile time checking to prevent misuse of managed property types.