### PR TITLE
(DOCSP-38826): Add `include` path to Doxyfile for generating API reference docs

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -908,7 +908,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = ./README.md ./src/cpprealm
+INPUT                  = ./README.md ./include/cpprealm ./src/cpprealm
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses


### PR DESCRIPTION
The `.hpp` files were recently moved to a new `/include` directory, which is outside the path that the Doxyfile uses to generate the API reference docs. This update to the Doxyfile should add all the classes back to the API reference.