### PR TITLE
Add ability to disable aligned storage for bridged types

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -31,7 +31,7 @@ jobs:
 
   build-macos:
     runs-on: macos-14
-    name: macOS ${{ matrix.configuration }}, Xcode ${{ matrix.xcode }}
+    name: macOS ${{ matrix.configuration }}, Xcode ${{ matrix.xcode }}, uses aligned storage ${{ matrix.use-aligned-storage }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -40,6 +40,9 @@ jobs:
         configuration:
           - Debug
           - Release
+        use-aligned-storage:
+          - 1
+          - 0
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -62,7 +65,7 @@ jobs:
       - uses: ammaraskar/gcc-problem-matcher@master
 
       - name: Configure
-        run: cmake --preset macos -DCMAKE_VERBOSE_MAKEFILE=${RUNNER_DEBUG:-OFF} -DCMAKE_OSX_DEPLOYMENT_TARGET=10.15 -DREALM_ENABLE_EXPERIMENTAL=1 -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+        run: cmake --preset macos -DCMAKE_VERBOSE_MAKEFILE=${RUNNER_DEBUG:-OFF} -DCMAKE_OSX_DEPLOYMENT_TARGET=10.15 -DREALM_ENABLE_EXPERIMENTAL=1 -DREALM_DISABLE_ALIGNED_STORAGE=${{ matrix.use-aligned-storage }} -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
 
       - name: Compile
         run: cmake --build --preset macos --config ${{ matrix.configuration }}

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -31,7 +31,7 @@ jobs:
 
   build-macos:
     runs-on: macos-14
-    name: macOS ${{ matrix.configuration }}, Xcode ${{ matrix.xcode }}, uses aligned storage ${{ matrix.use-aligned-storage }}
+    name: macOS ${{ matrix.configuration }}, Xcode ${{ matrix.xcode }}, REALM_DISABLE_ALIGNED_STORAGE=${{ matrix.use-aligned-storage }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -31,7 +31,7 @@ jobs:
 
   build-macos:
     runs-on: macos-14
-    name: macOS ${{ matrix.configuration }}, Xcode ${{ matrix.xcode }}, REALM_DISABLE_ALIGNED_STORAGE=${{ matrix.use-aligned-storage }}
+    name: macOS ${{ matrix.configuration }}, Xcode ${{ matrix.xcode }}, REALM_DISABLE_ALIGNED_STORAGE=${{ matrix.disable-aligned-storage }}
     strategy:
       fail-fast: false
       matrix:
@@ -40,7 +40,7 @@ jobs:
         configuration:
           - Debug
           - Release
-        use-aligned-storage:
+        disable-aligned-storage:
           - 1
           - 0
     steps:
@@ -65,7 +65,7 @@ jobs:
       - uses: ammaraskar/gcc-problem-matcher@master
 
       - name: Configure
-        run: cmake --preset macos -DCMAKE_VERBOSE_MAKEFILE=${RUNNER_DEBUG:-OFF} -DCMAKE_OSX_DEPLOYMENT_TARGET=10.15 -DREALM_ENABLE_EXPERIMENTAL=1 -DREALM_DISABLE_ALIGNED_STORAGE=${{ matrix.use-aligned-storage }} -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+        run: cmake --preset macos -DCMAKE_VERBOSE_MAKEFILE=${RUNNER_DEBUG:-OFF} -DCMAKE_OSX_DEPLOYMENT_TARGET=10.15 -DREALM_ENABLE_EXPERIMENTAL=1 -DREALM_DISABLE_ALIGNED_STORAGE=${{ matrix.disable-aligned-storage }} -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
 
       - name: Compile
         run: cmake --build --preset macos --config ${{ matrix.configuration }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ NEXT RELEASE Release notes (YYYY-MM-DD)
 * Add `realm::default_scheduler::make_default()` which generates a platform default scheduler if `realm::default_scheduler::set_default_factory` is not set.
 * Add `managed<T>::to_json(std::ostream&)` which allows managed objects to be printed as json.
 * Add `rbool::truepredicate()` and `rbool::falsepredicate()` expressions for type safe queries.
+* Add ability to build the Realm C++ SDK without stack allocated bridging types. Use the CMake flag `-DREALM_DISABLE_ALIGNED_STORAGE=1` to disable.
 
 ### Compatibility
 * Fileformat: Generates files with format v24. Reads and automatically upgrade from fileformat v10.

--- a/conanfile.py
+++ b/conanfile.py
@@ -36,7 +36,7 @@ class cpprealmRecipe(ConanFile):
         git = Git(self)
         git.clone(url="https://github.com/realm/realm-cpp", target=".")
         git.folder = "."
-        git.checkout(commit="fd20cf3d9f226dac8a21c89300728ac9be8bd2e2")
+        git.checkout(commit="9f0dc47ceaf5c2842df930aca28e98d7f594d0ce")
         git.run("submodule update --init --recursive")
 
     def layout(self):

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -138,10 +138,6 @@ if (NOT REALM_DISABLE_ALIGNED_STORAGE)
             COMPONENT devel)
 
     set(BRIDGING_HEADER ${CMAKE_CURRENT_BINARY_DIR}/cpprealm/internal/bridge/bridge_types.hpp)
-
-    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/cpprealm/internal/bridge/bridge_types.hpp
-            DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/cpprealm/internal/bridge
-            COMPONENT devel)
 endif()
 
 include(GNUInstallDirs)
@@ -163,5 +159,11 @@ foreach(header ${HEADERS})
             DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${dir}
             COMPONENT devel)
 endforeach()
