### PR TITLE
RCPP-55 Update to new base url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ X.Y.Z Release notes (YYYY-MM-DD)
   enabled on the platform ([#192](https://github.com/realm/realm-cpp/pull/192), since v1.1.0)
 
 ### Enhancements
-* None
+* Updated default base URL to be `https://services.cloud.mongodb.com` to support the new domains (was `https://realm.mongodb.com`)
 
 ### Breaking Changes
 * None
@@ -15,7 +15,7 @@ X.Y.Z Release notes (YYYY-MM-DD)
 * Fileformat: Generates files with format v24. Reads and automatically upgrade from fileformat v10.
 
 ### Internals
-* None
+* Upgraded to Core v14.5.1
 
 ----------------------------------------------
 

--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@
 import PackageDescription
 
 let sdkVersion = Version("1.1.0")
-let coreVersion = Version("14.4.1")
+let coreVersion = Version("14.5.1")
 
 var cxxSettings: [CXXSetting] = [
     .define("REALM_ENABLE_SYNC", to: "1"),
@@ -62,7 +62,7 @@ let package = Package(
             targets: ["realm-cpp-sdk"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/realm/realm-core.git", revision: "374dd672af357732dccc135fecc905406fec3223")
+        .package(url: "https://github.com/realm/realm-core.git", revision: "316889b967f845fbc10b4422f96c7eadd47136f2")
     ],
     targets: [
         cppSdkTarget,

--- a/include/cpprealm/app.hpp
+++ b/include/cpprealm/app.hpp
@@ -289,6 +289,7 @@ public:
     [[nodiscard]] std::optional<user> get_current_user() const;
     void clear_cached_apps();
     std::optional<App> get_cached_app(const std::string& app_id, const std::optional<std::string>& base_url);
+    std::string get_base_url() const;
 private:
     std::shared_ptr<app::App> m_app;
     App(std::shared_ptr<app::App>&& a) : m_app(std::move(a)) { }

--- a/src/cpprealm/app.cpp
+++ b/src/cpprealm/app.cpp
@@ -505,6 +505,10 @@ namespace realm {
         *this = App(std::move(c));
     }
 
+    std::string App::get_base_url() const {
+        return m_app->get_base_url();
+    }
+
     std::future<void> App::register_user(const std::string &username, const std::string &password) {
         std::promise<void> p;
         std::future<void> f = p.get_future();

--- a/tests/sync/app_tests.cpp
+++ b/tests/sync/app_tests.cpp
@@ -72,6 +72,13 @@ using namespace realm;
 TEST_CASE("app", "[app]") {
     auto app = realm::App(realm::App::configuration({Admin::Session::shared().cached_app_id(), Admin::Session::shared().base_url()}));
 
+    SECTION("base_url") {
+        auto no_url_provided_app = realm::App(realm::App::configuration({"NA"}));
+        CHECK(no_url_provided_app.get_base_url() == "https://services.cloud.mongodb.com");
+        auto with_url_provided_app = realm::App(realm::App::configuration({"NA", "https://foobar.com"}));
+        CHECK(with_url_provided_app.get_base_url() == "https://foobar.com");
+    }
+
     SECTION("get_current_user") {
         auto user = app.login(realm::App::credentials::anonymous()).get();
 


### PR DESCRIPTION
* Updated default base URL to be `https://services.cloud.mongodb.com` to support the new domains (was `https://realm.mongodb.com`)