### PR TITLE
RCPP-89 Add 301/308 redirection support for HTTP transport requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,10 @@
 .DS_Store
 /.build
+/build.debug
 /Packages
 /*.xcodeproj
+.idea/
+/.vscode
 /.swiftpm
 xcuserdata/
 DerivedData/
@@ -10,5 +13,4 @@ Package.resolved
 examples/*.pro.user
 docs/html
 docs/latex
-.idea/
 realm-core/src/realm/parser/generated/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,12 @@ NEXT_RELEASE Release notes (YYYY-MM-DD)
   even if a sync configuration is not supplied.
 * Added 301/308 http redirect response support to the default HTTP transport, since it has been
   removed from Core and is the responsibility of the SDKs to handle the redirect operation. A
-  redirect should rarely be received from teh server, and typically happens after changing the
-  deployment server for the cloud app or the base URL is configured to connect to the wrong host.
+  redirect should rarely be received from the server, and typically happens after changing the
+  deployment model for the cloud app or the base URL is configured to connect to the wrong host.
   If a custom HTTP transport is provided by the developer, it should also support handling
-  redirect responses with a status code of 301 or 308 and not change the request method from POST
-  to GET when resending the request.
-Add `managed<std::map<std::string, T>>::contains_key` for conveniently checking if a managed map
+  redirect responses with a status code of 301 or 308, remove the Authorization header and
+  retain the original HTTP method when re-sending requests after a redirect.
+* Add `managed<std::map<std::string, T>>::contains_key` for conveniently checking if a managed map
   contains a given key. Use this method in the Type Safe Query API instead of `managed<std::map<std::string, T>>::find`.
 
 ### Compatibility

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ NEXT_RELEASE Release notes (YYYY-MM-DD)
 ### Enhancements
 * Add `realm::db_config::enable_forced_sync_history()` which allows you to open a synced Realm
   even if a sync configuration is not supplied.
+* Added 301/308 http redirect response support to the default HTTP transport, since it has been
+  removed from Core and is the responsibility of the SDKs to handle the redirect operation. A
+  redirect should rarely be received from teh server, and typically happens after changing the
+  deployment server for the cloud app or the base URL is configured to connect to the wrong host.
+  If a custom HTTP transport is provided by the developer, it should also support handling
+  redirect responses with a status code of 301 or 308 and not change the request method from POST
+  to GET when resending the request.
+Add `managed<std::map<std::string, T>>::contains_key` for conveniently checking if a managed map
+  contains a given key. Use this method in the Type Safe Query API instead of `managed<std::map<std::string, T>>::find`.
 
 ### Compatibility
 * Fileformat: Generates files with format v24. Reads and automatically upgrade from fileformat v10.

--- a/include/cpprealm/networking/http.hpp
+++ b/include/cpprealm/networking/http.hpp
@@ -115,7 +115,7 @@ namespace realm::networking {
     [[maybe_unused]] void set_http_client_factory(std::function<std::shared_ptr<http_transport_client>()>&&);
 
     /// Built in HTTP transport client.
-    struct default_http_transport : public http_transport_client, public std::enable_shared_from_this<default_http_transport> {
+    struct default_http_transport : public http_transport_client {
         struct configuration {
             /**
              * Extra HTTP headers to be set on each request to Atlas Device Sync when using the internal HTTP client.

--- a/include/cpprealm/networking/http.hpp
+++ b/include/cpprealm/networking/http.hpp
@@ -158,8 +158,7 @@ namespace realm::networking {
         ~default_http_transport() = default;
 
         void send_request_to_server(::realm::networking::request &&request,
-                                    std::function<void(const ::realm::networking::response &)> &&completion)
-        {
+                                    std::function<void(const ::realm::networking::response &)> &&completion) {
             send_request_to_server(std::move(request), std::move(completion), 0);
         }
 

--- a/include/cpprealm/networking/http.hpp
+++ b/include/cpprealm/networking/http.hpp
@@ -105,8 +105,8 @@ namespace realm::networking {
     // Interface for providing http transport
     struct http_transport_client {
         virtual ~http_transport_client() = default;
-        virtual void send_request_to_server(const request& request,
-                                            std::function<void(const response&)>&& completion) = 0;
+        virtual void send_request_to_server(::realm::networking::request &&request,
+                                            std::function<void(const response &)> &&completion) = 0;
     };
 
     /// Produces a http transport client from the factory.
@@ -115,7 +115,7 @@ namespace realm::networking {
     [[maybe_unused]] void set_http_client_factory(std::function<std::shared_ptr<http_transport_client>()>&&);
 
     /// Built in HTTP transport client.
-    struct default_http_transport : public http_transport_client {
+    struct default_http_transport : public http_transport_client, public std::enable_shared_from_this<default_http_transport> {
         struct configuration {
             /**
              * Extra HTTP headers to be set on each request to Atlas Device Sync when using the internal HTTP client.
@@ -150,8 +150,8 @@ namespace realm::networking {
 
         ~default_http_transport() = default;
 
-        void send_request_to_server(const ::realm::networking::request& request,
-                                    std::function<void(const ::realm::networking::response&)>&& completion);
+        void send_request_to_server(::realm::networking::request &&request,
+                                    std::function<void(const ::realm::networking::response &)> &&completion);
 
     protected:
         configuration m_configuration;

--- a/include/cpprealm/networking/http.hpp
+++ b/include/cpprealm/networking/http.hpp
@@ -143,6 +143,13 @@ namespace realm::networking {
              * is not set.
              */
             std::function<SSLVerifyCallback> ssl_verify_callback;
