### PR TITLE
fixed CMake Error given target "Sync" which does not exist

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -153,7 +153,10 @@ include(GNUInstallDirs)
 add_library(cpprealm ${SOURCES} ${HEADERS} ${BRIDGING_HEADER})
 
 if (NOT VCPKG_TOOLCHAIN)
-    set(INSTALL_TARGETS ObjectStore Storage QueryParser Sync)
+    set(INSTALL_TARGETS ObjectStore Storage QueryParser)
+    if (REALM_ENABLE_SYNC)
+        list(APPEND INSTALL_TARGETS Sync)
+    endif()
 endif()
 
 install(TARGETS ${PROJECT_NAME} ${INSTALL_TARGETS}


### PR DESCRIPTION
### Issue Description

The CMake configuration process fails due to a non-existent target `Sync` being included in `INSTALL_TARGETS` when `REALM_ENABLE_SYNC=OFF`. The target `Sync` should only be appended to `INSTALL_TARGETS` if synchronization is enabled.

### Repro Steps

1. Configure the build with the following options:

```
   cmake -B build . \
       -D CMAKE_BUILD_TYPE=Release \
       -D REALM_ENABLE_SYNC=OFF
```

### What Happened?

The build fails with the following error:

```
CMake Error at src/CMakeLists.txt:159 (install):
  install TARGETS given target "Sync" which does not exist.
```

The target `Sync` is being appended to `INSTALL_TARGETS` unconditionally, without checking if it has been created. When `REALM_ENABLE_SYNC=OFF`, the `Sync` target is not defined, causing the error during the installation phase.

### Fix Proposal

Update the `src/CMakeLists.txt` to conditionally append the `Sync` target only if it has been created. The following changes are required:

```
set(INSTALL_TARGETS ObjectStore Storage QueryParser)
if (REALM_ENABLE_SYNC)
    list(APPEND INSTALL_TARGETS Sync)
endif()
```

This ensures that the `Sync` target is only included when `REALM_ENABLE_SYNC=ON`, avoiding errors during installation when synchronization is disabled.

### Version

- Realm C++ version: `2.2.0`
- Installation method: `CMake`

### Atlas Services in Use

- Local Database only

### Compiler

- AppleClang 16.0.0.16000026

### OS and Version

- Sequoia 15.1

### Code Snippets

Relevant code snippet causing the issue:

`set(INSTALL_TARGETS ObjectStore Storage QueryParser Sync)`

### Stacktrace of the Exception/Crash

CMake Error at src/CMakeLists.txt:159 (install):
  install TARGETS given target "Sync" which does not exist.

### Relevant Log Output

No additional log output provided.
