### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,87 @@
+name: Bug Report
+description: File a bug report
+labels: [T-Bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Tell us, what did you expect to happen?
+      placeholder: Tell us what you see!
+      value: "A bug happened!"
+    validations:
+      required: true
+  - type: textarea
+    id: repro-steps
+    attributes:
+      label: Repro steps
+      description: If you can reproduce the issue, please provide detailed repro steps here or provide a link to a repro project.
+      placeholder: 1. X, 2. Y, 3. Crash!
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: What version of the C++ SDK are you using?
+      placeholder: e.g. 0.6.1-preview
+    validations:
+      required: true
+  - type: input
+    id: install-method
+    attributes:
+      label: Installation method
+      description: How are you installing the C++ SDK?
+      placeholder: e.g. CMake 3.15
+    validations:
+      required: true
+  - type: dropdown
+    id: services
+    attributes:
+      label: What Atlas Services are you using?
+      options:
+        - -- select --
+        - Local Database only
+        - Atlas Device Sync
+        - 'Atlas App Services: Functions or GraphQL or DataAPI etc'
+        - Both Atlas Device Sync and Atlas App Services
+    validations:
+      required: true
+  - type: input
+    id: compiler
+    attributes:
+      label: Compiler
+      description: What compiler are you using?
+      placeholder: e.g. Clang 16.0.6
+    validations:
+      required: true
+  - type: input
+    id: client-platforms
+    attributes:
+      label: OS and version
+      description: What OS (name and version) are you seeing the issue on?
+      placeholder: e.g. Ubuntu 18.04
+    validations:
+      required: true
+  - type: textarea
+    id: code-snippets
+    attributes:
+      label: Code snippets
+      description: Please provide a code sample or test case that highlights the issue. If relevant, include your model definitions.
+      placeholder: Your code here
+  - type: textarea
+    id: stacktrace
+    attributes:
+      label: Stacktrace of the exception/crash you're getting
+      description: If you're getting an exception or a crash, please paste the stacktrace here.
+      render: shell
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant log output.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: General Questions and Inquiries
+    url: https://www.mongodb.com/community/forums/tags/c/atlas-app-services-realm/realm/58/cxx
+    about: Please ask general design/architecture questions in the community forums.
+  - name: MongoDB Atlas Device Sync Production Issues
+    url: https://support.mongodb.com/
+    about: Please report urgent production issues to the support portal directly.


### PR DESCRIPTION
This adds a bug.yml template, which can be previewed here: https://github.com/realm/realm-cpp/blob/ni/github-templates/.github/ISSUE_TEMPLATE/bug.yml.

I tried to add relevant fields (e.g. compiler, installation method, etc.) but let me know if there's more questions we should ask users.