+
+            /**
+             * Maximum number of subsequent redirect responses from the server to prevent getting stuck
+             * in a redirect loop indefinitely. Set to 0 to disable redirect support or -1 to allow
+             * redirecting indefinitely.
+             */
+            int max_redirect_count = 30;
         };
 
         default_http_transport() = default;
@@ -151,9 +158,16 @@ namespace realm::networking {
         ~default_http_transport() = default;
 
         void send_request_to_server(::realm::networking::request &&request,
-                                    std::function<void(const ::realm::networking::response &)> &&completion);
+                                    std::function<void(const ::realm::networking::response &)> &&completion)
+        {
+            send_request_to_server(std::move(request), std::move(completion), 0);
+        }
 
     protected:
+        void send_request_to_server(::realm::networking::request &&request,
+                                    std::function<void(const ::realm::networking::response &)> &&completion,
+                                    int redirect_count);
+
         configuration m_configuration;
     };
 }

--- a/src/cpprealm/analytics.cpp
+++ b/src/cpprealm/analytics.cpp
@@ -273,7 +273,7 @@ namespace realm {
         std::stringstream json_ss;
         json_ss << post_data;
         auto json_str = json_ss.str();
-        auto transport = std::make_unique<networking::default_http_transport>();
+        auto transport = std::make_shared<networking::default_http_transport>();
 
         std::vector<char> buffer;
         buffer.resize(5000);

--- a/tests/sync/flexible_sync_tests.cpp
+++ b/tests/sync/flexible_sync_tests.cpp
@@ -9,7 +9,6 @@ TEST_CASE("flexible_sync", "[sync][flx]") {
     config.app_id = Admin::Session::shared().cached_app_id();
     config.base_url = Admin::Session::shared().base_url();
     auto app = realm::App(config);
-    app.get_sync_manager().set_log_level(logger::level::trace);
     SECTION("all") {
         auto user = app.login(realm::App::credentials::anonymous()).get();
         auto flx_sync_config = user.flexible_sync_configuration();

--- a/tests/sync/flexible_sync_tests.cpp
+++ b/tests/sync/flexible_sync_tests.cpp
@@ -4,11 +4,12 @@
 
 using namespace realm;
 
-TEST_CASE("flexible_sync", "[sync]") {
+TEST_CASE("flexible_sync", "[sync][flx]") {
     auto config = realm::App::configuration();
     config.app_id = Admin::Session::shared().cached_app_id();
     config.base_url = Admin::Session::shared().base_url();
     auto app = realm::App(config);
+    app.get_sync_manager().set_log_level(logger::level::trace);
     SECTION("all") {
         auto user = app.login(realm::App::credentials::anonymous()).get();
         auto flx_sync_config = user.flexible_sync_configuration();
@@ -181,7 +182,6 @@ TEST_CASE("flexible_sync", "[sync]") {
             CHECK(synced_realm.objects<AllTypesObject>().size() == 2);
         }
     }
-
 }
 
 template<typename T, typename Func>
@@ -245,8 +245,7 @@ TEST_CASE("set collection sync", "[set]") {
         auto time = std::chrono::system_clock::now();
         auto time2 = time + time.time_since_epoch();
         test_set(&managed_obj.set_date_col, scenario, {time, time, time2, std::chrono::time_point<std::chrono::system_clock>()}); // here
-        test_set(&managed_obj.set_mixed_col, scenario, {realm::mixed((int64_t)42), realm::mixed((int64_t)42), realm::mixed("24"), realm::mixed(realm::uuid("18de7916-7f84-11ec-a8a3-0242ac120002"))});
-
+        test_set(&managed_obj.set_mixed_col, scenario, {realm::mixed((int64_t) 42), realm::mixed((int64_t) 42), realm::mixed("24"), realm::mixed(realm::uuid("18de7916-7f84-11ec-a8a3-0242ac120002"))});
         realm.get_sync_session()->wait_for_upload_completion().get();
         realm.get_sync_session()->wait_for_download_completion().get();
 
@@ -270,7 +269,7 @@ TEST_CASE("set collection sync", "[set]") {
     }
 }
 
-TEST_CASE("pause_resume_sync", "[sync]") {
+TEST_CASE("pause_resume_sync", "[sync][flx]") {
     auto config = realm::App::configuration();
     config.app_id = Admin::Session::shared().cached_app_id();
     config.base_url = Admin::Session::shared().base_url();
@@ -323,4 +322,50 @@ TEST_CASE("pause_resume_sync", "[sync]") {
         });
         CHECK(synced_realm.get_sync_session()->state() == realm::sync_session::state::active);
     }
+}
+
+TEST_CASE("delete created sync objects", "[sync][flx]") {
+    auto config = realm::App::configuration();
+    config.app_id = Admin::Session::shared().cached_app_id();
+    config.base_url = Admin::Session::shared().base_url();
+    auto app = realm::App(config);
+
+    auto user = app.login(realm::App::credentials::anonymous()).get();
+    auto flx_sync_config = user.flexible_sync_configuration();
+    auto synced_realm = db(flx_sync_config);
+    auto update_success = synced_realm.subscriptions().update([](realm::mutable_sync_subscription_set &subs) {
+                                                          subs.clear();
+                                                      })
+                                  .get();
+    CHECK(update_success == true);
+    update_success = synced_realm.subscriptions().update([](realm::mutable_sync_subscription_set &subs) {
+                                                     subs.add<AllTypesObject>("foo-strings");
+                                                     subs.add<AllTypesObjectLink>("foo-link");
+                                                 })
+                             .get();
+    CHECK(update_success == true);
+
+    CHECK(synced_realm.subscriptions().size() == 2);
+    synced_realm.get_sync_session()->wait_for_upload_completion().get();
+    synced_realm.get_sync_session()->wait_for_download_completion().get();
+    synced_realm.refresh();
+    auto links = synced_realm.objects<AllTypesObjectLink>();
+    // No links were created during the tests
+    CHECK(links.size() == 0);
+    auto objs = synced_realm.objects<AllTypesObject>();
+    CHECK(objs.size() > 0);
+    synced_realm.write([&synced_realm, &objs]() {
+        while (objs.size() > 0) {
+            auto obj = objs[0];
+            synced_realm.remove(obj);
+        }
+    });
+    synced_realm.get_sync_session()->wait_for_upload_completion().get();
+    synced_realm.get_sync_session()->wait_for_download_completion().get();
+    synced_realm.refresh();
+
+    links = synced_realm.objects<AllTypesObjectLink>();
+    CHECK(objs.size() == 0);
+    objs = synced_realm.objects<AllTypesObject>();
+    CHECK(objs.size() == 0);
 }

--- a/tests/sync/networking_tests.cpp
+++ b/tests/sync/networking_tests.cpp
@@ -60,16 +60,17 @@ TEST_CASE("custom transport to proxy", "[proxy]") {
             m_configuration = configuration;
         }
 
-        void send_request_to_server(const ::realm::networking::request& request,
-                                    std::function<void(const ::realm::networking::response&)>&& completion) override {
-            auto req_copy = request;
-            const std::string from = "https:";
-            const std::string to = "http:";
-            if (req_copy.url.find(from) == 0) {
-                req_copy.url.replace(0, from.length(), to);
+        void send_request_to_server(::realm::networking::request &&request,
+                                    std::function<void(const ::realm::networking::response &)> &&completion) override {
+            // We're already working with a copy of the original request that was created
+            // by `to_request()` by `core_http_transport_shim`
+            constexpr std::string_view from = "https:";
+            constexpr std::string_view to = "http:";
+            if (request.url.find(from) == 0) {
+                request.url.replace(0, from.length(), to);
             }
             m_called = true;
-            return ::realm::networking::default_http_transport::send_request_to_server(req_copy, std::move(completion));
+            return ::realm::networking::default_http_transport::send_request_to_server(std::move(request), std::move(completion));
         }
 
         bool was_called() const {


### PR DESCRIPTION
## What, How & Why?
Since the 301/308 http redirection support is being removed from Core via https://github.com/realm/realm-core/pull/7996, these changes add support to the CPP SDK network transport to support redirections.

Fixes #239