+
+if (NOT REALM_DISABLE_ALIGNED_STORAGE)
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/cpprealm/internal/bridge/bridge_types.hpp
+            DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/cpprealm/internal/bridge
+            COMPONENT devel)
+endif()
 
 install()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,21 +8,6 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/cpprealm/version_numbers.hpp
         DESTINATION include/cpprealm
         COMPONENT devel)
 
-add_custom_command(
-    COMMAND ${CMAKE_COMMAND} -D SOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR}/cpprealm/internal/bridge 
-                             -D BINARY_DIR=${CMAKE_CURRENT_BINARY_DIR}/cpprealm/internal/bridge
-                             -D BRIDGE_TYPE_INFO_BIN=$<TARGET_FILE:BridgeTypeInfoGenerator>
-                             -P ${CMAKE_CURRENT_SOURCE_DIR}/cpprealm/internal/bridge/generator/bridge_type_info_parser.cmake
-    DEPENDS BridgeTypeInfoGenerator
-    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/cpprealm/internal/bridge/generator/bridge_type_info_parser.cmake
-    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/cpprealm/internal/bridge/bridge_types.hpp.in
-    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/cpprealm/internal/bridge/bridge_types.hpp
-)
-
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/cpprealm/internal/bridge/bridge_types.hpp
-        DESTINATION include/cpprealm/internal/bridge
-        COMPONENT devel)
-
 set(SOURCES
     cpprealm/analytics.cpp
     cpprealm/app.cpp
@@ -136,9 +121,32 @@ set(HEADERS
     ../include/cpprealm/thread_safe_reference.hpp
     ../include/cpprealm/sdk.hpp) # REALM_INSTALL_HEADERS
 
+if (NOT REALM_DISABLE_ALIGNED_STORAGE)
+    add_custom_command(
+            COMMAND ${CMAKE_COMMAND} -D SOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR}/cpprealm/internal/bridge
+            -D BINARY_DIR=${CMAKE_CURRENT_BINARY_DIR}/cpprealm/internal/bridge
+            -D BRIDGE_TYPE_INFO_BIN=$<TARGET_FILE:BridgeTypeInfoGenerator>
+            -P ${CMAKE_CURRENT_SOURCE_DIR}/cpprealm/internal/bridge/generator/bridge_type_info_parser.cmake
+            DEPENDS BridgeTypeInfoGenerator
+            DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/cpprealm/internal/bridge/generator/bridge_type_info_parser.cmake
+            DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/cpprealm/internal/bridge/bridge_types.hpp.in
+            OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/cpprealm/internal/bridge/bridge_types.hpp
+    )
+
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/cpprealm/internal/bridge/bridge_types.hpp
+            DESTINATION include/cpprealm/internal/bridge
+            COMPONENT devel)
+
+    set(BRIDGING_HEADER ${CMAKE_CURRENT_BINARY_DIR}/cpprealm/internal/bridge/bridge_types.hpp)
+
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/cpprealm/internal/bridge/bridge_types.hpp
+            DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/cpprealm/internal/bridge
+            COMPONENT devel)
+endif()
+
 include(GNUInstallDirs)
 
-add_library(cpprealm ${SOURCES} ${HEADERS} ${CMAKE_CURRENT_BINARY_DIR}/cpprealm/internal/bridge/bridge_types.hpp)
+add_library(cpprealm ${SOURCES} ${HEADERS} ${BRIDGING_HEADER})
 
 if (NOT VCPKG_TOOLCHAIN)
     set(INSTALL_TARGETS ObjectStore Storage QueryParser Sync)
@@ -155,7 +163,5 @@ foreach(header ${HEADERS})
             DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${dir}
             COMPONENT devel)
 endforeach()
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/cpprealm/internal/bridge/bridge_types.hpp
-        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/cpprealm/internal/bridge
-        COMPONENT devel)
+
 install()


### PR DESCRIPTION
Currently when building with CMake we default to always generating the bridging headers size and aligned size for usage in `std::aligned_storage`. This PR allows you to override that and use `std::shared_ptr`for the Core bridged types instead. This is required when we can't generate the bridging headers correctly or a package manager might not allow it.