### PR TITLE
RCPP-85 fixed gcc clang build ubuntu 24.04

### DIFF
--- a/include/cpprealm/internal/bridge/realm.hpp
+++ b/include/cpprealm/internal/bridge/realm.hpp
@@ -27,6 +27,7 @@
 #include <optional>
 #include <string>
 #include <vector>
+#include <cstdint>
 
 namespace realm {
     class Realm;

--- a/include/cpprealm/link.hpp
+++ b/include/cpprealm/link.hpp
@@ -187,7 +187,7 @@ namespace realm {
         }
 
     private:
-        managed<T*>() = default;
+        managed() = default;
         template<typename, typename>
         friend struct managed;
     };


### PR DESCRIPTION
Issue RCPP-85

Fixed missing header in realm.hpp mentioned in RCPP-85.
Fixed the following build error in gcc:

> cpprealm/link.hpp:190:21: error: expected unqualified-id before ‘)’ token
>   190 |         managed<T*>() = default;
>       |                     ^
> 
> managed() = default;

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.